### PR TITLE
feat(convex-logto)!: SSR-safe config-only provider

### DIFF
--- a/.changeset/ssr-safe-config-only-provider.md
+++ b/.changeset/ssr-safe-config-only-provider.md
@@ -1,0 +1,14 @@
+---
+"convex-logto": minor
+---
+
+SSR-safe, config-only provider (breaking API slim).
+
+- **`ConvexLogtoProvider` is now safe to render anywhere, including on the server.** It mounts the Logto + Convex tree from the first render using an inert loading client, so children render immediately (under Convex's `<AuthLoading>`) while config loads, and nothing touches `window` on the server. SSR frameworks (Next.js App Router, TanStack Start) no longer need a hand-written client boundary — a single `<ConvexLogtoProvider>` is enough everywhere.
+- **Breaking — the provider is configured by `configQuery` only.** The literal `endpoint`/`appId` props (and their discriminated union) are removed; `{ endpoint, appId }` is served from the Convex deployment via `logtoConfigQuery()`, so config lives in exactly one place per environment.
+- **Breaking — removed the `callbackPath` prop.** `/callback` is the fixed convention; to use a different path, pass it explicitly: ``signIn(`${origin}/your-path`)``.
+- **Breaking — removed the `fallback` prop.** Children render during config load (gated by `<AuthLoading>`), so a separate fallback is no longer needed.
+- Auth no longer flickers on load or reload: the bridge latches on the first settle and sources `isAuthenticated`/`isLoading` from Convex, verified across repeated authenticated reloads.
+- A failed sign-in code exchange (a stale callback URL or a lost sign-in session) now throws a clear error instead of leaving the callback page stuck on "finishing sign in".
+
+Note: Convex's OIDC verifier accepts only RS256/EdDSA, but Logto signs with ES384 by default. Rotate your tenant's OIDC signing key to **RSA** (Tenant settings → OIDC configs → rotate private key → RSA), or `getUserIdentity()` returns `null`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,10 +45,10 @@ Changesets + npm **OIDC trusted publishing** (provenance, no tokens):
 2. Merge to `main` → a **"Version Packages" PR** opens automatically (bumps version + updates `CHANGELOG.md`).
 3. Merge that PR → CI publishes to npm with provenance.
 
-Never run `npm publish` by hand, and never hand-edit the version or `CHANGELOG.md` — Changesets owns them.
+Never version or publish locally — no `changeset version`, `pnpm version-packages`, or `npm publish`, and never hand-edit the version or `CHANGELOG.md`. The Release workflow owns both; your only local step is `pnpm changeset` + committing the `.changeset/*.md`.
 
 ## Don't
 
 - Don't add Node-only APIs to the library (it runs in Convex's V8 runtime).
 - Don't reformat `package.json`, `CHANGELOG.md`, or lockfiles.
-- Don't hand-edit versions or `CHANGELOG.md`.
+- Don't version or publish locally (`changeset version` / `pnpm version-packages` / `npm publish`) or hand-edit versions / `CHANGELOG.md`.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ npm i convex-logto @logto/react
 This is a pnpm + Turborepo monorepo.
 
 - **[`packages/convex-logto`](packages/convex-logto)** — the published library. See its [README](packages/convex-logto/README.md) for full docs and quick start.
-
-A documentation site (Fumadocs) is coming.
+- **[`examples/`](examples)** — runnable examples across Vite, TanStack Router/Start, and Next.js (one with role-based access).
+- **[`docs/`](docs)** — the documentation site source (Fumadocs).
 
 ## Links
 

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -12,7 +12,7 @@ description: Every export from convex-logto and convex-logto/react, with signatu
 | `logtoSync<DataModel>(handlers)` | `convex-logto` | Returns `{ sync }`, an internal mutation mapping user events to your tables. |
 | `registerLogtoWebhook(http, sync, opts?)` | `convex-logto` | Registers the verified webhook route. Reads `LOGTO_WEBHOOK_SIGNING_KEY`. |
 | `verifyLogtoSignature(key, body, sig)` | `convex-logto` | Low-level signature check, for custom routing. |
-| `ConvexLogtoProvider` | `convex-logto/react` | Logto + Convex + auto callback in one provider. Takes `configQuery` or `endpoint`+`appId`. |
+| `ConvexLogtoProvider` | `convex-logto/react` | Logto + Convex + auto sign-in callback in one provider. Pulls Logto config from the backend via `configQuery`. |
 | `useLogtoAuth()` | `convex-logto/react` | `{ isAuthenticated, isLoading, user, signIn, signOut }`. |
 
 ## Backend
@@ -40,8 +40,8 @@ export const config = logtoConfigQuery();
 ### `logtoSync<DataModel>(handlers)`
 
 Returns `{ sync }`, an internal mutation that maps Logto user events
-(`User.Created`, `User.Data.Updated`, `User.Deleted`) to your tables. See
-[Webhook sync](/docs/webhook-sync).
+(`User.Created`, `User.Data.Updated`, `User.SuspensionStatus.Updated`,
+`User.Deleted`) to your tables. See [Webhook sync](/docs/webhook-sync).
 
 ### `registerLogtoWebhook(http, sync, opts?)`
 
@@ -61,14 +61,30 @@ webhook yourself instead of using `registerLogtoWebhook`.
 
 ### `ConvexLogtoProvider`
 
-Logto + Convex + the auto callback in one provider. Takes either a `configQuery`
-(pulls config from the backend) or literal `endpoint` + `appId`.
+Logto + Convex + the auto sign-in callback in one provider. Pulls your Logto
+config from the backend via `configQuery`, so the frontend carries none.
 
 ```tsx
 <ConvexLogtoProvider client={convex} configQuery={api.logto.config}>
   <App />
 </ConvexLogtoProvider>
 ```
+
+| Prop | Required | Purpose |
+| --- | --- | --- |
+| `client` | yes | Your `ConvexReactClient`. |
+| `configQuery` | yes | Ref to the `logtoConfigQuery()` export, e.g. `api.logto.config`. |
+| `afterSignIn` | — | Where to go once sign-in completes. Default `/`. |
+| `navigate` | — | Soft navigation (your router's `navigate`). Falls back to a hard redirect. |
+| `scopes` / `resources` | — | Extra OIDC scopes / API resources. `openid`, `profile`, `offline_access`, and `email` are always included. |
+
+Safe to render on the server: while config loads, children render under Convex's
+`<AuthLoading>` and nothing touches `window` — no stub or mount-gate. (In the
+Next.js App Router, mark the component that imports it `"use client"`, as with any
+hook.)
+
+The sign-in redirect lands on `/callback` — add a route there that just renders.
+Use a different path by passing ``signIn(`${origin}/your-path`)``.
 
 ### `useLogtoAuth()`
 

--- a/docs/content/docs/auth-in-your-app.mdx
+++ b/docs/content/docs/auth-in-your-app.mdx
@@ -1,0 +1,173 @@
+---
+title: Auth in your app
+description: Render and route on auth state — declaratively, with a hook, or in a route guard — and store your own data for a user.
+---
+
+There is no special concept to learn. `convex-logto` plugs into Convex's normal
+auth, so you get **all** the standard ways to react to auth state:
+
+- **`useLogtoAuth()`** — a hook returning `{ isAuthenticated, isLoading, user, signIn, signOut }`.
+- **Convex's `<Authenticated>` / `<Unauthenticated>` / `<AuthLoading>`** and **`useConvexAuth()`** from `convex/react` — they work unchanged.
+
+`isAuthenticated` / `isLoading` from `useLogtoAuth()` come from `useConvexAuth()`,
+so they're **authoritative**: `isAuthenticated` is `true` only once Convex has
+accepted the token. Gate on these and there's no flash of the wrong state.
+
+## Storing data for a user
+
+You usually **don't need a users table**. Every Convex function already has the
+signed-in user's identity from the token — `identity.subject` is their stable Logto
+id — so attach your data to _your own_ tables, keyed by it:
+
+```ts
+export const createPost = mutation({
+  args: { body: v.string() },
+  handler: async (ctx, { body }) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("unauthenticated");
+    await ctx.db.insert("posts", { body, authorId: identity.subject }); // ← the link
+  },
+});
+```
+
+The user isn't a row — their _data_ points at `identity.subject`. That covers "the
+current user and the things they own."
+
+Reach for a synced **users table** only when you need users who _aren't_ the current
+caller (an admin list, another user's display name) or Logto-owned profile and
+lifecycle fields mirrored into Convex (email, name, suspended, deleted). App-owned
+data the token doesn't carry — preferences, plan, feature flags — can stay in your
+own tables keyed by `identity.subject`. See [Webhook sync](/docs/webhook-sync).
+
+## Declarative gating
+
+The simplest app shell. Each branch renders only in its state; queries inside
+`<Authenticated>` never run before auth settles.
+
+```tsx
+import { Authenticated, Unauthenticated, AuthLoading } from "convex/react";
+
+function App() {
+  return (
+    <>
+      <AuthLoading>
+        <Spinner />
+      </AuthLoading>
+      <Unauthenticated>
+        <SignInButton />
+      </Unauthenticated>
+      <Authenticated>
+        <Dashboard />
+      </Authenticated>
+    </>
+  );
+}
+```
+
+## The hook
+
+`useLogtoAuth()` is plain state. Call it at the top of your component, then use
+the values and `signIn` / `signOut` anywhere — in `return`, event handlers,
+effects, or conditionals.
+
+```tsx
+import { useLogtoAuth } from "convex-logto/react";
+
+function AuthButton() {
+  const { isAuthenticated, isLoading, user, signIn, signOut } = useLogtoAuth();
+  if (isLoading) return <Spinner />;
+  return isAuthenticated ? (
+    <button onClick={() => void signOut()}>Sign out ({user?.email ?? user?.sub})</button>
+  ) : (
+    <button onClick={() => void signIn()}>Sign in</button>
+  );
+}
+```
+
+## Route guards (TanStack Router)
+
+For redirect-based protection you need auth **outside render** — in a route's
+`beforeLoad`. Lift `useLogtoAuth()` into the router `context` and guard there.
+This is the standard TanStack Router auth pattern; it works because
+`useLogtoAuth()` is just state.
+
+```tsx title="src/main.tsx"
+import { useEffect } from "react";
+import { ConvexReactClient } from "convex/react";
+import { ConvexLogtoProvider, useLogtoAuth } from "convex-logto/react";
+import { RouterProvider } from "@tanstack/react-router";
+import { router } from "./router";
+import { api } from "../convex/_generated/api";
+
+const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL);
+
+// Lives inside <ConvexLogtoProvider> so useLogtoAuth() has its context.
+function InnerApp() {
+  const auth = useLogtoAuth();
+
+  // Re-run every route's beforeLoad when the authn outcome flips (loading→settled,
+  // sign in/out). Key on the primitive booleans so it fires on exactly those changes
+  // — not on every token refresh or profile (`user`) update.
+  useEffect(() => {
+    void router.invalidate();
+  }, [auth.isLoading, auth.isAuthenticated]);
+
+  return <RouterProvider router={router} context={{ auth }} />;
+}
+
+root.render(
+  <ConvexLogtoProvider
+    client={convex}
+    configQuery={api.logto.config}
+    navigate={(to) => void router.navigate({ to })}
+  >
+    <InnerApp />
+  </ConvexLogtoProvider>,
+);
+```
+
+```tsx title="src/router.tsx"
+import {
+  createRootRouteWithContext,
+  createRoute,
+  createRouter,
+  redirect,
+  Outlet,
+} from "@tanstack/react-router";
+import type { useLogtoAuth } from "convex-logto/react";
+
+type RouterAuthContext = { auth: ReturnType<typeof useLogtoAuth> };
+
+const rootRoute = createRootRouteWithContext<RouterAuthContext>()({
+  component: () => <Outlet />,
+});
+
+// Protected layout route — guarded outside render, in beforeLoad.
+const authedRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  id: "_authed",
+  beforeLoad: ({ context }) => {
+    if (context.auth.isLoading) return; // still settling — don't redirect yet
+    if (!context.auth.isAuthenticated) throw redirect({ to: "/signin" });
+  },
+  pendingComponent: () => <p>Checking access…</p>,
+  component: () => <Outlet />,
+});
+
+export const router = createRouter({
+  routeTree: rootRoute.addChildren([signinRoute, authedRoute.addChildren([dashboardRoute])]),
+  context: { auth: undefined! }, // real value injected by <RouterProvider context>
+  defaultPendingMs: 0, // show pendingComponent immediately while auth settles
+});
+```
+
+A few things make this robust:
+
+- **Check `isLoading` first.** `isAuthenticated` is `false` while auth is still
+  settling, so without the `if (context.auth.isLoading) return` you'd redirect a
+  signed-in user on every reload.
+- **The `router.invalidate()` effect is required** — it's what re-runs the guard
+  when auth resolves. Depend on `[auth.isLoading, auth.isAuthenticated]`.
+- **Give the route a `pendingComponent`** (with `defaultPendingMs: 0`) so the
+  loading window shows it instead of a flash of protected content.
+- **Pass `navigate`** to the provider so post-sign-in is a soft router navigation.

--- a/docs/content/docs/how-it-works.mdx
+++ b/docs/content/docs/how-it-works.mdx
@@ -11,21 +11,33 @@ Convex validates an OIDC **ID token**. Logto's access tokens are typed
 package returns the ID token.
 
 Because it goes through Convex's **OIDC** provider (not Custom JWT), Convex reads
-the issuer's discovery document and JWKS itself — including the signing
-algorithm (Logto uses **ES384**). That is why you never set an algorithm or a
-JWKS URL.
+the issuer's discovery document and JWKS itself, so you never set an algorithm or
+a JWKS URL.
+
+There is one catch. Convex's OIDC verifier accepts only **RS256** and **EdDSA**
+signatures, but Logto signs with **ES384** by default — and a mismatched
+signature is rejected silently: sign-in completes, yet `getUserIdentity()`
+returns `null`. The fix is a one-time, tenant-level key rotation: Logto Console →
+**Tenant settings → OIDC configs** → **OIDC private keys** → **Rotate private
+key** → choose **RSA**. Logto keeps the old key during a transition, so existing
+sessions stay signed in. After rotating, the discovery document advertises
+`RS256` and Convex accepts the token.
 
 ## Refresh via offline_access
 
 Sessions refresh via Logto's refresh token, which is why `ConvexLogtoProvider`
 requests the `offline_access` scope by default.
 
+## Server-side rendering
+
+`ConvexLogtoProvider` is safe to render on the server. Until the backend config
+loads it mounts an inert Logto client and reports "loading", so children render
+under Convex's `<AuthLoading>` and nothing touches `window` during SSR or the
+first client paint — no stub or mount-gate. In TanStack Start, render the same
+single `<ConvexLogtoProvider>` you'd use in a SPA. In the Next.js App Router the
+component that imports it must still be `"use client"` (its hooks and the
+sign-in / sign-out actions use `window`), but that's the only boundary.
+
 ## ESM-only `convex-logto/react`
 
-The `convex-logto/react` entry is ESM-only. `ConvexLogtoProvider` and
-`useLogtoAuth` are client-only (they use React hooks and `window`).
-
-## Next.js note
-
-In the Next.js App Router, render `ConvexLogtoProvider` and `useLogtoAuth`
-inside a `"use client"` component, since they rely on React hooks and `window`.
+The `convex-logto/react` entry is ESM-only (so is its `@logto/react` peer).

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -19,8 +19,10 @@ Use [Logto](https://logto.io) (self-hosted or cloud) as the auth provider for a
 ## ID token over OIDC
 
 It uses Logto's **ID token** over OIDC, so Convex auto-discovers the signing key
-and algorithm (Logto signs with ES384). There is nothing about JWTs for you to
-configure.
+and JWKS — no JWT template, no algorithm, no JWKS URL to configure. The one
+Logto-side requirement: the OIDC signing key must be **RSA/RS256** (Convex
+rejects Logto's default ES384). It's a one-time tenant rotation — see
+[Quick start](/docs/quick-start).
 
 ## Install
 
@@ -33,6 +35,8 @@ pnpm add convex-logto @logto/react
 ## Where to next
 
 - [Quick start](/docs/quick-start) — wire auth end to end in six steps.
+- [Auth in your app](/docs/auth-in-your-app) — render and route on auth state, and
+  store your own data for a user.
 - [Multiple environments](/docs/multiple-environments) — dev / staging / prod
   with a single source of config.
 - [Webhook sync](/docs/webhook-sync) — mirror Logto users into a queryable

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "index",
     "quick-start",
+    "auth-in-your-app",
     "multiple-environments",
     "webhook-sync",
     "api-reference",

--- a/docs/content/docs/multiple-environments.mdx
+++ b/docs/content/docs/multiple-environments.mdx
@@ -14,25 +14,14 @@ tokens can't cross environments), then set each deployment's env once:
 
 ```bash
 # dev deployment
-npx convex env set LOGTO_APP_ID <dev-app-id>
+npx convex env set LOGTO_ENDPOINT https://your-logto.example.com
+npx convex env set LOGTO_APP_ID   <dev-app-id>
 # production deployment
-npx convex env set --prod LOGTO_APP_ID <prod-app-id>
+npx convex env set --prod LOGTO_ENDPOINT https://your-logto.example.com
+npx convex env set --prod LOGTO_APP_ID   <prod-app-id>
 # staging: target that deployment the same way
 ```
 
-Same code everywhere. Switching environments = pointing `VITE_CONVEX_URL` at a
-different deployment. Nothing to recompile, nothing to copy twice.
-
-## Prefer literal values instead?
-
-If you'd rather not add the config query, pass the values directly (e.g. from
-`import.meta.env`). Then the frontend needs its own `VITE_LOGTO_*` vars per
-environment:
-
-```tsx
-<ConvexLogtoProvider
-  client={convex}
-  endpoint={import.meta.env.VITE_LOGTO_ENDPOINT}
-  appId={import.meta.env.VITE_LOGTO_APP_ID}
->
-```
+Same code everywhere. The only thing that changes per environment is which Convex
+deployment `VITE_CONVEX_URL` points at — there's no Logto config to duplicate or
+keep in sync.

--- a/docs/content/docs/quick-start.mdx
+++ b/docs/content/docs/quick-start.mdx
@@ -3,7 +3,7 @@ title: Quick start
 description: Wire Logto auth into your Convex React app end to end, in six steps.
 ---
 
-This is the whole auth setup. Many apps need nothing more.
+Everything below is copy-pasteable; work top to bottom and your Convex functions will see a signed-in user.
 
 ## Install
 
@@ -15,10 +15,30 @@ pnpm add convex-logto @logto/react
 
 ## 1. Create a Logto app
 
-In Logto Console → **Applications** → create a **Single Page App**. Note the
-**endpoint** (e.g. `https://auth.example.com`) and the **App ID**. Under
-**Redirect URIs** add `http://localhost:5173/callback` (and your prod URL);
-under **Post sign-out redirect URIs** add your origin.
+In Logto Console → **Applications** → **Create application** → under
+**Single page app** pick your framework (e.g. **React**) — **not** a
+**Third-party app**. A third-party app is for letting *other people's* apps sign
+in through your Logto; it withholds the `profile` / `email` scopes this package
+requests, so sign-in fails with `invalid_scope`. The app type can't be changed
+after creation, so if you picked third-party, create a new Single page app.
+
+Note the **endpoint** (e.g. `https://auth.example.com`) and the **App ID**, and
+add two URLs on the app (for each environment):
+
+- **Redirect URIs** → `http://localhost:5173/callback` (and your prod callback)
+- **Post sign-out redirect URIs** → `http://localhost:5173` (your app's origin,
+  and your prod origin)
+
+`signIn()` returns to the redirect URI and `signOut()` to the post-sign-out URI,
+so remember to add both.
+
+**Required — use an RSA signing key.** Convex only accepts ID tokens signed with
+**RS256** (or EdDSA). Logto signs with **ES384** by default, which Convex
+silently rejects: sign-in looks like it works, but `ctx.auth.getUserIdentity()`
+returns `null`. Rotate the key once per tenant — Logto Console → **Tenant
+settings → OIDC configs** → **OIDC private keys** → **Rotate private key** →
+choose **RSA** → rotate. Logto keeps the old key during a transition, so existing
+sessions stay signed in.
 
 ## 2. Set the config on your Convex deployment (only place needed)
 
@@ -81,12 +101,16 @@ function Header() {
   const { isAuthenticated, isLoading, user, signIn, signOut } = useLogtoAuth();
   if (isLoading) return null;
   return isAuthenticated ? (
-    <button onClick={() => signOut()}>Sign out ({user?.email})</button>
+    <button onClick={() => void signOut()}>Sign out ({user?.email ?? user?.sub})</button>
   ) : (
-    <button onClick={() => signIn()}>Sign in</button>
+    <button onClick={() => void signIn()}>Sign in</button>
   );
 }
 ```
+
+`signOut()` ends the Logto session and returns the user to your app's origin (the
+**Post sign-out redirect URI** from step 1). Pass `signOut("https://app.com/bye")`
+to land somewhere else — just register that URI too.
 
 In any Convex function, the Logto identity is already there:
 

--- a/docs/content/docs/webhook-sync.mdx
+++ b/docs/content/docs/webhook-sync.mdx
@@ -1,51 +1,117 @@
 ---
 title: Webhook sync
-description: Mirror Logto users into a queryable Convex table, with verified webhooks and RBAC.
+description: Mirror Logto users into a queryable Convex table you own, with verified webhooks, soft deletes, and RBAC.
 ---
 
 If you want a queryable `users` table (to list users, store roles, or join app
-data), add a webhook sync. It mirrors `@convex-dev/workos-authkit`'s ergonomics.
+data), add a webhook sync. The table is **yours** — `convex-logto` owns nothing —
+and a [runnable version of everything here is in the `tanstack-router-spa`
+example](https://github.com/Fanzzzd/convex-logto/tree/main/examples/tanstack-router-spa).
 
 ## 1. Schema
 
+Two kinds of fields share the row, with **different owners** — this split is what
+keeps the sync from fighting your app:
+
 ```ts title="convex/schema.ts"
 users: defineTable({
-  authId: v.string(),            // Logto user id (== identity.subject)
-  email: v.string(),
-  name: v.string(),
-  role: v.string(),              // for RBAC, if you want it
-}).index("authId", ["authId"]),
+  authId: v.string(), // == identity.subject (the Logto user id)
+  email: v.optional(v.string()), // Logto-owned (synced)
+  name: v.optional(v.string()), // Logto-owned (synced)
+  role: v.union(v.literal("user"), v.literal("admin")), // app-owned (RBAC)
+  status: v.union(
+    v.literal("active"),
+    v.literal("suspended"),
+    v.literal("deleted"),
+  ), // Logto-owned lifecycle ("deleted" is a tombstone, not a row removal)
+}).index("by_authId", ["authId"]),
 ```
 
 ## 2. Map events to your table
 
 ```ts title="convex/logto.ts"
 // alongside `config` from the quick start
-import { logtoSync } from "convex-logto";
+import { logtoSync, type LogtoSyncHandler } from "convex-logto";
 import type { DataModel } from "./_generated/dataModel";
+import type { QueryCtx, MutationCtx } from "./_generated/server";
 
-const upsert = async (ctx, u) => {
-  const existing = await ctx.db
+const byAuthId = (ctx: QueryCtx | MutationCtx, authId: string) =>
+  ctx.db
     .query("users")
-    .withIndex("authId", (q) => q.eq("authId", u.id))
+    .withIndex("by_authId", (q) => q.eq("authId", authId))
     .unique();
-  const fields = { email: u.primaryEmail ?? "", name: u.name ?? "" };
-  if (existing) await ctx.db.patch(existing._id, fields);
-  else await ctx.db.insert("users", { authId: u.id, role: "user", ...fields });
+
+// Mirror only the fields the event carries: present → set it (a `null` clears it),
+// absent → leave it. Never write `role` — that's app-owned.
+const syncedFields = (u: {
+  primaryEmail?: string | null;
+  name?: string | null;
+  isSuspended?: boolean;
+}) => ({
+  ...(u.primaryEmail !== undefined ? { email: u.primaryEmail ?? undefined } : {}),
+  ...(u.name !== undefined ? { name: u.name ?? undefined } : {}),
+  ...(u.isSuspended !== undefined
+    ? { status: u.isSuspended ? ("suspended" as const) : ("active" as const) }
+    : {}),
+});
+
+// The webhook only SYNCS rows that already exist — it never creates them (the next
+// section explains why). No row yet → there's nothing to sync.
+const syncRow: LogtoSyncHandler<DataModel> = async (ctx, u) => {
+  const row = await byAuthId(ctx, u.id);
+  if (!row || row.status === "deleted") return; // nothing to sync / don't resurrect a tombstone
+  await ctx.db.patch(row._id, syncedFields(u)); // Logto-owned fields only; role untouched
 };
 
 export const { sync } = logtoSync<DataModel>({
-  "User.Created": upsert,
-  "User.Data.Updated": upsert,
+  "User.Data.Updated": syncRow,
+  "User.SuspensionStatus.Updated": syncRow,
+  // Soft delete: scrub PII but keep the row (status "deleted") so authz fails
+  // closed and anything referencing the user by id doesn't dangle. `User.Deleted`
+  // carries no entity — just the id — so `u` here is the minimal `{ id }`.
   "User.Deleted": async (ctx, u) => {
-    const row = await ctx.db
-      .query("users")
-      .withIndex("authId", (q) => q.eq("authId", u.id))
-      .unique();
-    if (row) await ctx.db.delete(row._id);
+    const row = await byAuthId(ctx, u.id);
+    if (row)
+      await ctx.db.patch(row._id, {
+        status: "deleted",
+        email: undefined,
+        name: undefined,
+      });
   },
 });
 ```
+
+> **The webhook never creates rows — it only syncs.** `User.Created` fires only for
+> users created _after_ you add the webhook, never for users who already existed in
+> Logto or who arrive from another app on the same Logto. A webhook-created row would
+> also have to invent the app-owned `role`. So a row the webhook alone makes is both
+> unreliable and wrongly-owned.
+
+Create the row from an **authenticated mutation** instead — it runs as the signed-in
+user, so it always fires — and let the webhook keep it in sync afterward:
+
+```ts title="convex/users.ts"
+export const ensureUser = mutation({
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("unauthenticated");
+    const existing = await ctx.db
+      .query("users")
+      .withIndex("by_authId", (q) => q.eq("authId", identity.subject))
+      .unique();
+    if (existing) return; // already there
+    await ctx.db.insert("users", {
+      authId: identity.subject,
+      email: identity.email,
+      name: identity.name,
+      role: "user",
+      status: "active",
+    });
+  },
+});
+```
+
+Call it once on first authenticated load — an onboarding screen, or an effect.
 
 ## 3. Register the route
 
@@ -63,29 +129,49 @@ export default http;
 
 Logto Console → **Webhooks** → new webhook pointed at
 `<your-convex-site-url>/logto/webhook` (your Convex **HTTP Actions** URL, e.g.
-`https://happy-otter-123.convex.site/logto/webhook`). Subscribe to
-`User.Created`, `User.Data.Updated`, `User.Deleted`, and copy the **Signing
-key** — the one Logto value that *is* a secret:
+`https://happy-otter-123.convex.site/logto/webhook`). Subscribe to the events you
+handle — `User.Data.Updated`, `User.SuspensionStatus.Updated`, and `User.Deleted` —
+then copy the **Signing key**, the one Logto value that _is_ a secret:
 
 ```bash
 npx convex env set LOGTO_WEBHOOK_SIGNING_KEY <signing-key>
 ```
 
-The signature is verified with Web Crypto (HMAC-SHA256) inside the Convex
-runtime; bad signatures get a 401.
+The signature is verified with Web Crypto (HMAC-SHA256) inside the Convex runtime;
+bad signatures get a 401.
 
 ## RBAC
 
-Store a `role` on the synced user (above), then gate in Convex by loading the
-row via `identity.subject`:
+Gate on the row, not just the token — `getUserIdentity()` means "the token still
+validates", not "the account is still active":
 
-```ts
-const user = await ctx.db
-  .query("users")
-  .withIndex("authId", (q) => q.eq("authId", identity.subject))
-  .unique();
-if (user?.role !== "admin") throw new Error("forbidden");
+```ts title="convex/authz.ts"
+import type { QueryCtx, MutationCtx } from "./_generated/server";
+
+export async function requireActiveUser(ctx: QueryCtx | MutationCtx) {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity) throw new Error("unauthenticated");
+  const user = await ctx.db
+    .query("users")
+    .withIndex("by_authId", (q) => q.eq("authId", identity.subject))
+    .unique();
+  if (user?.status !== "active") throw new Error("forbidden"); // no row / suspended / deleted
+  return user;
+}
+
+export async function requireRole(
+  ctx: QueryCtx | MutationCtx,
+  role: "user" | "admin",
+) {
+  const user = await requireActiveUser(ctx);
+  if (user.role !== role) throw new Error("forbidden");
+  return user;
+}
 ```
+
+Use `requireRole(ctx, "admin")` for privileged work. For ordinary reads, prefer a
+**nullable** variant (return `null` instead of throwing) so a just-signed-up user
+isn't locked out in the moment between sign-in and their row being created.
 
 Keep the ability map in your app — the package stays out of your authorization
 policy.

--- a/docs/turbo.json
+++ b/docs/turbo.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": [".vercel/output/**"]
+    }
+  }
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,14 @@
+# Examples
+
+Working examples of [`convex-logto`](../packages/convex-logto) across frameworks.
+Each is a standalone app — see its README to run it.
+
+| Example | What it shows |
+| --- | --- |
+| [`vite-react`](./vite-react) | The minimal setup: `ConvexLogtoProvider` + declarative auth gating. |
+| [`tanstack-router-spa`](./tanstack-router-spa) | TanStack Router (SPA): declarative gating + `beforeLoad` route guards (auth outside render), **plus a webhook-synced users table with role-based access (RBAC)**. |
+| [`tanstack-start`](./tanstack-start) | TanStack Start (SSR): one SSR-safe provider + `beforeLoad` route guards. |
+| [`nextjs`](./nextjs) | Next.js App Router: client provider boundary + callback route. |
+
+In this monorepo each example depends on the package via `convex-logto: workspace:*`.
+Standalone, install it from npm: `npm i convex-logto @logto/react`.

--- a/examples/nextjs/.env.example
+++ b/examples/nextjs/.env.example
@@ -1,0 +1,6 @@
+# Your Convex deployment URL (the client connects here). `npx convex dev` writes
+# this into .env.local. NEXT_PUBLIC_ exposes it to the browser — there is no
+# VITE_* in Next.js. Logto config lives on the Convex deployment, not here:
+#   npx convex env set LOGTO_ENDPOINT https://auth.example.com
+#   npx convex env set LOGTO_APP_ID   your-app-id
+NEXT_PUBLIC_CONVEX_URL=

--- a/examples/nextjs/.gitignore
+++ b/examples/nextjs/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+/.next
+/out
+next-env.d.ts
+*.tsbuildinfo
+.convex
+convex/_generated
+.env.local

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -1,0 +1,40 @@
+# convex-logto + Next.js (App Router)
+
+The smallest correct way to use `convex-logto` in the Next.js App Router. The
+frontend carries **no Logto config** — it pulls `{ endpoint, appId }` from the
+Convex backend via `api.logto.config`.
+
+## Run
+
+1. Install from the repo root: `pnpm install`
+2. In this directory, start Convex (creates a deployment, writes `NEXT_PUBLIC_CONVEX_URL` to `.env.local`):
+   ```bash
+   npx convex dev
+   ```
+3. In Logto, create a **Single page app** and register (Next's default port is 3000):
+   - **Redirect URI** → `http://localhost:3000/callback`
+   - **Post sign-out redirect URI** → `http://localhost:3000`
+
+   Also rotate the tenant's OIDC signing key to **RSA** (Tenant settings → OIDC configs → rotate private key → RSA). Convex rejects Logto's default ES384, so this is required; otherwise `getUserIdentity()` returns `null`. Note its **endpoint** and **App ID** for the next step.
+4. Point that deployment at your Logto app:
+   ```bash
+   npx convex env set LOGTO_ENDPOINT https://auth.example.com
+   npx convex env set LOGTO_APP_ID   your-app-id
+   ```
+5. `pnpm dev`, then open http://localhost:3000.
+
+> In this monorepo the dependency is `convex-logto: workspace:*`. Standalone, run `npm i convex-logto @logto/react`.
+
+## Next.js gotchas this example gets right
+
+- **The provider is a `"use client"` boundary.** `convex-logto/react`, `@logto/react`,
+  and `ConvexReactClient` use React hooks and `window`, so they can't be imported
+  into a Server Component. `app/layout.tsx` stays a Server Component and only
+  renders the client `app/providers.tsx`.
+- **The Convex client is created once at module scope** in the client component,
+  never inside render.
+- **Use `process.env.NEXT_PUBLIC_CONVEX_URL`** — there is no `VITE_*` / `import.meta.env`.
+- **Soft navigation** after sign-in via `navigate={(to) => router.push(to)}` from
+  `next/navigation`.
+- **The callback route** (`app/callback/page.tsx`) is a plain Server Component (no
+  `"use client"` needed) that just renders; the provider finishes the OIDC exchange.

--- a/examples/nextjs/app/callback/page.tsx
+++ b/examples/nextjs/app/callback/page.tsx
@@ -1,0 +1,5 @@
+// The provider (mounted in layout.tsx) completes the OIDC code exchange; this page
+// just renders, so it can stay a Server Component.
+export default function CallbackPage() {
+  return <p style={{ padding: 24 }}>Finishing sign in…</p>;
+}

--- a/examples/nextjs/app/layout.tsx
+++ b/examples/nextjs/app/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import { Providers } from "./providers";
+
+export const metadata: Metadata = {
+  title: "convex-logto + Next.js",
+  description: "Logto auth for Convex in the Next.js App Router",
+};
+
+// Stays a Server Component; it only renders the client <Providers> boundary.
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <Providers>{children}</Providers>
+      </body>
+    </html>
+  );
+}

--- a/examples/nextjs/app/page.tsx
+++ b/examples/nextjs/app/page.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import {
+  Authenticated,
+  AuthLoading,
+  Unauthenticated,
+  useQuery,
+} from "convex/react";
+import { useLogtoAuth } from "convex-logto/react";
+import { api } from "../convex/_generated/api";
+
+// Auth state comes from Convex (via useConvexAuth), so the button never flashes the wrong state.
+function AuthButton() {
+  const { isAuthenticated, isLoading, user, signIn, signOut } = useLogtoAuth();
+  if (isLoading) return <span style={{ color: "#888" }}>Loading…</span>;
+  return isAuthenticated ? (
+    <button onClick={() => void signOut()}>
+      Sign out ({user?.email ?? user?.sub ?? "user"})
+    </button>
+  ) : (
+    <button onClick={() => void signIn()}>Sign in</button>
+  );
+}
+
+// The `me` query runs only inside <Authenticated>, so it never flashes null.
+function Me() {
+  const me = useQuery(api.me.me);
+  return <pre>{me ? JSON.stringify(me, null, 2) : "loading identity…"}</pre>;
+}
+
+export default function Home() {
+  return (
+    <main style={{ maxWidth: 640, margin: "48px auto", padding: "0 16px" }}>
+      <h1>convex-logto + Next.js</h1>
+      <AuthButton />
+      <div style={{ marginTop: 24 }}>
+        <AuthLoading>
+          <p>Auth loading…</p>
+        </AuthLoading>
+        <Unauthenticated>
+          <p>You are signed out.</p>
+        </Unauthenticated>
+        <Authenticated>
+          <p>Signed in — your Convex identity:</p>
+          <Me />
+        </Authenticated>
+      </div>
+    </main>
+  );
+}

--- a/examples/nextjs/app/providers.tsx
+++ b/examples/nextjs/app/providers.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+// `convex-logto/react`, `@logto/react`, and `ConvexReactClient` are client-only
+// (React hooks + `window`), so the provider lives in a "use client" component.
+import { ConvexReactClient } from "convex/react";
+import { ConvexLogtoProvider } from "convex-logto/react";
+import { useRouter } from "next/navigation";
+import { api } from "../convex/_generated/api";
+
+// Created once on the client — never recreated across renders.
+const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  return (
+    <ConvexLogtoProvider
+      client={convex}
+      configQuery={api.logto.config}
+      // Soft navigation after sign-in instead of a full page reload.
+      navigate={(to) => router.push(to)}
+    >
+      {children}
+    </ConvexLogtoProvider>
+  );
+}

--- a/examples/nextjs/convex/auth.config.ts
+++ b/examples/nextjs/convex/auth.config.ts
@@ -1,0 +1,3 @@
+import { logtoAuthConfig } from "convex-logto";
+
+export default { providers: [logtoAuthConfig()] };

--- a/examples/nextjs/convex/logto.ts
+++ b/examples/nextjs/convex/logto.ts
@@ -1,0 +1,4 @@
+// Serves the public { endpoint, appId } to the frontend (the `configQuery` prop).
+import { logtoConfigQuery } from "convex-logto";
+
+export const config = logtoConfigQuery();

--- a/examples/nextjs/convex/me.ts
+++ b/examples/nextjs/convex/me.ts
@@ -1,0 +1,10 @@
+import { query } from "./_generated/server";
+
+export const me = query({
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return null;
+    // identity.subject = Logto user id, plus email/name/etc. from the ID token.
+    return { id: identity.subject, email: identity.email, name: identity.name };
+  },
+});

--- a/examples/nextjs/convex/tsconfig.json
+++ b/examples/nextjs/convex/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ESNext",
+    "lib": ["ES2023", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/examples/nextjs/next.config.ts
+++ b/examples/nextjs/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "convex-logto-example-nextjs",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@logto/react": "^4.0.14",
+    "convex": "^1.41.0",
+    "convex-logto": "workspace:*",
+    "next": "^15.5.4",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "typescript": "~5.8.3"
+  }
+}

--- a/examples/nextjs/tsconfig.json
+++ b/examples/nextjs/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "ES2022"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/examples/tanstack-router-spa/.env.example
+++ b/examples/tanstack-router-spa/.env.example
@@ -1,0 +1,2 @@
+# Your Convex deployment URL, printed by `npx convex dev`.
+VITE_CONVEX_URL=

--- a/examples/tanstack-router-spa/.gitignore
+++ b/examples/tanstack-router-spa/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.convex
+convex/_generated
+.env.local

--- a/examples/tanstack-router-spa/README.md
+++ b/examples/tanstack-router-spa/README.md
@@ -1,0 +1,75 @@
+# convex-logto + TanStack Router (SPA)
+
+All three ways to use auth: declarative `<Authenticated>` gating, the `useLogtoAuth()` hook, and **`beforeLoad` route guards** that protect routes outside of render — plus a webhook-synced `users` table with a per-app **role** (RBAC).
+
+## Run
+
+1. Install from the repo root: `pnpm install`
+2. In this directory, start Convex (creates a dev deployment and generates types):
+   ```bash
+   npx convex dev
+   ```
+3. In Logto, create a **Single page app** (not a third-party app) and add:
+   - **Redirect URI** → `http://localhost:5173/callback`
+   - **Post sign-out redirect URI** → `http://localhost:5173`
+
+   Also rotate the tenant's OIDC signing key to **RSA** (Tenant settings → OIDC configs → rotate private key → RSA). Convex rejects Logto's default ES384, so this is required; otherwise `getUserIdentity()` returns `null`. Note its **endpoint** and **App ID** for the next step.
+4. Point that deployment at your Logto app — the one place config lives:
+   ```bash
+   npx convex env set LOGTO_ENDPOINT https://your-logto.example.com
+   npx convex env set LOGTO_APP_ID   your-spa-app-id
+   ```
+5. Copy `.env.example` to `.env.local` and set `VITE_CONVEX_URL` (printed by `npx convex dev`).
+6. `pnpm dev`, then open http://localhost:5173.
+
+> In this monorepo the dependency is `convex-logto: workspace:*`. Standalone, run `npm i convex-logto @logto/react`.
+
+## Users table + roles (RBAC)
+
+The opt-in **webhook-synced `users` table** pattern: a table you own, with a
+per-app `role`. (Full write-up: [Webhook sync](../../docs/content/docs/webhook-sync.mdx).)
+
+**Try it:**
+
+1. Sign in. The first time, the dashboard shows an **onboarding form** — pick
+   `user` or `admin`. Submitting creates your `users` row.
+2. Open **Admin (admin-only)**. As a `user` you get a 403; as an `admin` you see
+   the admin stats.
+3. Use **Switch role (demo)** on the dashboard to flip your role and watch the gate
+   allow / deny.
+
+**How it's wired:**
+
+- `convex/schema.ts` — the `users` table. `email`/`name`/`status` are Logto-owned
+  (synced); `role` is app-owned.
+- `convex/logto.ts` — the `logtoSync` webhook handlers (production sync of
+  email/name + suspend/delete), registered in `convex/http.ts`.
+- `convex/authz.ts` — `requireIdentity` / `getActiveUser` / `requireActiveUser` /
+  `requireRole`. Reads are nullable (never throw mid-provisioning); writes and
+  privileged reads throw and honor suspend + delete.
+- `convex/users.ts` — `myProfile`, `completeOnboarding` (first-login row creation),
+  `setMyRole` (the demo switcher, active-only), and `adminStats` (gated by
+  `requireRole`).
+
+**The rules that keep it correct** (and dodge two classic bugs):
+
+- **The webhook writes only Logto-owned fields (email, name, status), never
+  `role`.** Otherwise a Logto profile edit (`User.Data.Updated`) would reset
+  everyone's role to the default.
+- **The webhook never creates rows — it only syncs existing ones.** Rows are created
+  by the onboarding mutation, from the logged-in state. `User.Created` does **not**
+  fire for a user who already existed in Logto (or who arrived via another app on the
+  same Logto), so a webhook-only approach would leave them permanently row-less.
+  (That's the bug that bites component-owned auth tables.)
+- **Deletion is a tombstone**, not a row removal: PII is scrubbed, but the row stays
+  so authz fails closed and nothing referencing the user by id dangles.
+
+**Demo vs production:** a real app creates everyone as `user` and grants admin out
+of band — a Convex dashboard mutation, an internal mutation, or an allowlist —
+never self-service. The "become admin" button exists only so you can try the gate
+from both sides.
+
+**Prove the gate:** `pnpm test` (after `npx convex dev` has generated types) runs
+`convex/rbac.test.ts`, which checks that a pre-existing Logto user still gets a row
+on first sign-in, non-admins are denied `adminStats`, a profile edit can't reset a
+role, and a deleted user fails closed.

--- a/examples/tanstack-router-spa/convex/auth.config.ts
+++ b/examples/tanstack-router-spa/convex/auth.config.ts
@@ -1,0 +1,3 @@
+import { logtoAuthConfig } from "convex-logto";
+
+export default { providers: [logtoAuthConfig()] };

--- a/examples/tanstack-router-spa/convex/authz.ts
+++ b/examples/tanstack-router-spa/convex/authz.ts
@@ -1,0 +1,50 @@
+// Authorization helpers. These are app code, not part of the package — convex-logto
+// stays out of your table shape on purpose. Copy/adapt them for your own schema.
+import type { QueryCtx, MutationCtx } from "./_generated/server";
+import type { Doc } from "./_generated/dataModel";
+
+type Ctx = QueryCtx | MutationCtx;
+
+export function userByAuthId(ctx: Ctx, authId: string) {
+  return ctx.db
+    .query("users")
+    .withIndex("by_authId", (q) => q.eq("authId", authId))
+    .unique();
+}
+
+/** The validated token identity, or throw. For "must be signed in". */
+export async function requireIdentity(ctx: Ctx) {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity) throw new Error("unauthenticated");
+  return identity;
+}
+
+/**
+ * The current user's row IF it exists and is active, else `null`. Nullable on
+ * purpose: a signed-in user may not have a row yet (first request, before the
+ * form/webhook creates it), and a query should not throw mid-provisioning —
+ * Convex is reactive, so the UI fills in the moment the row appears.
+ */
+export async function getActiveUser(ctx: Ctx): Promise<Doc<"users"> | null> {
+  const identity = await ctx.auth.getUserIdentity();
+  if (!identity) return null;
+  const user = await userByAuthId(ctx, identity.subject);
+  return user?.status === "active" ? user : null;
+}
+
+/** Like {@link getActiveUser} but throws — for mutations and private data. */
+export async function requireActiveUser(ctx: Ctx): Promise<Doc<"users">> {
+  const user = await getActiveUser(ctx);
+  if (!user) throw new Error("forbidden"); // covers "no row", suspended, and deleted
+  return user;
+}
+
+/** Require an active user with a specific role. Throws "forbidden" otherwise. */
+export async function requireRole(
+  ctx: Ctx,
+  role: Doc<"users">["role"],
+): Promise<Doc<"users">> {
+  const user = await requireActiveUser(ctx);
+  if (user.role !== role) throw new Error("forbidden");
+  return user;
+}

--- a/examples/tanstack-router-spa/convex/http.ts
+++ b/examples/tanstack-router-spa/convex/http.ts
@@ -1,0 +1,15 @@
+import { httpRouter } from "convex/server";
+import { registerLogtoWebhook } from "convex-logto";
+import { internal } from "./_generated/api";
+
+const http = httpRouter();
+
+// Verifies the `logto-signature-sha-256` header (needs LOGTO_WEBHOOK_SIGNING_KEY)
+// and dispatches to the `sync` mutation in `logto.ts`. Serves POST /logto/webhook.
+//
+// Locally this won't fire (Logto can't reach your dev backend), so rows are created
+// by the onboarding form instead — see the README. In production it's what keeps
+// email/name in sync and handles suspension/deletion.
+registerLogtoWebhook(http, internal.logto.sync);
+
+export default http;

--- a/examples/tanstack-router-spa/convex/logto.ts
+++ b/examples/tanstack-router-spa/convex/logto.ts
@@ -1,0 +1,69 @@
+// Two things live here:
+//   1. `config` — serves the public { endpoint, appId } to the frontend (the
+//      `configQuery` prop on <ConvexLogtoProvider>).
+//   2. `sync`   — the Logto → Convex user mirror (the "C" pattern). Registered as
+//      a webhook in `http.ts`. One-way and read-only; it never writes to Logto.
+import {
+  logtoConfigQuery,
+  logtoSync,
+  type LogtoSyncHandler,
+} from "convex-logto";
+import type { DataModel } from "./_generated/dataModel";
+import { userByAuthId } from "./authz";
+
+export const config = logtoConfigQuery();
+
+// THE RULE: webhooks may write only Logto-owned fields — email, name, and the
+// `status` lifecycle (active/suspended). They must never touch `role`, which is
+// app-owned; otherwise a Logto profile edit (`User.Data.Updated`) would reset
+// everyone's role to the default.
+//
+// Mirror only the fields the event actually carries: present → set it (a `null`
+// clears it), absent → leave it. So a profile edit can clear an email, while a
+// suspension event (which carries only id + isSuspended) won't wipe name/email.
+const syncedFields = (u: {
+  primaryEmail?: string | null;
+  name?: string | null;
+  isSuspended?: boolean;
+}) => ({
+  ...(u.primaryEmail !== undefined ? { email: u.primaryEmail ?? undefined } : {}),
+  ...(u.name !== undefined ? { name: u.name ?? undefined } : {}),
+  ...(u.isSuspended !== undefined
+    ? { status: u.isSuspended ? ("suspended" as const) : ("active" as const) }
+    : {}),
+});
+
+// The webhook only SYNCS rows that already exist — it never creates them. Rows are
+// created by an authenticated mutation (`completeOnboarding` in users.ts), because
+// `User.Created` doesn't fire for users who already existed in Logto, and a
+// webhook-created row would have to invent the app-owned `role`. No row yet → there's
+// nothing to sync; the user's next authenticated visit creates it.
+const syncRow: LogtoSyncHandler<DataModel> = async (ctx, u) => {
+  const row = await userByAuthId(ctx, u.id);
+  if (!row || row.status === "deleted") return; // nothing to sync / don't resurrect a tombstone
+  await ctx.db.patch(row._id, syncedFields(u)); // Logto-owned fields only; role untouched
+};
+
+// Soft delete: scrub the synced PII but keep the row (status "deleted") so authz
+// stays fail-closed and rows that reference this user by id don't dangle. Logto's
+// `User.Deleted` carries no entity (just the id in the route params), so `u` here
+// is the minimal `{ id }` the package normalizes it to.
+const tombstone: LogtoSyncHandler<DataModel> = async (ctx, u) => {
+  const row = await userByAuthId(ctx, u.id);
+  if (row) {
+    await ctx.db.patch(row._id, {
+      status: "deleted",
+      email: undefined,
+      name: undefined,
+    });
+  }
+};
+
+// Subscribe to changes, not creation: the token seeds a new user's email/name at
+// onboarding, and these keep them fresh afterward. (A `User.Created` delivery, if
+// Logto sends one, simply no-ops — there's no row to sync yet.)
+export const { sync } = logtoSync<DataModel>({
+  "User.Data.Updated": syncRow,
+  "User.SuspensionStatus.Updated": syncRow,
+  "User.Deleted": tombstone,
+});

--- a/examples/tanstack-router-spa/convex/me.ts
+++ b/examples/tanstack-router-spa/convex/me.ts
@@ -1,0 +1,9 @@
+import { query } from "./_generated/server";
+
+export const me = query({
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return null;
+    return { id: identity.subject, email: identity.email, name: identity.name };
+  },
+});

--- a/examples/tanstack-router-spa/convex/rbac.test.ts
+++ b/examples/tanstack-router-spa/convex/rbac.test.ts
@@ -1,0 +1,191 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, expect, test } from "vitest";
+import schema from "./schema";
+import { api, internal } from "./_generated/api";
+
+// convex-test needs every convex module so function references resolve in-process.
+const modules = import.meta.glob("./**/*.*s");
+const makeT = () => convexTest(schema, modules);
+type TestT = ReturnType<typeof makeT>;
+
+// A token identity for someone who already exists in Logto. `subject` is the
+// stable Logto user id (== what `getUserIdentity().subject` returns).
+const ALICE = { subject: "logto|alice", email: "alice@example.com", name: "Alice" };
+
+// A Logto webhook delivery for the user-sync mutation (`internal.logto.sync`).
+// `data` is the User entity for create/update/suspension, but `null` for
+// `User.Deleted` — there the id rides in the Management API route `params`, passed
+// via `extra`.
+const hook = (
+  event: string,
+  data: Record<string, unknown> | null,
+  extra: Record<string, unknown> = {},
+) => ({
+  payload: {
+    hookId: "h",
+    event,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    data,
+    ...extra,
+  },
+});
+
+const rowFor = (t: TestT, authId: string) =>
+  t.run((ctx) =>
+    ctx.db
+      .query("users")
+      .withIndex("by_authId", (q) => q.eq("authId", authId))
+      .unique(),
+  );
+
+describe("RBAC example", () => {
+  test("a user who already exists in Logto still gets a row on first sign-in", async () => {
+    const t = makeT();
+    const asAlice = t.withIdentity(ALICE);
+
+    // Signed in (valid token) but brand new to THIS app: no row yet.
+    expect(await asAlice.query(api.users.myProfile)).toEqual({ onboarded: false });
+
+    // The onboarding mutation creates the row FROM THE LOGGED-IN STATE — it never
+    // waits on a `User.Created` webhook (which won't fire for a pre-existing user).
+    await asAlice.mutation(api.users.completeOnboarding, { role: "user" });
+
+    expect(await asAlice.query(api.users.myProfile)).toMatchObject({
+      onboarded: true,
+      role: "user",
+      status: "active",
+    });
+  });
+
+  test("non-admins are denied admin-only data; admins are allowed", async () => {
+    const t = makeT();
+    const asAlice = t.withIdentity(ALICE);
+
+    await asAlice.mutation(api.users.completeOnboarding, { role: "user" });
+    await expect(asAlice.query(api.users.adminStats)).rejects.toThrow("forbidden");
+
+    await asAlice.mutation(api.users.setMyRole, { role: "admin" });
+    expect(await asAlice.query(api.users.adminStats)).toMatchObject({ admins: 1 });
+  });
+
+  test("a signed-in user with no row is denied admin data", async () => {
+    const t = makeT();
+    await expect(
+      t.withIdentity({ subject: "logto|nobody" }).query(api.users.adminStats),
+    ).rejects.toThrow("forbidden");
+  });
+
+  test("the webhook never creates a row — only an authenticated mutation does", async () => {
+    const t = makeT();
+
+    // A sync event for a user who hasn't onboarded: nothing to sync, no row created.
+    await t.mutation(
+      internal.logto.sync,
+      hook("User.Data.Updated", {
+        id: ALICE.subject,
+        primaryEmail: ALICE.email,
+        name: ALICE.name,
+      }),
+    );
+    expect(await rowFor(t, ALICE.subject)).toBeNull();
+
+    // Onboarding (authenticated) is the sole creator.
+    await t
+      .withIdentity(ALICE)
+      .mutation(api.users.completeOnboarding, { role: "user" });
+    expect(await rowFor(t, ALICE.subject)).toMatchObject({
+      role: "user",
+      status: "active",
+    });
+  });
+
+  test("a Logto profile edit (webhook) never resets an app-owned role", async () => {
+    const t = makeT();
+    const asAlice = t.withIdentity(ALICE);
+    await asAlice.mutation(api.users.completeOnboarding, { role: "admin" });
+
+    await t.mutation(
+      internal.logto.sync,
+      hook("User.Data.Updated", {
+        id: ALICE.subject,
+        name: "Alice Renamed",
+        primaryEmail: ALICE.email,
+      }),
+    );
+
+    expect(await asAlice.query(api.users.myProfile)).toMatchObject({
+      onboarded: true,
+      role: "admin", // still admin — the webhook only wrote name/email
+      name: "Alice Renamed",
+    });
+  });
+
+  test("suspension flips status: admin denied, profile hides PII (but row keeps it)", async () => {
+    const t = makeT();
+    const asAlice = t.withIdentity(ALICE);
+    await asAlice.mutation(api.users.completeOnboarding, { role: "admin" });
+
+    // Suspension events carry only id + isSuspended — name/email must survive.
+    await t.mutation(
+      internal.logto.sync,
+      hook("User.SuspensionStatus.Updated", {
+        id: ALICE.subject,
+        isSuspended: true,
+      }),
+    );
+
+    await expect(asAlice.query(api.users.adminStats)).rejects.toThrow("forbidden");
+    expect(await asAlice.query(api.users.myProfile)).toMatchObject({
+      onboarded: true,
+      status: "suspended",
+      email: null, // hidden from an inactive account…
+      name: null,
+    });
+    expect(await rowFor(t, ALICE.subject)).toMatchObject({
+      email: ALICE.email, // …but suspension doesn't scrub the row (only deletion does)
+    });
+  });
+
+  test("deletion tombstones the row: PII scrubbed, authz fails closed", async () => {
+    const t = makeT();
+    const asAlice = t.withIdentity(ALICE);
+    await asAlice.mutation(api.users.completeOnboarding, { role: "admin" });
+
+    // Real `User.Deleted` shape: `data` is null; the id is in the route params
+    // (`DELETE /users/:userId`), NOT in `data.id`.
+    await t.mutation(
+      internal.logto.sync,
+      hook("User.Deleted", null, { params: { userId: ALICE.subject } }),
+    );
+
+    const row = await rowFor(t, ALICE.subject);
+    expect(row?.status).toBe("deleted");
+    expect(row?.email).toBeUndefined();
+    expect(row?.name).toBeUndefined();
+
+    await expect(asAlice.query(api.users.adminStats)).rejects.toThrow("forbidden");
+  });
+
+  test("a webhook that pins down no user id is rejected", async () => {
+    const t = makeT();
+    // `User.Deleted` with neither `data` nor a `params.userId` can't name a user.
+    await expect(
+      t.mutation(internal.logto.sync, hook("User.Deleted", null)),
+    ).rejects.toThrow();
+  });
+
+  test("a delete resolves its user from params even if data is a stray {}", async () => {
+    const t = makeT();
+    const asAlice = t.withIdentity(ALICE);
+    await asAlice.mutation(api.users.completeOnboarding, { role: "user" });
+
+    // Defensive: a malformed delete with an id-less `data: {}` must still tombstone
+    // via `params.userId`, never dispatch an id-less user that silently no-ops.
+    await t.mutation(
+      internal.logto.sync,
+      hook("User.Deleted", {}, { params: { userId: ALICE.subject } }),
+    );
+    expect((await rowFor(t, ALICE.subject))?.status).toBe("deleted");
+  });
+});

--- a/examples/tanstack-router-spa/convex/schema.ts
+++ b/examples/tanstack-router-spa/convex/schema.ts
@@ -1,0 +1,22 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+// One row per Logto user. Fields by OWNER — this split is the whole point:
+//   - Logto-owned (email, name, status): the webhook in `logto.ts` keeps these in
+//     sync. `status` is the Logto lifecycle — active / suspended, plus "deleted"
+//     written as a tombstone on User.Deleted.
+//   - App-owned (role): only your own mutations set this; the webhook never touches
+//     it, so editing a Logto profile can't reset someone's role.
+export default defineSchema({
+  users: defineTable({
+    authId: v.string(), // == identity.subject (the Logto user id)
+    email: v.optional(v.string()), // Logto-owned
+    name: v.optional(v.string()), // Logto-owned
+    role: v.union(v.literal("user"), v.literal("admin")), // app-owned (RBAC)
+    status: v.union(
+      v.literal("active"),
+      v.literal("suspended"),
+      v.literal("deleted"),
+    ), // Logto-owned lifecycle ("deleted" is a tombstone, not a row removal)
+  }).index("by_authId", ["authId"]),
+});

--- a/examples/tanstack-router-spa/convex/tsconfig.json
+++ b/examples/tanstack-router-spa/convex/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ESNext",
+    "lib": ["ES2023", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/examples/tanstack-router-spa/convex/users.ts
+++ b/examples/tanstack-router-spa/convex/users.ts
@@ -1,0 +1,94 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import {
+  requireActiveUser,
+  requireIdentity,
+  requireRole,
+  userByAuthId,
+} from "./authz";
+
+const roleValidator = v.union(v.literal("user"), v.literal("admin"));
+
+// What the dashboard reads. Discriminated so the client knows which UI to show:
+//   null                 -> signed out
+//   { onboarded: false } -> signed in, no row yet -> show the role-picker form
+//   { onboarded: true }  -> has a row -> show role/status (PII only while active)
+export const myProfile = query({
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return null;
+    const user = await userByAuthId(ctx, identity.subject);
+    if (!user) return { onboarded: false as const };
+    const active = user.status === "active";
+    return {
+      onboarded: true as const,
+      role: user.role,
+      status: user.status,
+      // Expose identity details only for an active account — a suspended/deleted
+      // row has its PII scrubbed, so don't rehydrate it from the token.
+      email: active ? (user.email ?? identity.email ?? null) : null,
+      name: active ? (user.name ?? identity.name ?? null) : null,
+    };
+  },
+});
+
+// First-login onboarding: create the caller's row, keyed by their token subject.
+// Get-or-create, so calling it twice is safe (and races resolve under Convex OCC).
+//
+// This — NOT the webhook — is what creates rows. `User.Created` doesn't fire for a
+// user who already existed in Logto, so a webhook-only approach would leave them
+// permanently row-less. An authenticated mutation is the reliable creator.
+//
+// Trust boundary: we create the row `active` on the strength of the caller's token,
+// which Convex already verified (signature + expiry). Like all JWT auth, a token
+// stays valid until it expires (≤ its TTL) even if Logto suspends/deletes the user
+// afterward. For someone already onboarded the webhook flips their status the moment
+// Logto fires the event; a user still in this pre-onboarding window could self-
+// provision an `active` row until their token lapses. Closing that residual gap
+// needs short token lifetimes or a live Logto check (Management API) — out of scope
+// for a demo, but the reason a webhook tombstone is the WRONG fix: it would mint a
+// row for every Logto user ever suspended/deleted, even ones who never used the app.
+//
+// DEMO ONLY: taking `role` from the client lets you try the gate from both sides.
+// A real app drops the arg, always creates `role: "user"`, and grants admin OUT OF
+// BAND (a Convex dashboard mutation, an internal mutation, or an allowlist).
+export const completeOnboarding = mutation({
+  args: { role: roleValidator },
+  handler: async (ctx, { role }) => {
+    const identity = await requireIdentity(ctx);
+    if (await userByAuthId(ctx, identity.subject)) return; // already onboarded
+    await ctx.db.insert("users", {
+      authId: identity.subject,
+      email: identity.email,
+      name: identity.name,
+      role,
+      status: "active",
+    });
+  },
+});
+
+// Change an EXISTING active user's role. `role` is app-owned, so writing it is
+// correct; `requireActiveUser` stops a suspended/deleted user from touching it.
+// (Demo switcher — a real app would gate this on `requireRole(ctx, "admin")`.)
+export const setMyRole = mutation({
+  args: { role: roleValidator },
+  handler: async (ctx, { role }) => {
+    const user = await requireActiveUser(ctx);
+    await ctx.db.patch(user._id, { role });
+  },
+});
+
+// The payload the /admin page shows. `requireRole` throws "forbidden" for anyone
+// who isn't an active admin — enforced on the server regardless of the client UI.
+export const adminStats = query({
+  handler: async (ctx) => {
+    await requireRole(ctx, "admin");
+    const all = await ctx.db.query("users").collect();
+    return {
+      total: all.length,
+      admins: all.filter((u) => u.role === "admin").length,
+      users: all.filter((u) => u.role === "user").length,
+      active: all.filter((u) => u.status === "active").length,
+    };
+  },
+});

--- a/examples/tanstack-router-spa/index.html
+++ b/examples/tanstack-router-spa/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>convex-logto + TanStack Router</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/tanstack-router-spa/package.json
+++ b/examples/tanstack-router-spa/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "convex-logto-example-tanstack-router-spa",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@logto/react": "^4.0.14",
+    "@tanstack/react-router": "^1.170.15",
+    "convex": "^1.41.0",
+    "convex-logto": "workspace:*",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@edge-runtime/vm": "^5.0.0",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.2",
+    "convex-test": "^0.0.53",
+    "typescript": "~5.8.3",
+    "vite": "^8.0.16",
+    "vitest": "^3.2.6"
+  }
+}

--- a/examples/tanstack-router-spa/src/AdminPage.tsx
+++ b/examples/tanstack-router-spa/src/AdminPage.tsx
@@ -1,0 +1,64 @@
+import { useQuery } from "convex/react";
+import { Link } from "@tanstack/react-router";
+import { api } from "../convex/_generated/api";
+
+// Two layers of protection here:
+//   - The `_authed` route guard already required a signed-in user (authn).
+//   - This component mirrors the server's authz for a friendly screen, AND the
+//     server enforces it independently: `adminStats` calls `requireRole`, so a
+//     non-admin can't read the data even by calling the query directly.
+export function AdminPage() {
+  const profile = useQuery(api.users.myProfile);
+
+  if (profile === undefined) return <p>Loading…</p>;
+  if (profile === null) return <p>You are signed out.</p>;
+  if (!profile.onboarded)
+    return (
+      <p>
+        Finish onboarding on the <Link to="/dashboard">dashboard</Link> first.
+      </p>
+    );
+
+  // Mirror the server's `requireRole` (active AND admin). Without the status check,
+  // a suspended/deleted admin would render <AdminContent />, then `adminStats` would
+  // throw "forbidden" under an admin header.
+  if (profile.status !== "active")
+    return (
+      <section>
+        <h1>Account {profile.status}</h1>
+        <p>
+          Your account is <code>{profile.status}</code>, so admin tools are
+          unavailable.
+        </p>
+      </section>
+    );
+
+  if (profile.role !== "admin")
+    return (
+      <section>
+        <h1>🚫 403 — Admins only</h1>
+        <p>
+          Your role is <code>{profile.role}</code>. This page requires{" "}
+          <code>admin</code>.
+        </p>
+        <p>
+          Go to the <Link to="/dashboard">dashboard</Link>, switch to{" "}
+          <code>admin</code>, and come back.
+        </p>
+      </section>
+    );
+
+  return <AdminContent />;
+}
+
+function AdminContent() {
+  // Reached only by active admins; the server agrees, so this resolves instead of throwing.
+  const stats = useQuery(api.users.adminStats);
+  return (
+    <section>
+      <h1>Admin area ✅</h1>
+      <p>You're an active admin, so the server let `adminStats` through.</p>
+      <pre>{stats ? JSON.stringify(stats, null, 2) : "loading…"}</pre>
+    </section>
+  );
+}

--- a/examples/tanstack-router-spa/src/AuthButton.tsx
+++ b/examples/tanstack-router-spa/src/AuthButton.tsx
@@ -1,0 +1,14 @@
+// Auth state comes from Convex (via useConvexAuth), so the button never flashes the wrong state.
+import { useLogtoAuth } from "convex-logto/react";
+
+export function AuthButton() {
+  const { isAuthenticated, isLoading, user, signIn, signOut } = useLogtoAuth();
+  if (isLoading) return <span style={{ color: "#888" }}>Loading…</span>;
+  return isAuthenticated ? (
+    <button onClick={() => void signOut()}>
+      Sign out ({user?.email ?? user?.sub ?? "user"})
+    </button>
+  ) : (
+    <button onClick={() => void signIn()}>Sign in</button>
+  );
+}

--- a/examples/tanstack-router-spa/src/Dashboard.tsx
+++ b/examples/tanstack-router-spa/src/Dashboard.tsx
@@ -1,0 +1,167 @@
+import { useState } from "react";
+import { useMutation, useQuery } from "convex/react";
+import { Link } from "@tanstack/react-router";
+import { api } from "../convex/_generated/api";
+
+type Role = "user" | "admin";
+
+export function Dashboard() {
+  const profile = useQuery(api.users.myProfile);
+  const completeOnboarding = useMutation(api.users.completeOnboarding);
+  const setMyRole = useMutation(api.users.setMyRole);
+
+  if (profile === undefined) return <p>Loading…</p>;
+  // We're inside the `_authed` guard, so signed-out is unreachable in practice.
+  if (profile === null) return <p>You are signed out.</p>;
+
+  // First login: the row doesn't exist yet. The form creates it with the chosen role.
+  if (!profile.onboarded)
+    return <Onboarding onSubmit={(role) => completeOnboarding({ role })} />;
+
+  if (profile.status !== "active")
+    return <InactiveNotice status={profile.status} />;
+
+  return (
+    <section>
+      <h1>Dashboard (protected)</h1>
+      <p>
+        Signed in as{" "}
+        <strong>{profile.name ?? profile.email ?? "your account"}</strong> — role{" "}
+        <RoleBadge role={profile.role} />, status <code>{profile.status}</code>.
+      </p>
+      <p>
+        <Link to="/admin">Open the Admin area →</Link> (only <code>admin</code> may
+        enter)
+      </p>
+      <RoleSwitcher
+        role={profile.role}
+        onSwitch={(role) => setMyRole({ role })}
+      />
+    </section>
+  );
+}
+
+function Onboarding({
+  onSubmit,
+}: {
+  onSubmit: (role: Role) => Promise<unknown>;
+}) {
+  const [role, setRole] = useState<Role>("user");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  return (
+    <section>
+      <h1>Welcome 👋</h1>
+      <p>Pick a role to finish setting up your account:</p>
+      <form
+        onSubmit={async (e) => {
+          e.preventDefault();
+          setSaving(true);
+          setError(null);
+          try {
+            await onSubmit(role);
+            // On success the query swaps this component out — nothing to reset.
+          } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+            setSaving(false);
+          }
+        }}
+        style={{ display: "grid", gap: 8, maxWidth: 320 }}
+      >
+        <label>
+          <input
+            type="radio"
+            name="role"
+            checked={role === "user"}
+            onChange={() => setRole("user")}
+          />{" "}
+          User (normal access)
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="role"
+            checked={role === "admin"}
+            onChange={() => setRole("admin")}
+          />{" "}
+          Admin (can open the Admin area)
+        </label>
+        <button type="submit" disabled={saving} style={{ marginTop: 8 }}>
+          {saving ? "Creating…" : "Create my account"}
+        </button>
+        {error && (
+          <p style={{ color: "#b30000" }}>Couldn't create account: {error}</p>
+        )}
+      </form>
+      <p style={{ color: "#888", fontSize: 13, marginTop: 12 }}>
+        Demo only — real apps create everyone as <code>user</code> and grant admin
+        server-side.
+      </p>
+    </section>
+  );
+}
+
+function RoleSwitcher({
+  role,
+  onSwitch,
+}: {
+  role: Role;
+  onSwitch: (role: Role) => Promise<unknown>;
+}) {
+  const [error, setError] = useState<string | null>(null);
+  const switchTo = async (next: Role) => {
+    setError(null);
+    try {
+      await onSwitch(next);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  return (
+    <fieldset
+      style={{ marginTop: 16, border: "1px solid #ddd", borderRadius: 8 }}
+    >
+      <legend>Switch role (demo)</legend>
+      <p style={{ color: "#888", fontSize: 13, margin: "4px 0 12px" }}>
+        Flip your role, then revisit the Admin area to watch the gate allow / deny.
+      </p>
+      <div style={{ display: "flex", gap: 12 }}>
+        <button
+          type="button"
+          disabled={role === "user"}
+          onClick={() => void switchTo("user")}
+        >
+          Become user
+        </button>
+        <button
+          type="button"
+          disabled={role === "admin"}
+          onClick={() => void switchTo("admin")}
+        >
+          Become admin
+        </button>
+      </div>
+      {error && <p style={{ color: "#b30000" }}>Couldn't switch role: {error}</p>}
+    </fieldset>
+  );
+}
+
+function InactiveNotice({ status }: { status: "suspended" | "deleted" }) {
+  return (
+    <section>
+      <h1>Account {status}</h1>
+      <p>
+        Your account is <code>{status}</code>, so the app is unavailable. (Set in
+        Logto, synced here by the webhook.)
+      </p>
+    </section>
+  );
+}
+
+function RoleBadge({ role }: { role: Role }) {
+  return (
+    <code style={{ color: role === "admin" ? "#b30000" : "#333" }}>{role}</code>
+  );
+}

--- a/examples/tanstack-router-spa/src/DeclarativeGate.tsx
+++ b/examples/tanstack-router-spa/src/DeclarativeGate.tsx
@@ -1,0 +1,32 @@
+// Declarative gating with Convex's <AuthLoading>/<Unauthenticated>/<Authenticated>.
+// convex-logto uses ConvexProviderWithAuth internally, so these work unchanged.
+// The `me` query runs only inside <Authenticated>, so it never flashes null first.
+import {
+  Authenticated,
+  AuthLoading,
+  Unauthenticated,
+  useQuery,
+} from "convex/react";
+import { api } from "../convex/_generated/api";
+
+function Me() {
+  const me = useQuery(api.me.me);
+  return <pre>{me ? JSON.stringify(me, null, 2) : "…"}</pre>;
+}
+
+export function DeclarativeGate() {
+  return (
+    <>
+      <AuthLoading>
+        <p>Auth loading…</p>
+      </AuthLoading>
+      <Unauthenticated>
+        <p>You are signed out.</p>
+      </Unauthenticated>
+      <Authenticated>
+        <p>Signed in — your Convex identity:</p>
+        <Me />
+      </Authenticated>
+    </>
+  );
+}

--- a/examples/tanstack-router-spa/src/SignInPage.tsx
+++ b/examples/tanstack-router-spa/src/SignInPage.tsx
@@ -1,0 +1,11 @@
+import { useLogtoAuth } from "convex-logto/react";
+
+export function SignInPage() {
+  const { signIn } = useLogtoAuth();
+  return (
+    <section>
+      <h1>Sign in</h1>
+      <button onClick={() => void signIn()}>Sign in with Logto</button>
+    </section>
+  );
+}

--- a/examples/tanstack-router-spa/src/main.tsx
+++ b/examples/tanstack-router-spa/src/main.tsx
@@ -1,0 +1,32 @@
+import { StrictMode, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import { ConvexReactClient } from "convex/react";
+import { ConvexLogtoProvider, useLogtoAuth } from "convex-logto/react";
+import { RouterProvider } from "@tanstack/react-router";
+import { api } from "../convex/_generated/api";
+import { router } from "./router";
+
+const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL as string);
+
+// Inside <ConvexLogtoProvider> so useLogtoAuth() has its context.
+function RouterWithAuth() {
+  const auth = useLogtoAuth();
+  // beforeLoad only runs on navigation — re-run the guards when auth changes.
+  useEffect(() => {
+    router.invalidate();
+  }, [auth.isLoading, auth.isAuthenticated]);
+  return <RouterProvider router={router} context={{ auth }} />;
+}
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <ConvexLogtoProvider
+      client={convex}
+      configQuery={api.logto.config}
+      // Soft-navigate via the router instead of a hard redirect after sign-in.
+      navigate={(to) => void router.navigate({ to })}
+    >
+      <RouterWithAuth />
+    </ConvexLogtoProvider>
+  </StrictMode>,
+);

--- a/examples/tanstack-router-spa/src/router.tsx
+++ b/examples/tanstack-router-spa/src/router.tsx
@@ -1,0 +1,108 @@
+import {
+  createRootRouteWithContext,
+  createRoute,
+  createRouter,
+  redirect,
+  Link,
+  Outlet,
+} from "@tanstack/react-router";
+import type { useLogtoAuth } from "convex-logto/react";
+import { AuthButton } from "./AuthButton";
+import { DeclarativeGate } from "./DeclarativeGate";
+import { SignInPage } from "./SignInPage";
+import { Dashboard } from "./Dashboard";
+import { AdminPage } from "./AdminPage";
+
+// Auth lives in router context so `beforeLoad` guards can read it outside render.
+export type RouterAuthContext = { auth: ReturnType<typeof useLogtoAuth> };
+
+const rootRoute = createRootRouteWithContext<RouterAuthContext>()({
+  component: RootLayout,
+});
+
+function RootLayout() {
+  return (
+    <div style={{ fontFamily: "system-ui", padding: 24, maxWidth: 720 }}>
+      <nav style={{ display: "flex", gap: 12, alignItems: "center" }}>
+        <Link to="/">Home</Link>
+        <Link to="/dashboard">Dashboard (protected)</Link>
+        <Link to="/admin">Admin (admin-only)</Link>
+        <span style={{ marginLeft: "auto" }}>
+          <AuthButton />
+        </span>
+      </nav>
+      <main style={{ paddingTop: 16 }}>
+        <Outlet />
+      </main>
+    </div>
+  );
+}
+
+const indexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/",
+  component: () => (
+    <section>
+      <h1>convex-logto + TanStack Router</h1>
+      <DeclarativeGate />
+    </section>
+  ),
+});
+
+const signinRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/signin",
+  component: SignInPage,
+});
+
+// OIDC callback. The provider finishes the code exchange; this just renders.
+const callbackRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/callback",
+  component: () => <p>Finishing sign in…</p>,
+});
+
+// Protected layout: its `beforeLoad` redirects unauthenticated users to /signin.
+const authedRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  id: "_authed",
+  beforeLoad: ({ context }) => {
+    if (context.auth.isLoading) return; // still settling — don't redirect yet
+    if (!context.auth.isAuthenticated) throw redirect({ to: "/signin" });
+  },
+  pendingComponent: () => <p>Checking access…</p>,
+  component: () => <Outlet />,
+});
+
+const dashboardRoute = createRoute({
+  getParentRoute: () => authedRoute,
+  path: "/dashboard",
+  component: Dashboard,
+});
+
+// Also behind `_authed` (must be signed in). The role check (authz) happens in
+// the component + on the server; the guard here only enforces authentication.
+const adminRoute = createRoute({
+  getParentRoute: () => authedRoute,
+  path: "/admin",
+  component: AdminPage,
+});
+
+export const router = createRouter({
+  routeTree: rootRoute.addChildren([
+    indexRoute,
+    signinRoute,
+    callbackRoute,
+    authedRoute.addChildren([dashboardRoute, adminRoute]),
+  ]),
+  // Real auth is injected via <RouterProvider context>; this only satisfies the type.
+  context: { auth: undefined! },
+  // Show pendingComponent immediately while auth settles.
+  defaultPendingMs: 0,
+});
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: typeof router;
+  }
+}

--- a/examples/tanstack-router-spa/src/vite-env.d.ts
+++ b/examples/tanstack-router-spa/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/tanstack-router-spa/tsconfig.json
+++ b/examples/tanstack-router-spa/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/examples/tanstack-router-spa/vite.config.ts
+++ b/examples/tanstack-router-spa/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 5173, strictPort: true },
+});

--- a/examples/tanstack-router-spa/vitest.config.ts
+++ b/examples/tanstack-router-spa/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+// convex-test runs your Convex functions in-process (no backend) using the
+// edge-runtime environment. See convex/rbac.test.ts.
+export default defineConfig({
+  test: {
+    environment: "edge-runtime",
+    server: { deps: { inline: ["convex-test"] } },
+  },
+});

--- a/examples/tanstack-start/.env.example
+++ b/examples/tanstack-start/.env.example
@@ -1,0 +1,6 @@
+# Your Convex deployment URL, printed by `npx convex dev`. Used by the
+# ConvexQueryClient (server + client) via `import.meta.env.VITE_CONVEX_URL`.
+# Logto config lives on the Convex deployment, not here:
+#   npx convex env set LOGTO_ENDPOINT https://auth.example.com
+#   npx convex env set LOGTO_APP_ID   your-app-id
+VITE_CONVEX_URL=

--- a/examples/tanstack-start/.gitignore
+++ b/examples/tanstack-start/.gitignore
@@ -1,0 +1,10 @@
+node_modules
+.output
+.nitro
+.tanstack
+dist
+*.tsbuildinfo
+.convex
+convex/_generated
+src/routeTree.gen.ts
+.env.local

--- a/examples/tanstack-start/README.md
+++ b/examples/tanstack-start/README.md
@@ -1,0 +1,64 @@
+# convex-logto + TanStack Start (SSR)
+
+`convex-logto` on TanStack Start, following Convex's canonical Start wiring
+(`ConvexQueryClient` + TanStack Query + `setupRouterSsrQueryIntegration`) with
+`ConvexLogtoProvider` layered on top. Shows both auth patterns from the SPA
+example: declarative `<Authenticated>` gating **and** a `beforeLoad` route guard
+reading auth from router context.
+
+## Run
+
+1. Install from the repo root: `pnpm install`
+2. In this directory, start Convex (creates a dev deployment and generates types):
+   ```bash
+   npx convex dev
+   ```
+3. In Logto, create a **Single page app** (not a third-party app) and add
+   (TanStack Start's dev server defaults to port 3000):
+   - **Redirect URI** → `http://localhost:3000/callback`
+   - **Post sign-out redirect URI** → `http://localhost:3000`
+
+   Also rotate the tenant's OIDC signing key to **RSA** (Tenant settings → OIDC configs → rotate private key → RSA). Convex rejects Logto's default ES384, so this is required; otherwise `getUserIdentity()` returns `null`. Note its **endpoint** and **App ID** for the next step.
+4. Point that deployment at your Logto app — the one place config lives:
+   ```bash
+   npx convex env set LOGTO_ENDPOINT https://your-logto.example.com
+   npx convex env set LOGTO_APP_ID   your-spa-app-id
+   ```
+5. Copy `.env.example` to `.env.local` and set `VITE_CONVEX_URL` (printed by `npx convex dev`).
+6. `pnpm dev`, then open http://localhost:3000.
+
+> In this monorepo the dependency is `convex-logto: workspace:*`. Standalone, run `npm i convex-logto @logto/react`.
+
+## How SSR is handled
+
+The provider is **SSR-safe**: `ConvexLogtoProvider` mounts the Logto + Convex tree
+from the first render using an inert loading client, so children render immediately
+under Convex's `<AuthLoading>` and nothing touches `window` on the server. So this
+example has **no hand-written client boundary, stub, or mount-gate** — the same
+`<ConvexLogtoProvider>` you'd write for a SPA works on the server too.
+
+- **`src/router.tsx`** is Convex's canonical Start setup; the router's `InnerWrap`
+  renders `src/auth.tsx`'s `AuthBoundary`.
+- **`AuthBoundary`** is just `<ConvexLogtoProvider>` plus a `RouterAuthBridge`. On
+  the server and the first client paint auth reports "loading", so the
+  `<AuthLoading>` shell renders; the client hydrates and auth settles. Server and
+  first client render match, so there's no hydration mismatch.
+- The `<Authenticated>/<Unauthenticated>/<AuthLoading>` components and the
+  `useLogtoAuth()` buttons read the provider's context directly — no mount-gating,
+  the same component code as the SPA example.
+
+## The two auth patterns
+
+1. **Declarative** (`src/DeclarativeGate.tsx`) — `<Authenticated>` /
+   `<Unauthenticated>` / `<AuthLoading>` from `convex/react`, unchanged.
+2. **`beforeLoad` route guard** (`src/routes/_authed.tsx`) — protects `/dashboard`
+   outside of render. Start builds the router context once, so auth is carried in
+   a **mutable holder** on the context that `AuthBoundary`'s `RouterAuthBridge`
+   keeps pointed at the live `useLogtoAuth()` result, calling `router.invalidate()` on every auth
+   change to re-run the guards. This is the Start equivalent of the SPA's
+   `<RouterProvider context={{ auth }}>` + `RouterWithAuth`.
+
+`navigate` is wired to the router (`router.navigate`), so post-sign-in is a soft
+navigation rather than a full reload. The OIDC redirect lands on
+`src/routes/callback.tsx`, which just renders while the provider finishes the
+code exchange.

--- a/examples/tanstack-start/convex/auth.config.ts
+++ b/examples/tanstack-start/convex/auth.config.ts
@@ -1,0 +1,3 @@
+import { logtoAuthConfig } from "convex-logto";
+
+export default { providers: [logtoAuthConfig()] };

--- a/examples/tanstack-start/convex/logto.ts
+++ b/examples/tanstack-start/convex/logto.ts
@@ -1,0 +1,4 @@
+// Serves the public { endpoint, appId } to the frontend (the `configQuery` prop).
+import { logtoConfigQuery } from "convex-logto";
+
+export const config = logtoConfigQuery();

--- a/examples/tanstack-start/convex/me.ts
+++ b/examples/tanstack-start/convex/me.ts
@@ -1,0 +1,10 @@
+import { query } from "./_generated/server";
+
+export const me = query({
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return null;
+    // identity.subject = Logto user id, plus email/name/etc. from the ID token.
+    return { id: identity.subject, email: identity.email, name: identity.name };
+  },
+});

--- a/examples/tanstack-start/convex/tsconfig.json
+++ b/examples/tanstack-start/convex/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ESNext",
+    "lib": ["ES2023", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/examples/tanstack-start/package.json
+++ b/examples/tanstack-start/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "convex-logto-example-tanstack-start",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build && tsc --noEmit",
+    "start": "node .output/server/index.mjs",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@convex-dev/react-query": "^0.1.0",
+    "@logto/react": "^4.0.14",
+    "@tanstack/react-query": "^5.101.0",
+    "@tanstack/react-router": "^1.170.15",
+    "@tanstack/react-router-ssr-query": "^1.167.1",
+    "@tanstack/react-start": "^1.168.25",
+    "convex": "^1.41.0",
+    "convex-logto": "workspace:*",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.2",
+    "typescript": "~5.8.3",
+    "vite": "^8.0.16"
+  }
+}

--- a/examples/tanstack-start/src/AuthButton.tsx
+++ b/examples/tanstack-start/src/AuthButton.tsx
@@ -1,0 +1,14 @@
+// Auth state comes from Convex (via useConvexAuth), so the button never flashes the wrong state.
+import { useLogtoAuth } from "convex-logto/react";
+
+export function AuthButton() {
+  const { isAuthenticated, isLoading, user, signIn, signOut } = useLogtoAuth();
+  if (isLoading) return <span style={{ color: "#888" }}>Loading…</span>;
+  return isAuthenticated ? (
+    <button onClick={() => void signOut()}>
+      Sign out ({user?.email ?? user?.sub ?? "user"})
+    </button>
+  ) : (
+    <button onClick={() => void signIn()}>Sign in</button>
+  );
+}

--- a/examples/tanstack-start/src/Dashboard.tsx
+++ b/examples/tanstack-start/src/Dashboard.tsx
@@ -1,0 +1,13 @@
+import { useQuery } from "convex/react";
+import { api } from "../convex/_generated/api";
+
+export function Dashboard() {
+  const me = useQuery(api.me.me);
+  return (
+    <section>
+      <h1>Dashboard (protected)</h1>
+      <p>You only see this because the beforeLoad guard lets you through.</p>
+      <pre>{me ? JSON.stringify(me, null, 2) : "loading identity…"}</pre>
+    </section>
+  );
+}

--- a/examples/tanstack-start/src/DeclarativeGate.tsx
+++ b/examples/tanstack-start/src/DeclarativeGate.tsx
@@ -1,0 +1,34 @@
+// Declarative gating with Convex's <AuthLoading>/<Unauthenticated>/<Authenticated>.
+// convex-logto uses ConvexProviderWithAuth internally, so these work unchanged.
+// The `me` query runs only inside <Authenticated>, so it never flashes null first.
+// The provider is SSR-safe and reports "loading" on the server, so SSR renders the
+// <AuthLoading> branch — these need no special handling.
+import {
+  Authenticated,
+  AuthLoading,
+  Unauthenticated,
+  useQuery,
+} from "convex/react";
+import { api } from "../convex/_generated/api";
+
+function Me() {
+  const me = useQuery(api.me.me);
+  return <pre>{me ? JSON.stringify(me, null, 2) : "…"}</pre>;
+}
+
+export function DeclarativeGate() {
+  return (
+    <>
+      <AuthLoading>
+        <p>Auth loading…</p>
+      </AuthLoading>
+      <Unauthenticated>
+        <p>You are signed out.</p>
+      </Unauthenticated>
+      <Authenticated>
+        <p>Signed in — your Convex identity:</p>
+        <Me />
+      </Authenticated>
+    </>
+  );
+}

--- a/examples/tanstack-start/src/SignInPage.tsx
+++ b/examples/tanstack-start/src/SignInPage.tsx
@@ -1,0 +1,11 @@
+import { useLogtoAuth } from "convex-logto/react";
+
+export function SignInPage() {
+  const { signIn } = useLogtoAuth();
+  return (
+    <section>
+      <h1>Sign in</h1>
+      <button onClick={() => void signIn()}>Sign in with Logto</button>
+    </section>
+  );
+}

--- a/examples/tanstack-start/src/auth.tsx
+++ b/examples/tanstack-start/src/auth.tsx
@@ -1,0 +1,53 @@
+// convex-logto's provider is SSR-safe: children render under Convex's <AuthLoading>
+// while config loads, and nothing touches `window` on the server. So the boundary is
+// just the provider plus a bridge that re-runs the route guards when auth changes.
+import { useEffect } from "react";
+import type { ConvexReactClient } from "convex/react";
+import { ConvexLogtoProvider, useLogtoAuth } from "convex-logto/react";
+import { type AnyRouter, useRouter } from "@tanstack/react-router";
+import { api } from "../convex/_generated/api";
+import type { AuthHolder } from "./router";
+
+// `beforeLoad` guards run only on navigation. Start builds the router context once,
+// so we keep a mutable holder pointed at the live auth and invalidate to re-run them.
+function RouterAuthBridge({
+  holder,
+  router,
+}: {
+  holder: AuthHolder;
+  router: AnyRouter;
+}) {
+  const auth = useLogtoAuth();
+  // `auth` is memoized, so its identity already changes whenever isAuthenticated /
+  // isLoading / user does — depending on it alone is enough (and listing the
+  // primitives too would be redundant).
+  useEffect(() => {
+    holder.auth = auth;
+    void router.invalidate();
+  }, [holder, router, auth]);
+  return null;
+}
+
+export function AuthBoundary({
+  client,
+  holder,
+  children,
+}: {
+  client: ConvexReactClient;
+  holder: AuthHolder;
+  children: React.ReactNode;
+}) {
+  // `useRouter()` works inside the router's `InnerWrap`, on both server and client.
+  const router = useRouter();
+  return (
+    <ConvexLogtoProvider
+      client={client}
+      configQuery={api.logto.config}
+      // Soft-navigate after sign-in instead of a hard redirect.
+      navigate={(to) => void router.navigate({ to })}
+    >
+      <RouterAuthBridge holder={holder} router={router} />
+      {children}
+    </ConvexLogtoProvider>
+  );
+}

--- a/examples/tanstack-start/src/router.tsx
+++ b/examples/tanstack-start/src/router.tsx
@@ -1,0 +1,73 @@
+// Convex's canonical TanStack Start wiring (ConvexQueryClient + TanStack Query +
+// SSR integration), with convex-logto layered on top via the router's `InnerWrap`.
+//
+// The Convex client is owned by the ConvexQueryClient; we pass that same client
+// into convex-logto so auth and queries share one socket.
+import { ConvexQueryClient } from "@convex-dev/react-query";
+import { QueryClient } from "@tanstack/react-query";
+import { createRouter as createTanStackRouter } from "@tanstack/react-router";
+import { setupRouterSsrQueryIntegration } from "@tanstack/react-router-ssr-query";
+import { AuthBoundary } from "./auth";
+import { routeTree } from "./routeTree.gen";
+import type { useLogtoAuth } from "convex-logto/react";
+
+// `beforeLoad` guards read auth from router context, but Start builds the context
+// once. Hold the live auth in a mutable object the AuthBoundary keeps current,
+// then `router.invalidate()` re-runs the guards. `auth` stays undefined until the
+// client-side bridge effect runs — i.e. through SSR and the first client paint.
+type LogtoAuth = ReturnType<typeof useLogtoAuth>;
+export type AuthHolder = { auth: LogtoAuth | undefined };
+
+export interface RouterContext {
+  queryClient: QueryClient;
+  authHolder: AuthHolder;
+}
+
+// TanStack Start auto-discovers this file (`src/router.tsx`) and calls the
+// exported `getRouter()` for both the SSR and client builds.
+export function getRouter() {
+  const CONVEX_URL = import.meta.env.VITE_CONVEX_URL;
+  if (!CONVEX_URL) {
+    console.error("missing VITE_CONVEX_URL envar");
+  }
+
+  const convexQueryClient = new ConvexQueryClient(CONVEX_URL);
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        queryKeyHashFn: convexQueryClient.hashFn(),
+        queryFn: convexQueryClient.queryFn(),
+      },
+    },
+  });
+  convexQueryClient.connect(queryClient);
+
+  const authHolder: AuthHolder = { auth: undefined };
+  const convex = convexQueryClient.convexClient;
+
+  const router = createTanStackRouter({
+    routeTree,
+    defaultPreload: "intent",
+    // Show pendingComponent immediately while auth settles (matches the SPA).
+    defaultPendingMs: 0,
+    scrollRestoration: true,
+    context: { queryClient, authHolder },
+    // `InnerWrap` runs on server and client, *inside* the RouterProvider, so
+    // AuthBoundary can use `useRouter()` for soft-navigation + invalidate.
+    InnerWrap: ({ children }) => (
+      <AuthBoundary client={convex} holder={authHolder}>
+        {children}
+      </AuthBoundary>
+    ),
+  });
+
+  setupRouterSsrQueryIntegration({ router, queryClient });
+
+  return router;
+}
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: ReturnType<typeof getRouter>;
+  }
+}

--- a/examples/tanstack-start/src/routes/__root.tsx
+++ b/examples/tanstack-start/src/routes/__root.tsx
@@ -1,0 +1,55 @@
+// The SSR document shell + the nav layout. This renders on the server
+// (unauthenticated) and hydrates on the client where auth settles.
+import {
+  createRootRouteWithContext,
+  HeadContent,
+  Link,
+  Outlet,
+  Scripts,
+} from "@tanstack/react-router";
+import type { RouterContext } from "../router";
+import { AuthButton } from "../AuthButton";
+
+export const Route = createRootRouteWithContext<RouterContext>()({
+  head: () => ({
+    meta: [
+      { charSet: "utf-8" },
+      { name: "viewport", content: "width=device-width, initial-scale=1" },
+      { title: "convex-logto + TanStack Start" },
+    ],
+  }),
+  component: RootComponent,
+});
+
+function RootComponent() {
+  return (
+    <RootDocument>
+      <div style={{ fontFamily: "system-ui", padding: 24, maxWidth: 720 }}>
+        <nav style={{ display: "flex", gap: 12, alignItems: "center" }}>
+          <Link to="/">Home</Link>
+          <Link to="/dashboard">Dashboard (protected)</Link>
+          <span style={{ marginLeft: "auto" }}>
+            <AuthButton />
+          </span>
+        </nav>
+        <main style={{ paddingTop: 16 }}>
+          <Outlet />
+        </main>
+      </div>
+    </RootDocument>
+  );
+}
+
+function RootDocument({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <head>
+        <HeadContent />
+      </head>
+      <body>
+        {children}
+        <Scripts />
+      </body>
+    </html>
+  );
+}

--- a/examples/tanstack-start/src/routes/_authed.tsx
+++ b/examples/tanstack-start/src/routes/_authed.tsx
@@ -1,0 +1,30 @@
+// Protected pathless layout. Two layers, because auth is a *client* fact (the token
+// lives in the browser, so the server can't know it):
+//   - `beforeLoad` redirects an unauthenticated user to /signin. It reads auth from
+//     the router context's mutable `authHolder`, which the AuthBoundary keeps pointed
+//     at the live useLogtoAuth() result and re-runs (via router.invalidate()) when
+//     auth settles — the Start analog of the SPA's <RouterProvider context={{ auth }}>.
+//   - `AuthedLayout` renders protected children only once the client confirms an
+//     authenticated session, so an unauthenticated SSR request never server-renders
+//     the protected component before the client redirect runs.
+import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
+import { useLogtoAuth } from "convex-logto/react";
+
+function AuthedLayout() {
+  const { isAuthenticated } = useLogtoAuth();
+  // Not authenticated yet (SSR, first paint, or signed out): show the pending UI.
+  // beforeLoad redirects the genuinely-unauthenticated once auth settles.
+  return isAuthenticated ? <Outlet /> : <p>Checking access…</p>;
+}
+
+export const Route = createFileRoute("/_authed")({
+  beforeLoad: ({ context }) => {
+    const auth = context.authHolder.auth;
+    // undefined during SSR / before convex-logto mounts, or still settling —
+    // don't redirect yet; the invalidate() after auth settles re-runs this.
+    if (!auth || auth.isLoading) return;
+    if (!auth.isAuthenticated) throw redirect({ to: "/signin" });
+  },
+  pendingComponent: () => <p>Checking access…</p>,
+  component: AuthedLayout,
+});

--- a/examples/tanstack-start/src/routes/_authed/dashboard.tsx
+++ b/examples/tanstack-start/src/routes/_authed/dashboard.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { Dashboard } from "../../Dashboard";
+
+export const Route = createFileRoute("/_authed/dashboard")({
+  component: Dashboard,
+});

--- a/examples/tanstack-start/src/routes/callback.tsx
+++ b/examples/tanstack-start/src/routes/callback.tsx
@@ -1,0 +1,6 @@
+// The provider completes the OIDC code exchange; this route just renders.
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/callback")({
+  component: () => <p>Finishing sign in…</p>,
+});

--- a/examples/tanstack-start/src/routes/index.tsx
+++ b/examples/tanstack-start/src/routes/index.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { DeclarativeGate } from "../DeclarativeGate";
+
+export const Route = createFileRoute("/")({
+  component: Home,
+});
+
+function Home() {
+  return (
+    <section>
+      <h1>convex-logto + TanStack Start</h1>
+      <DeclarativeGate />
+    </section>
+  );
+}

--- a/examples/tanstack-start/src/routes/signin.tsx
+++ b/examples/tanstack-start/src/routes/signin.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { SignInPage } from "../SignInPage";
+
+export const Route = createFileRoute("/signin")({
+  component: SignInPage,
+});

--- a/examples/tanstack-start/src/vite-env.d.ts
+++ b/examples/tanstack-start/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_CONVEX_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/examples/tanstack-start/tsconfig.json
+++ b/examples/tanstack-start/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/examples/tanstack-start/vite.config.ts
+++ b/examples/tanstack-start/vite.config.ts
@@ -1,0 +1,10 @@
+import { tanstackStart } from "@tanstack/react-start/plugin/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  // TanStack Start's dev server defaults to port 3000 — match the Logto redirect
+  // URIs (`http://localhost:3000/callback` and post-sign-out `http://localhost:3000`).
+  server: { port: 3000 },
+  plugins: [tanstackStart(), react()],
+});

--- a/examples/vite-react/.env.example
+++ b/examples/vite-react/.env.example
@@ -1,0 +1,2 @@
+# Your Convex deployment URL, printed by `npx convex dev`.
+VITE_CONVEX_URL=

--- a/examples/vite-react/.gitignore
+++ b/examples/vite-react/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.convex
+convex/_generated
+.env.local

--- a/examples/vite-react/README.md
+++ b/examples/vite-react/README.md
@@ -1,0 +1,25 @@
+# convex-logto + Vite + React
+
+The smallest working setup: one provider, and Convex's `<Authenticated>` / `<Unauthenticated>` / `<AuthLoading>` to render on auth state.
+
+## Run
+
+1. Install from the repo root: `pnpm install`
+2. In this directory, start Convex (creates a dev deployment and generates types):
+   ```bash
+   npx convex dev
+   ```
+3. In Logto, create a **Single page app** (not a third-party app) and add:
+   - **Redirect URI** → `http://localhost:5173/callback`
+   - **Post sign-out redirect URI** → `http://localhost:5173`
+
+   Also rotate the tenant's OIDC signing key to **RSA** (Tenant settings → OIDC configs → rotate private key → RSA). Convex rejects Logto's default ES384, so this is required; otherwise `getUserIdentity()` returns `null`. Note its **endpoint** and **App ID** for the next step.
+4. Point that deployment at your Logto app — the one place config lives:
+   ```bash
+   npx convex env set LOGTO_ENDPOINT https://your-logto.example.com
+   npx convex env set LOGTO_APP_ID   your-spa-app-id
+   ```
+5. Copy `.env.example` to `.env.local` and set `VITE_CONVEX_URL` (printed by `npx convex dev`).
+6. `pnpm dev`, then open http://localhost:5173.
+
+> In this monorepo the dependency is `convex-logto: workspace:*`. Standalone, run `npm i convex-logto @logto/react`.

--- a/examples/vite-react/convex/auth.config.ts
+++ b/examples/vite-react/convex/auth.config.ts
@@ -1,0 +1,3 @@
+import { logtoAuthConfig } from "convex-logto";
+
+export default { providers: [logtoAuthConfig()] };

--- a/examples/vite-react/convex/logto.ts
+++ b/examples/vite-react/convex/logto.ts
@@ -1,0 +1,4 @@
+// Serves the public { endpoint, appId } to the frontend (the `configQuery` prop).
+import { logtoConfigQuery } from "convex-logto";
+
+export const config = logtoConfigQuery();

--- a/examples/vite-react/convex/me.ts
+++ b/examples/vite-react/convex/me.ts
@@ -1,0 +1,10 @@
+import { query } from "./_generated/server";
+
+export const me = query({
+  handler: async (ctx) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return null;
+    // identity.subject = Logto user id, plus email/name/etc. from the ID token.
+    return { id: identity.subject, email: identity.email, name: identity.name };
+  },
+});

--- a/examples/vite-react/convex/tsconfig.json
+++ b/examples/vite-react/convex/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ESNext",
+    "lib": ["ES2023", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/examples/vite-react/index.html
+++ b/examples/vite-react/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>convex-logto + Vite</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/vite-react/package.json
+++ b/examples/vite-react/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "convex-logto-example-vite-react",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc --noEmit && vite build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@logto/react": "^4.0.14",
+    "convex": "^1.41.0",
+    "convex-logto": "workspace:*",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.2",
+    "typescript": "~5.8.3",
+    "vite": "^8.0.16"
+  }
+}

--- a/examples/vite-react/src/App.tsx
+++ b/examples/vite-react/src/App.tsx
@@ -1,0 +1,52 @@
+import {
+  Authenticated,
+  AuthLoading,
+  Unauthenticated,
+  useQuery,
+} from "convex/react";
+import { useLogtoAuth } from "convex-logto/react";
+import { api } from "../convex/_generated/api";
+import { Callback } from "./Callback";
+
+function Me() {
+  const me = useQuery(api.me.me);
+  return <pre>{me ? JSON.stringify(me, null, 2) : "loading identity…"}</pre>;
+}
+
+function SignedIn() {
+  const { user, signOut } = useLogtoAuth();
+  return (
+    <>
+      <button onClick={() => void signOut()}>
+        Sign out ({user?.email ?? user?.sub ?? "user"})
+      </button>
+      <Me />
+    </>
+  );
+}
+
+function SignIn() {
+  const { signIn } = useLogtoAuth();
+  return <button onClick={() => void signIn()}>Sign in</button>;
+}
+
+export function App() {
+  // On /callback the provider auto-finishes the OIDC exchange; just render.
+  if (window.location.pathname === "/callback") return <Callback />;
+
+  // Gate on Convex's own auth state so queries never run before auth settles.
+  return (
+    <main style={{ fontFamily: "system-ui", padding: 24 }}>
+      <h1>convex-logto + Vite</h1>
+      <AuthLoading>
+        <p>Loading…</p>
+      </AuthLoading>
+      <Unauthenticated>
+        <SignIn />
+      </Unauthenticated>
+      <Authenticated>
+        <SignedIn />
+      </Authenticated>
+    </main>
+  );
+}

--- a/examples/vite-react/src/Callback.tsx
+++ b/examples/vite-react/src/Callback.tsx
@@ -1,0 +1,4 @@
+// The provider completes the OIDC code exchange; this route just renders.
+export function Callback() {
+  return <p>Finishing sign in…</p>;
+}

--- a/examples/vite-react/src/main.tsx
+++ b/examples/vite-react/src/main.tsx
@@ -1,0 +1,18 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { ConvexReactClient } from "convex/react";
+import { ConvexLogtoProvider } from "convex-logto/react";
+import { api } from "../convex/_generated/api";
+import { App } from "./App";
+
+const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL as string);
+
+// The frontend carries no Logto config — `configQuery` pulls { endpoint, appId }
+// from the Convex deployment, so it's set in exactly one place per environment.
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <ConvexLogtoProvider client={convex} configQuery={api.logto.config}>
+      <App />
+    </ConvexLogtoProvider>
+  </StrictMode>,
+);

--- a/examples/vite-react/src/vite-env.d.ts
+++ b/examples/vite-react/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/vite-react/tsconfig.json
+++ b/examples/vite-react/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/examples/vite-react/vite.config.ts
+++ b/examples/vite-react/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 5173, strictPort: true },
+});

--- a/packages/convex-logto/README.md
+++ b/packages/convex-logto/README.md
@@ -10,7 +10,7 @@ Use [Logto](https://logto.io) (self-hosted or cloud) as the auth provider for a 
 - **One line on the backend.** `logtoAuthConfig()` reads your env. No JWT template, no algorithm, no JWKS URL to copy.
 - **One source of truth across environments.** The frontend can pull its Logto config from the backend, so you configure Logto in exactly one place per environment — the Convex deployment.
 
-It uses Logto's **ID token** over OIDC, so Convex auto-discovers the signing key and algorithm (Logto signs with ES384). There is nothing about JWTs for you to configure.
+It uses Logto's **ID token** over OIDC, so Convex auto-discovers the signing key and JWKS — no JWT template, no algorithm, no JWKS URL to configure. (One Logto-side requirement: the OIDC signing key must be RSA/RS256 — see [step 1](#1-create-a-logto-app).)
 
 ## Install
 
@@ -24,7 +24,16 @@ pnpm add convex-logto @logto/react
 
 ### 1. Create a Logto app
 
-In Logto Console → **Applications** → create a **Single Page App**. Note the **endpoint** (e.g. `https://auth.example.com`) and the **App ID**. Under **Redirect URIs** add `http://localhost:5173/callback` (and your prod URL); under **Post sign-out redirect URIs** add your origin.
+In Logto Console → **Applications** → **Create application** → under **Single page app** pick your framework (e.g. **React**) — **not** a **Third-party app**. A third-party app is for letting *other people's* apps sign in through your Logto; it withholds the `profile` / `email` scopes this package requests, so sign-in fails with `invalid_scope`. The app type can't be changed after creation.
+
+Note the **endpoint** (e.g. `https://auth.example.com`) and the **App ID**, and add two URLs on the app (for each environment):
+
+- **Redirect URIs** → `http://localhost:5173/callback` (and your prod callback)
+- **Post sign-out redirect URIs** → `http://localhost:5173` (your app's origin, and your prod origin)
+
+`signIn()` returns to the redirect URI and `signOut()` to the post-sign-out URI, so remember to add both.
+
+**Required — use an RSA signing key.** Convex only accepts ID tokens signed with **RS256** (or EdDSA); Logto signs with **ES384** by default, which Convex silently rejects (sign-in looks fine, but `ctx.auth.getUserIdentity()` returns `null`). Rotate it once per tenant: Logto Console → **Tenant settings → OIDC configs** → **OIDC private keys** → **Rotate private key** → choose **RSA**. Logto keeps the old key during a transition, so existing sessions stay signed in.
 
 ### 2. Set the config on your Convex deployment (only place needed)
 
@@ -87,9 +96,9 @@ function Header() {
   const { isAuthenticated, isLoading, user, signIn, signOut } = useLogtoAuth();
   if (isLoading) return null;
   return isAuthenticated ? (
-    <button onClick={() => signOut()}>Sign out ({user?.email})</button>
+    <button onClick={() => void signOut()}>Sign out ({user?.email ?? user?.sub})</button>
   ) : (
-    <button onClick={() => signIn()}>Sign in</button>
+    <button onClick={() => void signIn()}>Sign in</button>
   );
 }
 ```
@@ -117,112 +126,56 @@ Create one Logto app per environment (dev / staging / prod — best practice, so
 
 ```bash
 # dev deployment
-npx convex env set LOGTO_APP_ID <dev-app-id>
+npx convex env set LOGTO_ENDPOINT https://your-logto.example.com
+npx convex env set LOGTO_APP_ID   <dev-app-id>
 # production deployment
-npx convex env set --prod LOGTO_APP_ID <prod-app-id>
+npx convex env set --prod LOGTO_ENDPOINT https://your-logto.example.com
+npx convex env set --prod LOGTO_APP_ID   <prod-app-id>
 # staging: target that deployment the same way
 ```
 
-Same code everywhere. Switching environments = pointing `VITE_CONVEX_URL` at a different deployment. Nothing to recompile, nothing to copy twice.
-
-### Prefer literal values instead?
-
-If you'd rather not add the config query, pass the values directly (e.g. from `import.meta.env`). Then the frontend needs its own `VITE_LOGTO_*` vars per environment:
-
-```tsx
-<ConvexLogtoProvider
-  client={convex}
-  endpoint={import.meta.env.VITE_LOGTO_ENDPOINT}
-  appId={import.meta.env.VITE_LOGTO_APP_ID}
->
-```
+Same code everywhere. The only thing that changes per environment is which Convex deployment `VITE_CONVEX_URL` points at — there's no Logto config to duplicate or keep in sync.
 
 ## Optional: sync Logto users into a table
 
-If you want a queryable `users` table (to list users, store roles, or join app data), add a webhook sync. It mirrors `@convex-dev/workos-authkit`'s ergonomics.
-
-### 1. Schema
+You don't need a table to authenticate — identity comes from the token, so attach
+your data to your own tables keyed by `identity.subject`. Add a `users` table only
+when you need to query users (an admin list, another user's name) or store fields
+the token doesn't carry (a per-app **role**). The table is **yours**; the package
+just provides the webhook glue.
 
 ```ts
-// convex/schema.ts
+// convex/schema.ts — fields grouped by who owns them
 users: defineTable({
-  authId: v.string(),            // Logto user id (== identity.subject)
-  email: v.string(),
-  name: v.string(),
-  role: v.string(),              // for RBAC, if you want it
-}).index("authId", ["authId"]),
+  authId: v.string(), // == identity.subject
+  email: v.optional(v.string()), // Logto-owned (synced)
+  name: v.optional(v.string()), // Logto-owned (synced)
+  role: v.union(v.literal("user"), v.literal("admin")), // app-owned (RBAC)
+  status: v.union(v.literal("active"), v.literal("suspended"), v.literal("deleted")),
+}).index("by_authId", ["authId"]),
 ```
 
-### 2. Map events to your table
+Three rules keep it correct:
 
-```ts
-// convex/logto.ts  (alongside `config` from above)
-import { logtoSync } from "convex-logto";
-import type { DataModel } from "./_generated/dataModel";
+- **The webhook writes only Logto-owned fields (`email`, `name`, `status`), never
+  `role`** — otherwise a Logto profile edit would reset everyone's role.
+- **The webhook never creates rows — it only syncs existing ones.** `User.Created`
+  doesn't fire for users who already existed in Logto, so create rows from an
+  authenticated mutation on first load (get-or-create) and let the webhook keep them
+  in sync. (Webhook-only creation is the bug that bites component-owned auth tables.)
+- **Soft-delete on `User.Deleted`** — scrub PII but keep a tombstone row, so authz
+  fails closed and nothing referencing the user by id dangles.
 
-const upsert = async (ctx, u) => {
-  const existing = await ctx.db
-    .query("users")
-    .withIndex("authId", (q) => q.eq("authId", u.id))
-    .unique();
-  const fields = { email: u.primaryEmail ?? "", name: u.name ?? "" };
-  if (existing) await ctx.db.patch(existing._id, fields);
-  else await ctx.db.insert("users", { authId: u.id, role: "user", ...fields });
-};
+Full walkthrough — `logtoSync` handlers, `registerLogtoWebhook`, signing-key setup,
+and `requireRole` authz — in the [Webhook sync guide][webhook-sync] and the runnable
+[`tanstack-router-spa`][spa-example] example.
 
-export const { sync } = logtoSync<DataModel>({
-  "User.Created": upsert,
-  "User.Data.Updated": upsert,
-  "User.Deleted": async (ctx, u) => {
-    const row = await ctx.db
-      .query("users")
-      .withIndex("authId", (q) => q.eq("authId", u.id))
-      .unique();
-    if (row) await ctx.db.delete(row._id);
-  },
-});
-```
-
-### 3. Register the route
-
-```ts
-// convex/http.ts
-import { httpRouter } from "convex/server";
-import { registerLogtoWebhook } from "convex-logto";
-import { internal } from "./_generated/api";
-
-const http = httpRouter();
-registerLogtoWebhook(http, internal.logto.sync); // serves POST /logto/webhook
-export default http;
-```
-
-### 4. Create the webhook in Logto
-
-Logto Console → **Webhooks** → new webhook pointed at `<your-convex-site-url>/logto/webhook` (your Convex **HTTP Actions** URL, e.g. `https://happy-otter-123.convex.site/logto/webhook`). Subscribe to `User.Created`, `User.Data.Updated`, `User.Deleted`, and copy the **Signing key** — the one Logto value that *is* a secret:
-
-```bash
-npx convex env set LOGTO_WEBHOOK_SIGNING_KEY <signing-key>
-```
-
-The signature is verified with Web Crypto (HMAC-SHA256) inside the Convex runtime; bad signatures get a 401.
-
-### RBAC
-
-Store a `role` on the synced user (above), then gate in Convex by loading the row via `identity.subject`:
-
-```ts
-const user = await ctx.db
-  .query("users")
-  .withIndex("authId", (q) => q.eq("authId", identity.subject))
-  .unique();
-if (user?.role !== "admin") throw new Error("forbidden");
-```
-
-Keep the ability map in your app — the package stays out of your authorization policy.
+[webhook-sync]: https://github.com/Fanzzzd/convex-logto/blob/main/docs/content/docs/webhook-sync.mdx
+[spa-example]: https://github.com/Fanzzzd/convex-logto/tree/main/examples/tanstack-router-spa
 
 ## Why the ID token (and why there's no JWT config)
 
-Convex validates an OIDC **ID token**. Logto's access tokens are typed `at+jwt`, which Convex does not accept ([convex#75](https://github.com/get-convex/convex-backend/issues/75)), so this package returns the ID token. Because it goes through Convex's **OIDC** provider (not Custom JWT), Convex reads the issuer's discovery document and JWKS itself — including the signing algorithm (Logto uses **ES384**). That is why you never set an algorithm or a JWKS URL. Sessions refresh via Logto's refresh token, which is why `ConvexLogtoProvider` requests the `offline_access` scope by default.
+Convex validates an OIDC **ID token**. Logto's access tokens are typed `at+jwt`, which Convex does not accept ([convex#75](https://github.com/get-convex/convex-backend/issues/75)), so this package returns the ID token. Because it goes through Convex's **OIDC** provider (not Custom JWT), Convex reads the issuer's discovery document and JWKS itself, so you never set an algorithm or a JWKS URL — with one catch: Convex's OIDC verifier accepts only **RS256**/**EdDSA**, while Logto signs with **ES384** by default, so you rotate the Logto OIDC signing key to **RSA** once (step 1). A mismatch is rejected silently (`getUserIdentity()` returns `null`). Sessions refresh via Logto's refresh token, which is why `ConvexLogtoProvider` requests the `offline_access` scope by default.
 
 ## API
 
@@ -233,12 +186,12 @@ Convex validates an OIDC **ID token**. Logto's access tokens are typed `at+jwt`,
 | `logtoSync<DataModel>(handlers)` | `convex-logto` | Returns `{ sync }`, an internal mutation mapping user events to your tables. |
 | `registerLogtoWebhook(http, sync, opts?)` | `convex-logto` | Registers the verified webhook route. Reads `LOGTO_WEBHOOK_SIGNING_KEY`. |
 | `verifyLogtoSignature(key, body, sig)` | `convex-logto` | Low-level signature check, for custom routing. |
-| `ConvexLogtoProvider` | `convex-logto/react` | Logto + Convex + auto callback in one provider. Takes `configQuery` or `endpoint`+`appId`. |
+| `ConvexLogtoProvider` | `convex-logto/react` | Logto + Convex + auto sign-in callback in one provider. Pulls Logto config from the backend via `configQuery`. |
 | `useLogtoAuth()` | `convex-logto/react` | `{ isAuthenticated, isLoading, user, signIn, signOut }`. |
 
 ### Next.js note
 
-`ConvexLogtoProvider` and `useLogtoAuth` are client-only (they use React hooks and `window`). In the Next.js App Router, render them inside a `"use client"` component.
+`ConvexLogtoProvider` and `useLogtoAuth` use React hooks (and `window` for sign-in / sign-out), so in the Next.js App Router render them from a `"use client"` component — the provider is SSR-safe within that boundary.
 
 ## License
 

--- a/packages/convex-logto/package.json
+++ b/packages/convex-logto/package.json
@@ -80,11 +80,13 @@
     "@arethetypeswrong/cli": "^0.18.3",
     "@logto/react": "^4.0.14",
     "@types/react": "^19.1.10",
+    "@types/react-dom": "^19.2.3",
     "convex": "^1.38.0",
     "oxfmt": "^0.54.0",
     "oxlint": "^1.69.0",
     "publint": "^0.3.21",
     "react": "^19.1.0",
+    "react-dom": "^19.2.7",
     "tsup": "^8.5.1",
     "typescript": "^5.8.3",
     "vitest": "^3.2.4"

--- a/packages/convex-logto/src/callback.test.ts
+++ b/packages/convex-logto/src/callback.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { classifySignInSearch } from "./callback";
+
+describe("classifySignInSearch", () => {
+  it("ignores URLs without a `state` param (not a sign-in redirect)", () => {
+    expect(classifySignInSearch("")).toEqual({ kind: "none" });
+    expect(classifySignInSearch("?foo=bar")).toEqual({ kind: "none" });
+    // A stray ?error= on an ordinary app route must NOT be read as a sign-in failure.
+    expect(classifySignInSearch("?error=invalid_scope")).toEqual({
+      kind: "none",
+    });
+    expect(classifySignInSearch("?code=abc")).toEqual({ kind: "none" });
+  });
+
+  it("is 'pending' only for a real code redirect (both code and state)", () => {
+    expect(classifySignInSearch("?code=abc&state=xyz")).toEqual({
+      kind: "pending",
+    });
+    // state without a code is not a callback we should try to exchange.
+    expect(classifySignInSearch("?state=xyz")).toEqual({ kind: "none" });
+  });
+
+  it("treats 'no session' errors (e.g. the user cancelled) as benign", () => {
+    for (const error of [
+      "access_denied",
+      "login_required",
+      "interaction_required",
+      "consent_required",
+    ]) {
+      expect(classifySignInSearch(`?error=${error}&state=xyz`)).toEqual({
+        kind: "benign",
+      });
+    }
+  });
+
+  it("surfaces a setup error with its description and a hint", () => {
+    const outcome = classifySignInSearch(
+      "?error=invalid_scope&error_description=bad%20scope&state=xyz",
+    );
+    expect(outcome.kind).toBe("error");
+    if (outcome.kind === "error") {
+      expect(outcome.message).toContain("invalid_scope");
+      expect(outcome.message).toContain("bad scope");
+      expect(outcome.message).toContain("scope"); // the hint mentions scopes
+    }
+  });
+
+  it("surfaces an unknown error without inventing a hint", () => {
+    const outcome = classifySignInSearch("?error=server_error&state=xyz");
+    expect(outcome.kind).toBe("error");
+    if (outcome.kind === "error") {
+      expect(outcome.message).toContain("server_error");
+      expect(outcome.message).not.toContain("Single-page app");
+    }
+  });
+});

--- a/packages/convex-logto/src/callback.ts
+++ b/packages/convex-logto/src/callback.ts
@@ -1,0 +1,44 @@
+// Classifies the URL after a Logto sign-in redirect. Only a real OIDC redirect
+// carries a `state` param, so a stray `?error=`/`?code=` on an ordinary app route
+// is ignored rather than mistaken for a sign-in result.
+
+const OAUTH_ERROR_HINTS: Record<string, string> = {
+  invalid_scope:
+    "This usually means a requested scope isn't allowed — check any extra `scopes` " +
+    "you passed, and that LOGTO_APP_ID points at a Single-page app (not a Third-party app).",
+};
+
+// OAuth errors that just mean "no session" (e.g. the user cancelled): return to the app.
+const BENIGN_OAUTH_ERRORS = new Set([
+  "access_denied",
+  "login_required",
+  "interaction_required",
+  "consent_required",
+]);
+
+export type SignInOutcome =
+  | { kind: "none" } // not a sign-in redirect
+  | { kind: "pending" } // a redirect with no error — the SDK is exchanging the code
+  | { kind: "benign" } // the user cancelled / no session — return to the app
+  | { kind: "error"; message: string }; // a setup error worth surfacing
+
+export function classifySignInSearch(search: string): SignInOutcome {
+  const params = new URLSearchParams(search);
+  // Every OIDC redirect carries `state`; without it, this isn't a sign-in result.
+  if (!params.has("state")) return { kind: "none" };
+  const error = params.get("error");
+  if (error) {
+    if (BENIGN_OAUTH_ERRORS.has(error)) return { kind: "benign" };
+    const description = params.get("error_description");
+    const hint = OAUTH_ERROR_HINTS[error];
+    return {
+      kind: "error",
+      message:
+        `Logto sign-in failed with "${error}"` +
+        (description ? ` (${description})` : "") +
+        (hint ? `. ${hint}` : "."),
+    };
+  }
+  // A successful redirect carries both `code` and `state`.
+  return params.has("code") ? { kind: "pending" } : { kind: "none" };
+}

--- a/packages/convex-logto/src/config.test.ts
+++ b/packages/convex-logto/src/config.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { logtoAuthConfig, logtoConfigQuery } from "./config";
+
+function restoreEnv(key: string, value: string | undefined) {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}
+
+describe("logtoAuthConfig", () => {
+  const saved = {
+    endpoint: process.env.LOGTO_ENDPOINT,
+    appId: process.env.LOGTO_APP_ID,
+  };
+  beforeEach(() => {
+    delete process.env.LOGTO_ENDPOINT;
+    delete process.env.LOGTO_APP_ID;
+  });
+  afterEach(() => {
+    restoreEnv("LOGTO_ENDPOINT", saved.endpoint);
+    restoreEnv("LOGTO_APP_ID", saved.appId);
+  });
+
+  it("builds { domain: `${endpoint}/oidc`, applicationID } from explicit options", () => {
+    expect(
+      logtoAuthConfig({
+        endpoint: "https://auth.example.com",
+        appId: "app123",
+      }),
+    ).toEqual({
+      domain: "https://auth.example.com/oidc",
+      applicationID: "app123",
+    });
+  });
+
+  it("reads LOGTO_ENDPOINT / LOGTO_APP_ID from the environment", () => {
+    process.env.LOGTO_ENDPOINT = "https://env.example.com";
+    process.env.LOGTO_APP_ID = "env-app";
+    expect(logtoAuthConfig()).toEqual({
+      domain: "https://env.example.com/oidc",
+      applicationID: "env-app",
+    });
+  });
+
+  it("lets explicit options override the environment", () => {
+    process.env.LOGTO_ENDPOINT = "https://env.example.com";
+    process.env.LOGTO_APP_ID = "env-app";
+    expect(
+      logtoAuthConfig({
+        endpoint: "https://opt.example.com",
+        appId: "opt-app",
+      }),
+    ).toEqual({
+      domain: "https://opt.example.com/oidc",
+      applicationID: "opt-app",
+    });
+  });
+
+  it("strips one or more trailing slashes from the endpoint", () => {
+    expect(
+      logtoAuthConfig({ endpoint: "https://x.com/", appId: "a" }).domain,
+    ).toBe("https://x.com/oidc");
+    expect(
+      logtoAuthConfig({ endpoint: "https://x.com///", appId: "a" }).domain,
+    ).toBe("https://x.com/oidc");
+  });
+
+  it("trims surrounding whitespace from endpoint and appId", () => {
+    expect(
+      logtoAuthConfig({ endpoint: "  https://x.com  ", appId: "  a  " }),
+    ).toEqual({ domain: "https://x.com/oidc", applicationID: "a" });
+  });
+
+  it("throws naming LOGTO_ENDPOINT when the endpoint is missing", () => {
+    expect(() => logtoAuthConfig({ appId: "a" })).toThrow(/LOGTO_ENDPOINT/);
+  });
+
+  it("throws naming LOGTO_APP_ID when the appId is missing", () => {
+    expect(() => logtoAuthConfig({ endpoint: "https://x.com" })).toThrow(
+      /LOGTO_APP_ID/,
+    );
+  });
+
+  it("names both when endpoint and appId are missing", () => {
+    expect(() => logtoAuthConfig()).toThrow(/LOGTO_ENDPOINT and LOGTO_APP_ID/);
+  });
+
+  it("treats a whitespace-only endpoint as missing", () => {
+    expect(() => logtoAuthConfig({ endpoint: "   ", appId: "a" })).toThrow(
+      /LOGTO_ENDPOINT/,
+    );
+  });
+
+  it("rejects an endpoint that already ends in /oidc (common paste error)", () => {
+    expect(() =>
+      logtoAuthConfig({ endpoint: "https://x.com/oidc", appId: "a" }),
+    ).toThrow(/\/oidc/);
+  });
+
+  it("rejects /oidc even with a trailing slash (slash is stripped first)", () => {
+    expect(() =>
+      logtoAuthConfig({ endpoint: "https://x.com/oidc/", appId: "a" }),
+    ).toThrow(/\/oidc/);
+  });
+});
+
+describe("logtoConfigQuery", () => {
+  it("constructs without reading the environment (lazy until the handler runs)", () => {
+    const saved = process.env.LOGTO_ENDPOINT;
+    delete process.env.LOGTO_ENDPOINT;
+    // Defining the query must not throw even with the env unset.
+    expect(() => logtoConfigQuery()).not.toThrow();
+    expect(logtoConfigQuery()).toBeDefined();
+    restoreEnv("LOGTO_ENDPOINT", saved);
+  });
+});

--- a/packages/convex-logto/src/config.ts
+++ b/packages/convex-logto/src/config.ts
@@ -34,6 +34,16 @@ function readEndpointAndAppId(options: LogtoAuthConfigOptions = {}): {
         `or pass it to this function.`,
     );
   }
+  // The package appends `/oidc` itself, so the endpoint must be the base URL.
+  // Setting it to the issuer URL is a common paste error that would otherwise
+  // produce `.../oidc/oidc` and a confusing JWKS-discovery failure.
+  if (endpoint.endsWith("/oidc")) {
+    throw new Error(
+      `convex-logto: LOGTO_ENDPOINT should be your Logto base URL ` +
+        `(e.g. https://auth.example.com), not the /oidc issuer URL — ` +
+        `drop the trailing "/oidc".`,
+    );
+  }
   return { endpoint, appId };
 }
 

--- a/packages/convex-logto/src/react.test.tsx
+++ b/packages/convex-logto/src/react.test.tsx
@@ -1,0 +1,34 @@
+import { renderToString } from "react-dom/server";
+import {
+  Authenticated,
+  AuthLoading,
+  ConvexReactClient,
+  Unauthenticated,
+} from "convex/react";
+import { describe, expect, it } from "vitest";
+import { ConvexLogtoProvider } from "./react";
+import type { LogtoConfigQueryRef } from "./config";
+
+// The headline 0.2.0 guarantee: the provider is safe to render on the server.
+// renderToString runs with no `window` and never runs effects, so config stays
+// unresolved — children must mount under <AuthLoading> and nothing may throw.
+describe("ConvexLogtoProvider SSR", () => {
+  it("renders the loading branch on the server (no window) without throwing", () => {
+    expect(typeof window).toBe("undefined");
+
+    const client = new ConvexReactClient("https://example.convex.cloud");
+    const configQuery = {} as unknown as LogtoConfigQueryRef;
+
+    const html = renderToString(
+      <ConvexLogtoProvider client={client} configQuery={configQuery}>
+        <AuthLoading>LOADING_SHELL</AuthLoading>
+        <Authenticated>AUTHED</Authenticated>
+        <Unauthenticated>ANON</Unauthenticated>
+      </ConvexLogtoProvider>,
+    );
+
+    expect(html).toContain("LOADING_SHELL");
+    expect(html).not.toContain("AUTHED");
+    expect(html).not.toContain("ANON");
+  });
+});

--- a/packages/convex-logto/src/react.tsx
+++ b/packages/convex-logto/src/react.tsx
@@ -2,31 +2,29 @@ import {
   type IdTokenClaims,
   type LogtoConfig,
   LogtoProvider,
-  ReservedScope,
+  type LogtoProviderProps,
   UserScope,
   useHandleSignInCallback,
   useLogto,
 } from "@logto/react";
-import { ConvexProviderWithAuth, type ConvexReactClient } from "convex/react";
 import {
-  createContext,
+  ConvexProviderWithAuth,
+  type ConvexReactClient,
+  useConvexAuth,
+} from "convex/react";
+import {
   type ReactNode,
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useState,
 } from "react";
+import { type SignInOutcome, classifySignInSearch } from "./callback";
 import type { LogtoConfigQueryRef, LogtoPublicConfig } from "./config";
 
-const CallbackPathContext = createContext("/callback");
+const CALLBACK_PATH = "/callback";
 
-/**
- * Bridges Logto's `useLogto()` into the `useAuth` shape `ConvexProviderWithAuth`
- * expects, returning the Logto **ID token** (not the `at+jwt` access token).
- * `@logto/react` wraps these methods so they resolve `undefined` on failure
- * rather than throwing, so no try/catch is needed here.
- */
+/** Bridges Logto's ID token into the `useAuth` shape `ConvexProviderWithAuth` expects. */
 function useAuthFromLogto() {
   const {
     isAuthenticated,
@@ -36,34 +34,65 @@ function useAuthFromLogto() {
     clearAccessToken,
   } = useLogto();
 
+  // `@logto/react` toggles `isLoading` around every SDK call; forwarding that to
+  // Convex creates a token-fetch ↔ loading feedback loop that flickers the
+  // identity. Latch on the first settle and ignore the churn after.
+  const [settled, setSettled] = useState(false);
+  useEffect(() => {
+    if (!isLoading) setSettled(true);
+  }, [isLoading]);
+
   const fetchAccessToken = useCallback(
     async ({ forceRefreshToken }: { forceRefreshToken: boolean }) => {
-      if (forceRefreshToken) {
-        // Force a refresh-token exchange: dropping the cached access token makes
-        // getAccessToken() hit the token endpoint, which also rotates the cached
-        // ID token. If the refresh fails, getAccessToken() resolves undefined, so
-        // bail out rather than return the now-stale ID token; Convex then drives
-        // re-authentication.
-        await clearAccessToken();
-        const refreshed = await getAccessToken();
-        if (!refreshed) return null;
+      try {
+        if (forceRefreshToken) {
+          // Clearing the access token forces a token-endpoint round-trip that also
+          // rotates the ID token; bail if it fails rather than return a stale token.
+          await clearAccessToken();
+          if (!(await getAccessToken())) return null;
+        }
+        return (await getIdToken()) ?? null;
+      } catch {
+        // The refresh token expired or Logto is unreachable: report "no token" so
+        // Convex transitions cleanly to unauthenticated instead of surfacing a
+        // rejection (which is how a returning user's stale session should resolve).
+        return null;
       }
-      return (await getIdToken()) ?? null;
     },
     [getIdToken, getAccessToken, clearAccessToken],
   );
 
   return useMemo(
-    () => ({ isLoading, isAuthenticated, fetchAccessToken }),
-    [isLoading, isAuthenticated, fetchAccessToken],
+    () => ({ isLoading: !settled, isAuthenticated, fetchAccessToken }),
+    [settled, isAuthenticated, fetchAccessToken],
   );
 }
 
-/**
- * Drives Logto's `useHandleSignInCallback`, which only acts when the current URL
- * matches a stored sign-in session (so it's a no-op off the redirect), then
- * navigates to `afterSignIn` once the OIDC exchange completes.
- */
+// An inert Logto client mounted only while the backend config loads. Its
+// `isAuthenticated()` never resolves, so @logto/react's loadingCount stays > 0 —
+// `isLoading` holds true and there's no signed-out flash — until the real client
+// swaps in once config arrives. A Proxy covers every method @logto/react binds,
+// and it touches no `window`, so the whole provider tree is safe to render on the
+// server (SSR) and during the first client paint.
+type LogtoClientClass = NonNullable<LogtoProviderProps["LogtoClientClass"]>;
+const pendingForever = new Promise<never>(() => {});
+const LoadingLogtoClient = function () {
+  return new Proxy(
+    {},
+    {
+      get: (_t, key) =>
+        key === "isAuthenticated"
+          ? () => pendingForever
+          : async () => undefined,
+    },
+  );
+} as unknown as LogtoClientClass;
+const LOADING_LOGTO_CONFIG: LogtoConfig = {
+  endpoint: "https://convex-logto-loading.invalid",
+  appId: "__convex_logto_loading__",
+};
+
+/** Finishes the OIDC redirect then navigates to `afterSignIn`; surfaces setup errors loudly. */
 function LogtoCallback({
   afterSignIn,
   navigate,
@@ -71,74 +100,69 @@ function LogtoCallback({
   afterSignIn: string;
   navigate?: (to: string) => void;
 }) {
-  useHandleSignInCallback(() => {
+  const goAfterSignIn = useCallback(() => {
     if (navigate) navigate(afterSignIn);
     else window.location.replace(afterSignIn);
-  });
+  }, [navigate, afterSignIn]);
+
+  // Classified once from the landing URL; only a real OIDC redirect carries `state`.
+  // A real callback always arrives via a full-page redirect, so mount == landing.
+  const outcome = useMemo<SignInOutcome>(
+    () =>
+      typeof window === "undefined"
+        ? { kind: "none" }
+        : classifySignInSearch(window.location.search),
+    [],
+  );
+  // This component renders on every route, so once the exchange succeeds we latch
+  // it finished and unmount <CodeExchange> — otherwise it lingers off `/callback`,
+  // keeping the SDK's callback hook alive over an already-consumed code.
+  const [exchanged, setExchanged] = useState(false);
+
+  useEffect(() => {
+    // The user cancelled / there was no session — just return to the app.
+    if (outcome.kind === "benign") goAfterSignIn();
+  }, [outcome, goAfterSignIn]);
+
+  if (outcome.kind === "error")
+    throw new Error(`convex-logto: ${outcome.message}`);
+  // Only a real `?code=` callback runs the token exchange; benign/error redirects
+  // never touch the SDK, so a cancelled sign-in can't poison the next one.
+  if (outcome.kind === "pending" && !exchanged)
+    return (
+      <CodeExchange
+        onExchanged={() => setExchanged(true)}
+        goAfterSignIn={goAfterSignIn}
+      />
+    );
   return null;
 }
 
-type InnerProviderProps = {
-  client: ConvexReactClient;
-  endpoint: string;
-  appId: string;
-  scopes?: string[];
-  resources?: string[];
-  callbackPath: string;
-  afterSignIn: string;
-  navigate?: (to: string) => void;
-  children: ReactNode;
-};
-
-/** Mounts Logto + the Convex bridge once concrete config is available. */
-function InnerProvider({
-  client,
-  endpoint,
-  appId,
-  scopes,
-  resources,
-  callbackPath,
-  afterSignIn,
-  navigate,
-  children,
-}: InnerProviderProps) {
-  // Inline `scopes`/`resources` arrays get a fresh identity each render, which
-  // would rebuild `logtoConfig` (and the underlying LogtoClient) every time.
-  // Key on the content instead, and reconstruct the arrays inside the memo.
-  const scopesKey = scopes?.join(" ") ?? "";
-  const resourcesKey = resources?.join(" ") ?? "";
-  const logtoConfig = useMemo<LogtoConfig>(
-    () => ({
-      endpoint,
-      appId,
-      scopes: [
-        UserScope.Email,
-        UserScope.Profile,
-        ReservedScope.OfflineAccess,
-        ...(scopesKey ? scopesKey.split(" ") : []),
-      ],
-      ...(resourcesKey ? { resources: resourcesKey.split(" ") } : {}),
-    }),
-    [endpoint, appId, scopesKey, resourcesKey],
-  );
-
-  return (
-    <LogtoProvider config={logtoConfig}>
-      <CallbackPathContext.Provider value={callbackPath}>
-        {/*
-         * Mount the callback handler unconditionally: `useHandleSignInCallback`
-         * is a no-op unless Logto's stored sign-in session matches the current
-         * URL (it checks `isSignInRedirected`), so it correctly finishes `?code=`
-         * exchanges *and* `?error=`/custom-redirect landings, and does nothing
-         * on ordinary navigation.
-         */}
-        <LogtoCallback afterSignIn={afterSignIn} navigate={navigate} />
-        <ConvexProviderWithAuth client={client} useAuth={useAuthFromLogto}>
-          {children}
-        </ConvexProviderWithAuth>
-      </CallbackPathContext.Provider>
-    </LogtoProvider>
-  );
+/** Runs the code→token exchange for a real `/callback?code=…` landing. */
+function CodeExchange({
+  onExchanged,
+  goAfterSignIn,
+}: {
+  onExchanged: () => void;
+  goAfterSignIn: () => void;
+}) {
+  // Fires once when the code→token exchange succeeds: stop rendering this handler
+  // (so the spent code is never re-submitted), then continue into the app.
+  useHandleSignInCallback(() => {
+    onExchanged();
+    goAfterSignIn();
+  });
+  const { error } = useLogto();
+  // Surface a failed exchange instead of hanging the page on "finishing sign in".
+  if (error) {
+    throw new Error(
+      `convex-logto: completing Logto sign-in failed (${error.message}). ` +
+        `The callback URL was likely stale or the sign-in session was lost — ` +
+        `start sign-in again.`,
+      { cause: error },
+    );
+  }
+  return null;
 }
 
 type ConfigState =
@@ -146,21 +170,54 @@ type ConfigState =
   | { status: "ready"; config: LogtoPublicConfig }
   | { status: "error"; error: unknown };
 
-/** Fetches `{ endpoint, appId }` from the backend, then mounts InnerProvider. */
-function BackendConfiguredProvider({
+export type ConvexLogtoProviderProps = {
+  /** Your `ConvexReactClient`. */
+  client: ConvexReactClient;
+  /** Reference to the query exported from `logtoConfigQuery()`, e.g. `api.logto.config`. */
+  configQuery: LogtoConfigQueryRef;
+  /** Extra scopes. `openid`, `profile`, `offline_access`, and `email` are always included. */
+  scopes?: string[];
+  /** API resource indicators to request, if any. */
+  resources?: string[];
+  /** Where to go once sign-in completes. Default `/`. */
+  afterSignIn?: string;
+  /** Soft navigation (e.g. your router's navigate). Falls back to a hard redirect. */
+  navigate?: (to: string) => void;
+  children: ReactNode;
+};
+
+/**
+ * Wires Logto to Convex: pulls `{ endpoint, appId }` from the backend (`configQuery`),
+ * mounts Logto, bridges the ID token into Convex, and finishes the sign-in redirect.
+ * No hand-rolled `useAuth`, no JWT template, no JWKS URL.
+ *
+ * Safe to render on the server: children mount immediately (under Convex's
+ * `<AuthLoading>`) while config loads and nothing touches `window`, so SSR
+ * frameworks need no stub or mount-gate. The redirect lands on `/callback` — add a
+ * route there that just renders; pass `signIn(`${origin}/your-path`)` for another path.
+ *
+ * @example
+ * <ConvexLogtoProvider client={convex} configQuery={api.logto.config}>
+ *   <App />
+ * </ConvexLogtoProvider>
+ */
+export function ConvexLogtoProvider({
   client,
   configQuery,
-  fallback,
-  ...rest
-}: Omit<InnerProviderProps, "endpoint" | "appId"> & {
-  configQuery: LogtoConfigQueryRef;
-  fallback?: ReactNode;
-}) {
+  scopes,
+  resources,
+  afterSignIn = "/",
+  navigate,
+  children,
+}: ConvexLogtoProviderProps) {
+  // One-shot fetch (config is per-deployment, fixed at runtime). Until it lands we
+  // mount the same tree with an inert client, so there's no remount when it does.
   const [state, setState] = useState<ConfigState>({ status: "loading" });
 
   useEffect(() => {
     let active = true;
-    setState({ status: "loading" });
+    // Don't reset to "loading" on re-run: once resolved, demoting back would swap
+    // the live Logto client for the inert one mid-session and drop the identity.
     client
       .query(configQuery)
       .then((config) => {
@@ -174,118 +231,44 @@ function BackendConfiguredProvider({
     };
   }, [client, configQuery]);
 
+  // Key the memo on array contents, not identity, so a fresh `scopes`/`resources`
+  // array each render doesn't rebuild the LogtoClient.
+  const scopesKey = scopes?.join(" ") ?? "";
+  const resourcesKey = resources?.join(" ") ?? "";
+  const logtoConfig = useMemo<LogtoConfig>(() => {
+    if (state.status !== "ready") return LOADING_LOGTO_CONFIG;
+    return {
+      endpoint: state.config.endpoint,
+      appId: state.config.appId,
+      // Logto adds openid, offline_access, and profile by default; we add email.
+      scopes: [UserScope.Email, ...(scopesKey ? scopesKey.split(" ") : [])],
+      ...(resourcesKey ? { resources: resourcesKey.split(" ") } : {}),
+    };
+  }, [state, scopesKey, resourcesKey]);
+
   if (state.status === "error") {
-    // Surface loudly instead of hanging on a blank screen: an error boundary
-    // (or the dev overlay) shows exactly what went wrong.
+    // Throw so an error boundary / dev overlay shows it, instead of a blank screen.
     throw new Error(
-      "convex-logto: could not load Logto config from configQuery. Check that " +
-        "the query is deployed and LOGTO_ENDPOINT / LOGTO_APP_ID are set on the " +
-        "Convex deployment.",
+      "convex-logto: could not load Logto config from configQuery. Check the query " +
+        "is deployed and LOGTO_ENDPOINT / LOGTO_APP_ID are set on the Convex deployment.",
       { cause: state.error },
     );
   }
-  if (state.status === "loading") return <>{fallback ?? null}</>;
+
+  const ready = state.status === "ready";
   return (
-    <InnerProvider
-      client={client}
-      endpoint={state.config.endpoint}
-      appId={state.config.appId}
-      {...rest}
-    />
-  );
-}
-
-type CommonProps = {
-  /** Your `ConvexReactClient`. */
-  client: ConvexReactClient;
-  /** Extra scopes. `email`, `profile`, and `offline_access` are always included. */
-  scopes?: string[];
-  /** API resource indicators to request, if any. */
-  resources?: string[];
-  /**
-   * Path that receives the OIDC redirect. Default `/callback`. The provider
-   * auto-finishes the sign-in redirect (both `?code=` success and `?error=`
-   * cases) once Logto recognizes the landing URL as its callback.
-   */
-  callbackPath?: string;
-  /** Where to go once sign-in completes. Default `/`. */
-  afterSignIn?: string;
-  /** Soft navigation (e.g. your router's navigate). Falls back to a hard redirect. */
-  navigate?: (to: string) => void;
-  children: ReactNode;
-};
-
-/** Configure Logto directly with literal values (or `import.meta.env`). */
-export type ConvexLogtoLiteralProps = CommonProps & {
-  endpoint: string;
-  appId: string;
-  configQuery?: never;
-  fallback?: never;
-};
-
-/** Single source of truth: pull `{ endpoint, appId }` from your backend. */
-export type ConvexLogtoBackendProps = CommonProps & {
-  /** Reference to the query exported from `logtoConfigQuery()`, e.g. `api.logto.config`. */
-  configQuery: LogtoConfigQueryRef;
-  /** Rendered while the config is being fetched. Default: nothing. */
-  fallback?: ReactNode;
-  endpoint?: never;
-  appId?: never;
-};
-
-export type ConvexLogtoProviderProps =
-  | ConvexLogtoLiteralProps
-  | ConvexLogtoBackendProps;
-
-/**
- * One provider that wires Logto to Convex: it renders `<LogtoProvider>`, bridges
- * the Logto ID token into `<ConvexProviderWithAuth>`, and finishes the sign-in
- * redirect automatically. No hand-rolled `useAuth`, no JWT template, no JWKS URL.
- *
- * Provide either literal `endpoint`/`appId`, or a `configQuery` so the frontend
- * pulls them from the backend (configure Logto in one place per environment).
- *
- * @example
- * <ConvexLogtoProvider client={convex} configQuery={api.logto.config}>
- *   <App />
- * </ConvexLogtoProvider>
- */
-export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
-  const {
-    client,
-    scopes,
-    resources,
-    callbackPath = "/callback",
-    afterSignIn = "/",
-    navigate,
-    children,
-  } = props;
-
-  const shared = {
-    client,
-    scopes,
-    resources,
-    callbackPath,
-    afterSignIn,
-    navigate,
-  };
-
-  if (props.configQuery) {
-    return (
-      <BackendConfiguredProvider
-        {...shared}
-        configQuery={props.configQuery}
-        fallback={props.fallback}
-      >
+    <LogtoProvider
+      config={logtoConfig}
+      {...(ready ? {} : { LogtoClientClass: LoadingLogtoClient })}
+    >
+      {/* Only meaningful once the real client is up; a no-op until the callback URL. */}
+      {ready ? (
+        <LogtoCallback afterSignIn={afterSignIn} navigate={navigate} />
+      ) : null}
+      <ConvexProviderWithAuth client={client} useAuth={useAuthFromLogto}>
         {children}
-      </BackendConfiguredProvider>
-    );
-  }
-
-  return (
-    <InnerProvider {...shared} endpoint={props.endpoint} appId={props.appId}>
-      {children}
-    </InnerProvider>
+      </ConvexProviderWithAuth>
+    </LogtoProvider>
   );
 }
 
@@ -294,30 +277,32 @@ export type LogtoAuth = {
   isLoading: boolean;
   /** Decoded ID token claims (sub, email, name, ...), once authenticated. */
   user: IdTokenClaims | undefined;
-  /** Start sign-in. Defaults the redirect to `${origin}${callbackPath}`. */
+  /** Start sign-in. Defaults the redirect to `${origin}/callback`. */
   signIn: (redirectUri?: string) => Promise<void>;
-  /** Sign out. Defaults the post-logout redirect to the current origin. */
+  /**
+   * Sign out: ends the Logto session, then returns to `window.location.origin`,
+   * which you must register as a **Post sign-out redirect URI** (exact match, no
+   * trailing slash). Pass another registered URI to land elsewhere.
+   */
   signOut: (postLogoutRedirectUri?: string) => Promise<void>;
 };
 
 /**
- * Everything a component needs for auth, from one import — no need to also pull
- * in `@logto/react`. `signIn`/`signOut` come pre-filled with sensible redirects
- * that respect the provider's `callbackPath`.
+ * Auth state and actions from one import. `isAuthenticated` / `isLoading` come
+ * from Convex, so they're true only once Convex has accepted the token.
  *
  * @example
  * const { isAuthenticated, user, signIn, signOut } = useLogtoAuth();
  */
 export function useLogtoAuth(): LogtoAuth {
-  const { isAuthenticated, isLoading, signIn, signOut, getIdTokenClaims } =
-    useLogto();
-  const callbackPath = useContext(CallbackPathContext);
+  const { isAuthenticated, isLoading } = useConvexAuth();
+  const { signIn, signOut, getIdTokenClaims } = useLogto();
   const [user, setUser] = useState<IdTokenClaims>();
 
   useEffect(() => {
     let active = true;
     if (isAuthenticated) {
-      // getIdTokenClaims() resolves undefined on failure (never rejects).
+      // Resolves undefined on failure (never rejects).
       getIdTokenClaims().then((claims) => {
         if (active) setUser(claims);
       });
@@ -331,9 +316,11 @@ export function useLogtoAuth(): LogtoAuth {
 
   const doSignIn = useCallback(
     (redirectUri?: string) =>
-      signIn(redirectUri ?? `${window.location.origin}${callbackPath}`),
-    [signIn, callbackPath],
+      signIn(redirectUri ?? `${window.location.origin}${CALLBACK_PATH}`),
+    [signIn],
   );
+  // Federated sign-out: ends the SSO session (so the next sign-in isn't silent),
+  // then returns to origin — which must be a registered Post sign-out redirect URI.
   const doSignOut = useCallback(
     (postLogoutRedirectUri?: string) =>
       signOut(postLogoutRedirectUri ?? window.location.origin),

--- a/packages/convex-logto/src/webhooks.ts
+++ b/packages/convex-logto/src/webhooks.ts
@@ -24,20 +24,21 @@ export type LogtoUserEntity = {
   applicationId?: string | null;
 };
 
-/** Logto data-mutation events that carry a User entity. */
-export type LogtoUserEvent =
-  | "User.Created"
-  | "User.Data.Updated"
-  | "User.Deleted"
-  | "User.SuspensionStatus.Updated";
-
-/** The known User.* events, for membership-testing an incoming payload. */
-const LOGTO_USER_EVENTS: ReadonlySet<LogtoUserEvent> = new Set([
+/** The known User.* data-mutation events, each carrying a User entity. */
+const LOGTO_USER_EVENTS = [
   "User.Created",
   "User.Data.Updated",
   "User.Deleted",
   "User.SuspensionStatus.Updated",
-]);
+] as const;
+
+/** Logto data-mutation events that carry a User entity. */
+export type LogtoUserEvent = (typeof LOGTO_USER_EVENTS)[number];
+
+/** Set form of {@link LOGTO_USER_EVENTS}, for membership-testing a payload. */
+const LOGTO_USER_EVENT_SET: ReadonlySet<LogtoUserEvent> = new Set(
+  LOGTO_USER_EVENTS,
+);
 
 /** Shape of a Logto data-mutation webhook delivery (User family). */
 export type LogtoWebhookPayload = {
@@ -46,7 +47,18 @@ export type LogtoWebhookPayload = {
   createdAt: string;
   userAgent?: string;
   ip?: string;
-  data: LogtoUserEntity;
+  /**
+   * The affected User entity — but `null` for `User.Deleted`: Logto can't
+   * summarize a deletion as a single entity, so it sends `data: null` and the
+   * deleted user's id rides in the Management API `params` (`{ userId }`) instead.
+   */
+  data: LogtoUserEntity | null;
+  /** Management API context, present for admin-triggered changes (e.g. deletion). */
+  path?: string;
+  method?: string;
+  status?: number;
+  params?: Record<string, unknown>;
+  matchedRoute?: string;
   [key: string]: unknown;
 };
 
@@ -80,8 +92,8 @@ export async function verifyLogtoSignature(
   expectedSignature: string,
 ): Promise<boolean> {
   if (!signingKey || !expectedSignature) return false;
-  // Reject anything that isn't a 64-char lowercase-hex SHA-256 digest before the
-  // compare, so a malformed header can never be (length-)matched by accident.
+  // Normalize to lowercase, then reject anything that isn't a 64-char hex SHA-256
+  // digest, so a malformed header can never be (length-)matched by accident.
   const expected = expectedSignature.trim().toLowerCase();
   if (!/^[0-9a-f]{64}$/.test(expected)) return false;
   const body = typeof rawBody === "string" ? encoder.encode(rawBody) : rawBody;
@@ -96,24 +108,45 @@ export async function verifyLogtoSignature(
   return timingSafeEqual(toHex(signature), expected);
 }
 
+/** The id from the User entity in `data` — present on every event but `User.Deleted`. */
+function entityId(payload: Record<string, unknown>): string | undefined {
+  const data = payload.data;
+  if (typeof data === "object" && data !== null) {
+    const id = (data as Record<string, unknown>).id;
+    if (typeof id === "string") return id;
+  }
+  return undefined;
+}
+
+/** The deleted user's id from the Management API route params (`DELETE /users/:userId`). */
+function paramsUserId(payload: Record<string, unknown>): string | undefined {
+  const params = payload.params;
+  if (typeof params === "object" && params !== null) {
+    const userId = (params as Record<string, unknown>).userId;
+    if (typeof userId === "string") return userId;
+  }
+  return undefined;
+}
+
 function isLogtoWebhookPayload(value: unknown): value is LogtoWebhookPayload {
   if (typeof value !== "object" || value === null) return false;
-  const { event, data } = value as Record<string, unknown>;
+  const candidate = value as Record<string, unknown>;
+  const event = candidate.event;
   // Only accept the known User.* events; an unknown event would otherwise 200
   // silently with no handler, hiding a misconfigured hook.
   if (
     typeof event !== "string" ||
-    !LOGTO_USER_EVENTS.has(event as LogtoUserEvent)
+    !LOGTO_USER_EVENT_SET.has(event as LogtoUserEvent)
   ) {
     return false;
   }
-  // Every User.* data-mutation event carries an entity with a string id;
-  // requiring it keeps a malformed body from reaching handlers as `id: undefined`.
-  return (
-    typeof data === "object" &&
-    data !== null &&
-    typeof (data as Record<string, unknown>).id === "string"
-  );
+  // `User.Deleted` is the one event Logto sends with `data: null` — there the id
+  // rides in the route params. Every other User.* event must carry the full entity,
+  // so require it; that keeps a malformed `data: null` body from reaching a sync
+  // handler as a bare `{ id }` (which it could misread as "all fields were cleared").
+  return event === "User.Deleted"
+    ? entityId(candidate) !== undefined || paramsUserId(candidate) !== undefined
+    : entityId(candidate) !== undefined;
 }
 
 /** A per-event sync handler. Runs in a Convex mutation, so `ctx.db` is available. */
@@ -131,7 +164,7 @@ export type LogtoSyncHandlers<DataModel extends GenericDataModel> = Partial<
 export type LogtoSyncReference = FunctionReference<
   "mutation",
   "internal",
-  { event: string; payload: unknown },
+  { payload: unknown },
   null
 >;
 
@@ -141,14 +174,27 @@ export type LogtoSyncReference = FunctionReference<
  * signature. Handlers get a mutation `ctx`, so you write to `ctx.db` directly.
  * Pass your generated `DataModel` for a typed `ctx.db`.
  *
+ * Sync rows here; don't create them. `User.Created` doesn't fire for users who
+ * already existed in Logto, so create rows from an authenticated mutation and let
+ * these handlers keep them in sync. See the Webhook sync guide for the ownership
+ * rules (which fields the webhook may write, and which are app-owned).
+ *
  * @example
- * // convex/logto.ts
+ * // convex/logto.ts — keep an existing user's profile in sync (never create here)
  * import { logtoSync } from "convex-logto";
  * import type { DataModel } from "./_generated/dataModel";
  *
  * export const { sync } = logtoSync<DataModel>({
- *   "User.Created": (ctx, u) =>
- *     ctx.db.insert("users", { authId: u.id, email: u.primaryEmail ?? "" }),
+ *   "User.Data.Updated": async (ctx, u) => {
+ *     const row = await ctx.db
+ *       .query("users")
+ *       .withIndex("by_authId", (q) => q.eq("authId", u.id))
+ *       .unique();
+ *     // Mirror only fields the event carries (present → set, absent → leave).
+ *     if (row && u.primaryEmail !== undefined) {
+ *       await ctx.db.patch(row._id, { email: u.primaryEmail ?? undefined });
+ *     }
+ *   },
  * });
  */
 export function logtoSync<
@@ -156,19 +202,30 @@ export function logtoSync<
 >(handlers: LogtoSyncHandlers<DataModel>) {
   return {
     sync: internalMutationGeneric({
-      args: { event: v.string(), payload: v.any() },
+      args: { payload: v.any() },
       returns: v.null(),
       handler: async (ctx, args) => {
-        const handler = handlers[args.event as LogtoUserEvent];
+        // registerLogtoWebhook validates before calling, but this is an exported
+        // internal mutation — reject anything that isn't a known User.* event.
+        if (!isLogtoWebhookPayload(args.payload)) {
+          throw new Error(
+            "convex-logto: logtoSync received a payload that isn't a known Logto User.* event.",
+          );
+        }
+        const payload = args.payload;
+        const handler = handlers[payload.event];
         if (handler) {
-          const payload = args.payload as LogtoWebhookPayload;
+          // Use the entity Logto sent when it actually carries an id; `User.Deleted`
+          // has none (`data: null`), so synthesize one from the route params. Keyed
+          // on entityId, not `data ?? …`, so a stray `data: {}` can't slip through as
+          // an id-less user. (The guard guaranteed one of the two is present.)
+          const user: LogtoUserEntity =
+            entityId(payload) !== undefined
+              ? (payload.data as LogtoUserEntity)
+              : { id: paramsUserId(payload)! };
           // `ctx` here is typed for the generic data model; the user's handlers
           // are written against their concrete `DataModel`.
-          await handler(
-            ctx as GenericMutationCtx<DataModel>,
-            payload.data,
-            payload,
-          );
+          await handler(ctx as GenericMutationCtx<DataModel>, user, payload);
         }
         return null;
       },
@@ -235,7 +292,7 @@ export function registerLogtoWebhook(
         });
       }
 
-      await ctx.runMutation(sync, { event: parsed.event, payload: parsed });
+      await ctx.runMutation(sync, { payload: parsed });
       return new Response(null, { status: 200 });
     }),
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 0.7.0
       '@changesets/cli':
         specifier: ^2.31.0
-        version: 2.31.0
+        version: 2.31.0(@types/node@22.19.21)
       turbo:
         specifier: ^2.5.0
         version: 2.9.18
@@ -25,13 +25,13 @@ importers:
         version: 1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-start':
         specifier: ^1.168.25
-        version: 1.168.25(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0))
+        version: 1.168.25(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0))
       fumadocs-core:
         specifier: ^16.10.2
         version: 16.10.2(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.476.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3)
       fumadocs-mdx:
         specifier: ^15.0.12
-        version: 15.0.12(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.10.2(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.476.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(react@19.2.7)(rolldown@1.1.1)(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0))
+        version: 15.0.12(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.10.2(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.476.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(react@19.2.7)(rolldown@1.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0))
       fumadocs-ui:
         specifier: ^16.10.2
         version: 16.10.2(@tailwindcss/oxide@4.3.1)(@types/mdx@2.0.14)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(fumadocs-core@16.10.2(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.476.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)
@@ -50,7 +50,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.3.1
-        version: 4.3.1(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0))
+        version: 4.3.1(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0))
       '@types/mdx':
         specifier: ^2.0.13
         version: 2.0.14
@@ -62,10 +62,10 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0))
+        version: 6.0.2(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0))
       nitro:
         specifier: 3.0.260610-beta
-        version: 3.0.260610-beta(chokidar@5.0.0)(dotenv@8.6.0)(jiti@2.7.0)(lru-cache@11.5.1)(rollup@4.62.0)(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0))
+        version: 3.0.260610-beta(chokidar@5.0.0)(dotenv@8.6.0)(jiti@2.7.0)(lru-cache@11.5.1)(rollup@4.62.0)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0))
       tailwindcss:
         specifier: ^4.3.1
         version: 4.3.1
@@ -74,10 +74,173 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.16
-        version: 8.0.16(esbuild@0.28.1)(jiti@2.7.0)
+        version: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)
       vite-tsconfig-paths:
         specifier: ^6.1.1
-        version: 6.1.1(typescript@5.9.3)(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0))
+        version: 6.1.1(typescript@5.9.3)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0))
+
+  examples/nextjs:
+    dependencies:
+      '@logto/react':
+        specifier: ^4.0.14
+        version: 4.0.14(react@19.2.7)
+      convex:
+        specifier: ^1.41.0
+        version: 1.41.0(react@19.2.7)
+      convex-logto:
+        specifier: workspace:*
+        version: link:../../packages/convex-logto
+      next:
+        specifier: ^15.5.4
+        version: 15.5.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.21
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+
+  examples/tanstack-router-spa:
+    dependencies:
+      '@logto/react':
+        specifier: ^4.0.14
+        version: 4.0.14(react@19.2.7)
+      '@tanstack/react-router':
+        specifier: ^1.170.15
+        version: 1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      convex:
+        specifier: ^1.41.0
+        version: 1.41.0(react@19.2.7)
+      convex-logto:
+        specifier: workspace:*
+        version: link:../../packages/convex-logto
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@edge-runtime/vm':
+        specifier: ^5.0.0
+        version: 5.0.0
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.2
+        version: 6.0.2(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0))
+      convex-test:
+        specifier: ^0.0.53
+        version: 0.0.53(convex@1.41.0(react@19.2.7))
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@edge-runtime/vm@5.0.0)(@types/debug@4.1.13)(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)
+
+  examples/tanstack-start:
+    dependencies:
+      '@convex-dev/react-query':
+        specifier: ^0.1.0
+        version: 0.1.0(@tanstack/react-query@5.101.0(react@19.2.7))(convex@1.41.0(react@19.2.7))
+      '@logto/react':
+        specifier: ^4.0.14
+        version: 4.0.14(react@19.2.7)
+      '@tanstack/react-query':
+        specifier: ^5.101.0
+        version: 5.101.0(react@19.2.7)
+      '@tanstack/react-router':
+        specifier: ^1.170.15
+        version: 1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/react-router-ssr-query':
+        specifier: ^1.167.1
+        version: 1.167.1(@tanstack/query-core@5.101.0)(@tanstack/react-query@5.101.0(react@19.2.7))(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.171.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/react-start':
+        specifier: ^1.168.25
+        version: 1.168.25(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0))
+      convex:
+        specifier: ^1.41.0
+        version: 1.41.0(react@19.2.7)
+      convex-logto:
+        specifier: workspace:*
+        version: link:../../packages/convex-logto
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.2
+        version: 6.0.2(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0))
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)
+
+  examples/vite-react:
+    dependencies:
+      '@logto/react':
+        specifier: ^4.0.14
+        version: 4.0.14(react@19.2.7)
+      convex:
+        specifier: ^1.41.0
+        version: 1.41.0(react@19.2.7)
+      convex-logto:
+        specifier: workspace:*
+        version: link:../../packages/convex-logto
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.2
+        version: 6.0.2(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0))
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)
 
   packages/convex-logto:
     devDependencies:
@@ -90,6 +253,9 @@ importers:
       '@types/react':
         specifier: ^19.1.10
         version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
       convex:
         specifier: ^1.38.0
         version: 1.41.0(react@19.2.7)
@@ -105,6 +271,9 @@ importers:
       react:
         specifier: ^19.1.0
         version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.7.0)(postcss@8.5.15)(typescript@5.9.3)
@@ -113,7 +282,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.6(@types/debug@4.1.13)(jiti@2.7.0)(lightningcss@1.32.0)
+        version: 3.2.6(@edge-runtime/vm@5.0.0)(@types/debug@4.1.13)(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)
 
 packages:
 
@@ -271,6 +440,20 @@ packages:
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
+
+  '@convex-dev/react-query@0.1.0':
+    resolution: {integrity: sha512-ULmBZCtAQDUePdBhUv7hj1Yy4QiCelhi6uEIOtMpjW8db6W9CFKvQwLt9heLngccFyMFfAZdOfSrT+cP4AH0Jw==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.0.0
+      convex: ^1.29.3
+
+  '@edge-runtime/primitives@6.0.0':
+    resolution: {integrity: sha512-FqoxaBT+prPBHBwE1WXS1ocnu/VLTQyZ6NMUBAdbP7N2hsFTTxMC/jMu2D/8GAlMQfxeuppcPuCUk/HO3fpIvA==}
+    engines: {node: '>=18'}
+
+  '@edge-runtime/vm@5.0.0':
+    resolution: {integrity: sha512-NKBGBSIKUG584qrS1tyxVpX/AKJKQw5HgjYEnPLC0QsTw79JrGn+qUr8CXFb955Iy7GUdiiUv1rJ6JBGvaKb6w==}
+    engines: {node: '>=18'}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -794,6 +977,159 @@ packages:
       tailwindcss:
         optional: true
 
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
   '@inquirer/external-editor@1.0.3':
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
     engines: {node: '>=18'}
@@ -850,6 +1186,61 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@next/env@15.5.19':
+    resolution: {integrity: sha512-sWWluFvcv5v3Fxznmf2ZfjyoVQt/64oCnYqS90inQWGzMPK1VjvekPiz3OPHKmFT30EnHrjlbyaHLt3M0vWabw==}
+
+  '@next/swc-darwin-arm64@15.5.19':
+    resolution: {integrity: sha512-jx9wWlTKueHKPvVOndyr7WuaevWCkuYqsQ8gC0TMPKAVWG3MhcdMrjfo9tvIZNXd0QOUYXXvAcZ325y8Uq7uzg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@15.5.19':
+    resolution: {integrity: sha512-291KFcsIQ3OenRdiUDFOR6W3wezzH4auENXm1gbm1Bjd4ANMMRgxPrWTUztQN43BnVoVuMnHCrLeECIMwgFKbA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@15.5.19':
+    resolution: {integrity: sha512-WeH+nelQyyMeE2f8FxBRZNrGipya5zHZV2vjzfCOAYyiI6am+NbnWAAldOBFQBB2w0DjJcsvrKqoFT2b7+5YoA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-arm64-musl@15.5.19':
+    resolution: {integrity: sha512-5xTOE0lDlDCSSfp+BAif7j17VRRCjWp//ZPZy6NI0QpdrhxtQnsZguSx0xAAZ0c9XZLrLLwCe/XVe5YPrRilKw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-linux-x64-gnu@15.5.19':
+    resolution: {integrity: sha512-LTxRmMgqqMv05Had879W00Fm53quiJd3Zuz8h1JSNJ3nGSlbZ/7Tjs1tKyScgN3Au3t3MyPsjPlq60fMmSHLsg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-x64-musl@15.5.19':
+    resolution: {integrity: sha512-eoNQSpA5PQfB9wBO4RA47MTDXWz1fizy9Y3Z6e4DetYIF3dvjuu8sj7aIGn/bFCU6lnFzTK34NtCaffP4NsQ7Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-win32-arm64-msvc@15.5.19':
+    resolution: {integrity: sha512-6UNt2dFuCHOe446sm/Kp69nUe8/wIhnh9bm6Xcqw4qEWCOppLMOvhTBVgvM7invVUNr4SPpP6NOQsACtn2IN9Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@15.5.19':
+    resolution: {integrity: sha512-PhmojAHyqMne56HBLGu9dhDnHPuFmEjrXSQMM/nW0J6j849lk3ESrVtqNJcCk8CKOV7brpTTbaYAjwKPzKM69w==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1866,6 +2257,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
   '@tailwindcss/node@4.3.1':
     resolution: {integrity: sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==}
 
@@ -1964,6 +2358,24 @@ packages:
     resolution: {integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==}
     engines: {node: '>=20.19'}
 
+  '@tanstack/query-core@5.101.0':
+    resolution: {integrity: sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==}
+
+  '@tanstack/react-query@5.101.0':
+    resolution: {integrity: sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==}
+    peerDependencies:
+      react: ^18 || ^19
+
+  '@tanstack/react-router-ssr-query@1.167.1':
+    resolution: {integrity: sha512-W9j5JPnBikyafvuUfykFfHIWod58OAbAAa5leNkXBcoDoocghMmu6w9uZOmUZvAWT7CSvgj5tBUtF7CM2OoHXQ==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      '@tanstack/query-core': '>=5.90.0'
+      '@tanstack/react-query': '>=5.90.0'
+      '@tanstack/react-router': '>=1.127.0'
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
   '@tanstack/react-router@1.170.15':
     resolution: {integrity: sha512-GawYz7HEjj8rTUUDoT/SemDEVm63pZUO+2mOcXHY9Jl3EwMS5gFBnPu/2UvcrwRm1jN1k79fokc0d4aFmrLatg==}
     engines: {node: '>=20.19'}
@@ -2053,6 +2465,13 @@ packages:
         optional: true
       webpack:
         optional: true
+
+  '@tanstack/router-ssr-query-core@1.169.1':
+    resolution: {integrity: sha512-rngux8s/3mPQzcjLYDLkNU31coYVyCgrVTfpdwqUdY5jIEHqGTXrO73DTkPR1PppwYUeVhmNCgl8TctRcnupjg==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      '@tanstack/query-core': '>=5.90.0'
+      '@tanstack/router-core': '>=1.127.0'
 
   '@tanstack/router-utils@1.162.2':
     resolution: {integrity: sha512-hTWqJtqIFFdvuCl8WXNyrodp2L9zo2G37xKRrcVmVRWpAB2h+U1LuRAfS4tsFTiWOIoE/B+WDVFB8JpoEdw6jQ==}
@@ -2155,6 +2574,9 @@ packages:
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
+  '@types/node@22.19.21':
+    resolution: {integrity: sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -2380,6 +2802,9 @@ packages:
     resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
     engines: {node: 10.* || >= 12.*}
 
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
   cliui@7.0.4:
     resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
 
@@ -2420,6 +2845,11 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  convex-test@0.0.53:
+    resolution: {integrity: sha512-bouZQTnTvZi8IHljHL++yClj1vcV+/9ZxEcd8JZz7RDxOfPkRKrkMgkk/xlX4M1EAiwcEJPNiQE7VJFvDM3lCQ==}
+    peerDependencies:
+      convex: ^1.32.0
 
   convex@1.41.0:
     resolution: {integrity: sha512-euxVf6yfpB7/VGKOobkLgjpbJidsUgW+b0ezonEyCUPqlpHFwR4/yIiI1hjjErzraiw91GxrtxpXQClMLNqU+w==}
@@ -3357,6 +3787,27 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
+  next@15.5.19:
+    resolution: {integrity: sha512-xNOW6tYshGX1/Oi3F8uuk4gpDeWsSUE/1Z0G5uUMekIxaQ0xc03UXd9II0VQHYMWviMeA0OHpJFAKsHf8bTYVg==}
+    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
   nf3@0.3.17:
     resolution: {integrity: sha512-N9zEWySuJFw+gR0lhS5863YsvNeudOdqRyFvNb+jMXbeTJOdrjDqkCpDginIZfUm0LzT1t1nCRiDeqQm/8kirQ==}
 
@@ -3556,6 +4007,10 @@ packages:
       yaml:
         optional: true
 
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
@@ -3751,6 +4206,10 @@ packages:
     resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
     engines: {node: '>=10'}
 
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -3829,6 +4288,19 @@ packages:
 
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
+  styled-jsx@5.1.6:
+    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -3959,6 +4431,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -3966,6 +4443,9 @@ packages:
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
@@ -4488,7 +4968,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@changesets/cli@2.31.0':
+  '@changesets/cli@2.31.0(@types/node@22.19.21)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
       '@changesets/assemble-release-plan': 6.0.10
@@ -4504,7 +4984,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3
+      '@inquirer/external-editor': 1.0.3(@types/node@22.19.21)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       enquirer: 2.4.1
@@ -4611,6 +5091,17 @@ snapshots:
 
   '@colors/colors@1.5.0':
     optional: true
+
+  '@convex-dev/react-query@0.1.0(@tanstack/react-query@5.101.0(react@19.2.7))(convex@1.41.0(react@19.2.7))':
+    dependencies:
+      '@tanstack/react-query': 5.101.0(react@19.2.7)
+      convex: 1.41.0(react@19.2.7)
+
+  '@edge-runtime/primitives@6.0.0': {}
+
+  '@edge-runtime/vm@5.0.0':
+    dependencies:
+      '@edge-runtime/primitives': 6.0.0
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -4907,10 +5398,109 @@ snapshots:
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
 
-  '@inquirer/external-editor@1.0.3':
+  '@img/colour@1.1.0':
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.11.0
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@inquirer/external-editor@1.0.3(@types/node@22.19.21)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 22.19.21
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -5017,6 +5607,32 @@ snapshots:
       '@emnapi/core': 1.11.0
       '@emnapi/runtime': 1.11.0
       '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@next/env@15.5.19': {}
+
+  '@next/swc-darwin-arm64@15.5.19':
+    optional: true
+
+  '@next/swc-darwin-x64@15.5.19':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@15.5.19':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@15.5.19':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@15.5.19':
+    optional: true
+
+  '@next/swc-linux-x64-musl@15.5.19':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@15.5.19':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@15.5.19':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -5739,6 +6355,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@swc/helpers@0.5.15':
+    dependencies:
+      tslib: 2.8.1
+
   '@tailwindcss/node@4.3.1':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -5800,14 +6420,32 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
 
-  '@tailwindcss/vite@4.3.1(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0))':
+  '@tailwindcss/vite@4.3.1(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0))':
     dependencies:
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
-      vite: 8.0.16(esbuild@0.28.1)(jiti@2.7.0)
+      vite: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)
 
   '@tanstack/history@1.162.0': {}
+
+  '@tanstack/query-core@5.101.0': {}
+
+  '@tanstack/react-query@5.101.0(react@19.2.7)':
+    dependencies:
+      '@tanstack/query-core': 5.101.0
+      react: 19.2.7
+
+  '@tanstack/react-router-ssr-query@1.167.1(@tanstack/query-core@5.101.0)(@tanstack/react-query@5.101.0(react@19.2.7))(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.171.13)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/query-core': 5.101.0
+      '@tanstack/react-query': 5.101.0(react@19.2.7)
+      '@tanstack/react-router': 1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/router-ssr-query-core': 1.169.1(@tanstack/query-core@5.101.0)(@tanstack/router-core@1.171.13)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    transitivePeerDependencies:
+      - '@tanstack/router-core'
 
   '@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
@@ -5826,14 +6464,14 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  '@tanstack/react-start-rsc@0.1.24(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0))':
+  '@tanstack/react-start-rsc@0.1.24(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0))':
     dependencies:
       '@tanstack/react-router': 1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/router-core': 1.171.13
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-client-core': 1.170.12
       '@tanstack/start-fn-stubs': 1.162.0
-      '@tanstack/start-plugin-core': 1.171.17(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(crossws@0.4.6(srvx@0.11.16))(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0))
+      '@tanstack/start-plugin-core': 1.171.17(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(crossws@0.4.6(srvx@0.11.16))(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0))
       '@tanstack/start-server-core': 1.169.14(crossws@0.4.6(srvx@0.11.16))
       '@tanstack/start-storage-context': 1.167.15
       pathe: 2.0.3
@@ -5857,21 +6495,21 @@ snapshots:
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start@1.168.25(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0))':
+  '@tanstack/react-start@1.168.25(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0))':
     dependencies:
       '@tanstack/react-router': 1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-start-client': 1.168.13(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tanstack/react-start-rsc': 0.1.24(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0))
+      '@tanstack/react-start-rsc': 0.1.24(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0))
       '@tanstack/react-start-server': 1.167.19(crossws@0.4.6(srvx@0.11.16))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-client-core': 1.170.12
-      '@tanstack/start-plugin-core': 1.171.17(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(crossws@0.4.6(srvx@0.11.16))(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0))
+      '@tanstack/start-plugin-core': 1.171.17(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(crossws@0.4.6(srvx@0.11.16))(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0))
       '@tanstack/start-server-core': 1.169.14(crossws@0.4.6(srvx@0.11.16))
       pathe: 2.0.3
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      vite: 8.0.16(esbuild@0.28.1)(jiti@2.7.0)
+      vite: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)
     transitivePeerDependencies:
       - '@rspack/core'
       - crossws
@@ -5907,7 +6545,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.168.18(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0))':
+  '@tanstack/router-plugin@1.168.18(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/template': 7.29.7
@@ -5920,9 +6558,14 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       '@tanstack/react-router': 1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      vite: 8.0.16(esbuild@0.28.1)(jiti@2.7.0)
+      vite: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)
     transitivePeerDependencies:
       - supports-color
+
+  '@tanstack/router-ssr-query-core@1.169.1(@tanstack/query-core@5.101.0)(@tanstack/router-core@1.171.13)':
+    dependencies:
+      '@tanstack/query-core': 5.101.0
+      '@tanstack/router-core': 1.171.13
 
   '@tanstack/router-utils@1.162.2':
     dependencies:
@@ -5946,14 +6589,14 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.162.0': {}
 
-  '@tanstack/start-plugin-core@1.171.17(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(crossws@0.4.6(srvx@0.11.16))(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0))':
+  '@tanstack/start-plugin-core@1.171.17(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(crossws@0.4.6(srvx@0.11.16))(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.7
       '@babel/types': 7.29.7
       '@tanstack/router-core': 1.171.13
       '@tanstack/router-generator': 1.167.17
-      '@tanstack/router-plugin': 1.168.18(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0))
+      '@tanstack/router-plugin': 1.168.18(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0))
       '@tanstack/router-utils': 1.162.2
       '@tanstack/start-server-core': 1.169.14(crossws@0.4.6(srvx@0.11.16))
       exsolve: 1.0.8
@@ -5965,11 +6608,11 @@ snapshots:
       srvx: 0.11.16
       tinyglobby: 0.2.17
       ufo: 1.6.4
-      vitefu: 1.1.3(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0))
+      vitefu: 1.1.3(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0))
       xmlbuilder2: 4.0.3
       zod: 4.4.3
     optionalDependencies:
-      vite: 8.0.16(esbuild@0.28.1)(jiti@2.7.0)
+      vite: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)
     transitivePeerDependencies:
       - '@tanstack/react-router'
       - crossws
@@ -6051,6 +6694,10 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
+  '@types/node@22.19.21':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
       '@types/react': 19.2.17
@@ -6065,10 +6712,10 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@vitejs/plugin-react@6.0.2(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0))':
+  '@vitejs/plugin-react@6.0.2(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.16(esbuild@0.28.1)(jiti@2.7.0)
+      vite: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)
 
   '@vitest/expect@3.2.6':
     dependencies:
@@ -6078,13 +6725,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.6(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0))':
+  '@vitest/mocker@3.2.6(vite@7.3.5(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0))':
     dependencies:
       '@vitest/spy': 3.2.6
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.5(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.5(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)
 
   '@vitest/pretty-format@3.2.6':
     dependencies:
@@ -6259,6 +6906,8 @@ snapshots:
     optionalDependencies:
       '@colors/colors': 1.5.0
 
+  client-only@0.0.1: {}
+
   cliui@7.0.4:
     dependencies:
       string-width: 4.2.3
@@ -6288,6 +6937,10 @@ snapshots:
   consola@3.4.2: {}
 
   convert-source-map@2.0.0: {}
+
+  convex-test@0.0.53(convex@1.41.0(react@19.2.7)):
+    dependencies:
+      convex: 1.41.0(react@19.2.7)
 
   convex@1.41.0(react@19.2.7):
     dependencies:
@@ -6622,7 +7275,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@15.0.12(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.10.2(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.476.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(react@19.2.7)(rolldown@1.1.1)(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0)):
+  fumadocs-mdx@15.0.12(@types/mdast@4.0.4)(@types/mdx@2.0.14)(@types/react@19.2.17)(fumadocs-core@16.10.2(@mdx-js/mdx@3.1.1)(@tanstack/react-router@1.170.15(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.17)(lucide-react@0.476.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@4.4.3))(react@19.2.7)(rolldown@1.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
@@ -6647,7 +7300,7 @@ snapshots:
       '@types/react': 19.2.17
       react: 19.2.7
       rolldown: 1.1.1
-      vite: 8.0.16(esbuild@0.28.1)(jiti@2.7.0)
+      vite: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7490,9 +8143,32 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
+  next@15.5.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@next/env': 15.5.19
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001799
+      postcss: 8.4.31
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      styled-jsx: 5.1.6(react@19.2.7)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.5.19
+      '@next/swc-darwin-x64': 15.5.19
+      '@next/swc-linux-arm64-gnu': 15.5.19
+      '@next/swc-linux-arm64-musl': 15.5.19
+      '@next/swc-linux-x64-gnu': 15.5.19
+      '@next/swc-linux-x64-musl': 15.5.19
+      '@next/swc-win32-arm64-msvc': 15.5.19
+      '@next/swc-win32-x64-msvc': 15.5.19
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
   nf3@0.3.17: {}
 
-  nitro@3.0.260610-beta(chokidar@5.0.0)(dotenv@8.6.0)(jiti@2.7.0)(lru-cache@11.5.1)(rollup@4.62.0)(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0)):
+  nitro@3.0.260610-beta(chokidar@5.0.0)(dotenv@8.6.0)(jiti@2.7.0)(lru-cache@11.5.1)(rollup@4.62.0)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.6(srvx@0.11.16)
@@ -7512,7 +8188,7 @@ snapshots:
       dotenv: 8.6.0
       jiti: 2.7.0
       rollup: 4.62.0
-      vite: 8.0.16(esbuild@0.28.1)(jiti@2.7.0)
+      vite: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -7700,6 +8376,12 @@ snapshots:
     optionalDependencies:
       jiti: 2.7.0
       postcss: 8.5.15
+
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postcss@8.5.15:
     dependencies:
@@ -7981,6 +8663,38 @@ snapshots:
 
   seroval@1.5.4: {}
 
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+    optional: true
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -8055,6 +8769,11 @@ snapshots:
   style-to-object@1.0.14:
     dependencies:
       inline-style-parser: 0.2.7
+
+  styled-jsx@5.1.6(react@19.2.7):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.7
 
   sucrase@3.35.1:
     dependencies:
@@ -8171,9 +8890,13 @@ snapshots:
 
   typescript@5.6.1-rc: {}
 
+  typescript@5.8.3: {}
+
   typescript@5.9.3: {}
 
   ufo@1.6.4: {}
+
+  undici-types@6.21.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:
@@ -8280,13 +9003,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(jiti@2.7.0)(lightningcss@1.32.0):
+  vite-node@3.2.4(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.5(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.5(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -8301,17 +9024,17 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0)):
+  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.3)
-      vite: 8.0.16(esbuild@0.28.1)(jiti@2.7.0)
+      vite: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0):
+  vite@7.3.5(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -8320,11 +9043,12 @@ snapshots:
       rollup: 4.62.0
       tinyglobby: 0.2.17
     optionalDependencies:
+      '@types/node': 22.19.21
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
 
-  vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0):
+  vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -8332,19 +9056,20 @@ snapshots:
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:
+      '@types/node': 22.19.21
       esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0
 
-  vitefu@1.1.3(vite@8.0.16(esbuild@0.28.1)(jiti@2.7.0)):
+  vitefu@1.1.3(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)):
     optionalDependencies:
-      vite: 8.0.16(esbuild@0.28.1)(jiti@2.7.0)
+      vite: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)
 
-  vitest@3.2.6(@types/debug@4.1.13)(jiti@2.7.0)(lightningcss@1.32.0):
+  vitest@3.2.6(@edge-runtime/vm@5.0.0)(@types/debug@4.1.13)(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
-      '@vitest/mocker': 3.2.6(vite@7.3.5(jiti@2.7.0)(lightningcss@1.32.0))
+      '@vitest/mocker': 3.2.6(vite@7.3.5(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0))
       '@vitest/pretty-format': 3.2.6
       '@vitest/runner': 3.2.6
       '@vitest/snapshot': 3.2.6
@@ -8362,11 +9087,13 @@ snapshots:
       tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.5(jiti@2.7.0)(lightningcss@1.32.0)
-      vite-node: 3.2.4(jiti@2.7.0)(lightningcss@1.32.0)
+      vite: 7.3.5(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)
+      vite-node: 3.2.4(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@edge-runtime/vm': 5.0.0
       '@types/debug': 4.1.13
+      '@types/node': 22.19.21
     transitivePeerDependencies:
       - jiti
       - less

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - packages/*
   - docs
+  - examples/*


### PR DESCRIPTION
## Summary

`convex-logto` 0.2.0 — SSR-safe, config-only provider (breaking API slim), plus runnable examples, expanded docs, and unit tests.

This branch carries `.changeset/ssr-safe-config-only-provider.md` (minor). **It does not bump the version itself** — on merge to `main`, the Release workflow opens the "Version Packages" PR; merging that publishes 0.2.0 to npm via OIDC trusted publishing.

### Breaking

- The provider is configured by `configQuery` only. Removed the literal `endpoint`/`appId` props (and their union), the `callbackPath` prop, and the `fallback` prop.

### Highlights

- **SSR-safe provider** — a single `<ConvexLogtoProvider>` works everywhere (Next.js App Router, TanStack Start); no hand-written client boundary, nothing touches `window` on the server.
- **No auth flicker** on load or reload. Verified live against real Logto: sign-in → 10× authenticated reload (0 flashes) → sign-out.
- A failed sign-in code exchange now throws a clear error instead of hanging on "Finishing sign in".
- **Patch-only webhook sync** — it never creates rows (can't race onboarding or clobber app-owned fields); `User.Deleted` handled via its real payload shape (`data: null`, id in `params.userId`).
- Unit tests (callback, config, react, webhooks) and runnable examples: Vite, TanStack Router SPA, TanStack Start (SSR), Next.js App Router + an RBAC demo.

### Also

- `AGENTS.md`: tighten the release rule to forbid local `changeset version` / `pnpm version-packages` / `npm publish`, not just hand-edits.

> Note: Convex's OIDC verifier accepts only RS256/EdDSA; Logto signs with ES384 by default. Tenants must rotate their OIDC signing key to RSA or `getUserIdentity()` returns `null` (documented in the package README and docs site).
