### PR TITLE
docs: per-framework setup with tabbed code; surface examples

### DIFF
--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -75,7 +75,7 @@ config from the backend via `configQuery`, so the frontend carries none.
 | `client` | yes | Your `ConvexReactClient`. |
 | `configQuery` | yes | Ref to the `logtoConfigQuery()` export, e.g. `api.logto.config`. |
 | `afterSignIn` | — | Where to go once sign-in completes. Default `/`. |
-| `navigate` | — | Soft navigation (your router's `navigate`). Falls back to a hard redirect. |
+| `navigate` | — | Soft navigation (your router's `navigate`). Optional for plain Vite; **recommended for any router** (TanStack / Next) so post-sign-in is a soft navigation rather than a full-page reload that drops router state. Falls back to a hard redirect. |
 | `scopes` / `resources` | — | Extra OIDC scopes / API resources. `openid`, `profile`, `offline_access`, and `email` are always included. |
 
 Safe to render on the server: while config loads, children render under Convex's

--- a/docs/content/docs/how-it-works.mdx
+++ b/docs/content/docs/how-it-works.mdx
@@ -17,10 +17,10 @@ a JWKS URL.
 There is one catch. Convex's OIDC verifier accepts only **RS256** and **EdDSA**
 signatures, but Logto signs with **ES384** by default — and a mismatched
 signature is rejected silently: sign-in completes, yet `getUserIdentity()`
-returns `null`. The fix is a one-time, tenant-level key rotation: Logto Console →
-**Tenant settings → OIDC configs** → **OIDC private keys** → **Rotate private
-key** → choose **RSA**. Logto keeps the old key during a transition, so existing
-sessions stay signed in. After rotating, the discovery document advertises
+returns `null`. The fix is a one-time, tenant-level key rotation: in the Logto Console, open
+**Tenant settings → OIDC configs**, click **Rotate private keys**, and choose
+**RSA** as the signing algorithm. Logto keeps the old key during a transition, so
+existing sessions stay signed in. After rotating, the discovery document advertises
 `RS256` and Convex accepts the token.
 
 ## Refresh via offline_access
@@ -40,4 +40,7 @@ sign-in / sign-out actions use `window`), but that's the only boundary.
 
 ## ESM-only `convex-logto/react`
 
-The `convex-logto/react` entry is ESM-only (so is its `@logto/react` peer).
+The `convex-logto/react` entry is ESM-only (so is its `@logto/react` peer). This
+is a non-issue for Vite, Next.js, and TanStack (all ESM); it would only bite a
+CommonJS (`require`) consumer. The root `convex-logto` (server) entry stays dual
+ESM + CJS.

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -44,3 +44,25 @@ pnpm add convex-logto @logto/react
 - [API reference](/docs/api-reference) — every export and its signature.
 - [How it works](/docs/how-it-works) — why the ID token, and why there's no JWT
   config.
+- [Examples](https://github.com/Fanzzzd/convex-logto/tree/main/examples) — runnable
+  apps for Vite, TanStack Router / Start, and Next.js.
+
+## Examples
+
+Runnable apps you can copy from — each wires the same package for a different
+framework:
+
+<Cards>
+  <Card title="Vite + React" href="https://github.com/Fanzzzd/convex-logto/tree/main/examples/vite-react">
+    Minimal setup: one provider + declarative auth gating.
+  </Card>
+  <Card title="TanStack Router (SPA)" href="https://github.com/Fanzzzd/convex-logto/tree/main/examples/tanstack-router-spa">
+    Route guards in beforeLoad, plus a webhook-synced users table with RBAC.
+  </Card>
+  <Card title="TanStack Start (SSR)" href="https://github.com/Fanzzzd/convex-logto/tree/main/examples/tanstack-start">
+    One SSR-safe provider + beforeLoad route guards.
+  </Card>
+  <Card title="Next.js App Router" href="https://github.com/Fanzzzd/convex-logto/tree/main/examples/nextjs">
+    Client provider boundary + callback route.
+  </Card>
+</Cards>

--- a/docs/content/docs/quick-start.mdx
+++ b/docs/content/docs/quick-start.mdx
@@ -5,6 +5,10 @@ description: Wire Logto auth into your Convex React app end to end, in six steps
 
 Everything below is copy-pasteable; work top to bottom and your Convex functions will see a signed-in user.
 
+<Callout>
+Steps 4 and 5 differ by framework — pick yours in the tabs, and the choice follows you down the page.
+</Callout>
+
 ## Install
 
 ```bash
@@ -35,9 +39,9 @@ so remember to add both.
 **Required — use an RSA signing key.** Convex only accepts ID tokens signed with
 **RS256** (or EdDSA). Logto signs with **ES384** by default, which Convex
 silently rejects: sign-in looks like it works, but `ctx.auth.getUserIdentity()`
-returns `null`. Rotate the key once per tenant — Logto Console → **Tenant
-settings → OIDC configs** → **OIDC private keys** → **Rotate private key** →
-choose **RSA** → rotate. Logto keeps the old key during a transition, so existing
+returns `null`. Rotate the key once per tenant — in the Logto Console, open **Tenant
+settings → OIDC configs**, click **Rotate private keys**, and choose **RSA** as
+the signing algorithm. Logto keeps the old key during a transition, so existing
 sessions stay signed in.
 
 ## 2. Set the config on your Convex deployment (only place needed)
@@ -66,7 +70,12 @@ export const config = logtoConfigQuery();
 
 ## 4. Wrap your app
 
-The frontend carries **no Logto config** — it asks the backend:
+The frontend carries **no Logto config** — it asks the backend. Where the provider
+lives, the env var name, and whether you pass `navigate` depend on your framework:
+
+<Tabs groupId="framework" persist items={['Vite', 'TanStack Router', 'TanStack Start', 'Next.js']}>
+
+<Tab value="Vite">
 
 ```tsx title="src/main.tsx"
 import { ConvexReactClient } from "convex/react";
@@ -82,15 +91,138 @@ root.render(
 );
 ```
 
+Full app: [`examples/vite-react`](https://github.com/Fanzzzd/convex-logto/tree/main/examples/vite-react).
+
+</Tab>
+
+<Tab value="TanStack Router">
+
+```tsx title="src/main.tsx"
+const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL);
+
+root.render(
+  <ConvexLogtoProvider
+    client={convex}
+    configQuery={api.logto.config}
+    navigate={(to) => void router.navigate({ to })}
+  >
+    <RouterProvider router={router} />
+  </ConvexLogtoProvider>,
+);
+```
+
+Pass `navigate` so post-sign-in is a soft router navigation, not a full reload.
+Full app: [`examples/tanstack-router-spa`](https://github.com/Fanzzzd/convex-logto/tree/main/examples/tanstack-router-spa).
+
+</Tab>
+
+<Tab value="TanStack Start">
+
+One SSR-safe provider — the same one you'd use in a SPA, no client boundary needed.
+
+```tsx title="src/router.tsx"
+const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL);
+
+<ConvexLogtoProvider
+  client={convex}
+  configQuery={api.logto.config}
+  navigate={(to) => void router.navigate({ to })}
+>
+  <RouterProvider router={router} />
+</ConvexLogtoProvider>;
+```
+
+Full app: [`examples/tanstack-start`](https://github.com/Fanzzzd/convex-logto/tree/main/examples/tanstack-start).
+
+</Tab>
+
+<Tab value="Next.js">
+
+The provider uses hooks and `window`, so it lives in a `"use client"` component;
+`app/layout.tsx` stays a Server Component and just renders it.
+
+```tsx title="app/providers.tsx"
+"use client";
+import { ConvexReactClient } from "convex/react";
+import { ConvexLogtoProvider } from "convex-logto/react";
+import { useRouter } from "next/navigation";
+import { api } from "../convex/_generated/api";
+
+const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  return (
+    <ConvexLogtoProvider
+      client={convex}
+      configQuery={api.logto.config}
+      navigate={(to) => router.push(to)}
+    >
+      {children}
+    </ConvexLogtoProvider>
+  );
+}
+```
+
+Note `NEXT_PUBLIC_CONVEX_URL` — not `import.meta.env`.
+Full app: [`examples/nextjs`](https://github.com/Fanzzzd/convex-logto/tree/main/examples/nextjs).
+
+</Tab>
+
+</Tabs>
+
 ## 5. Add a callback route
 
-The provider finishes the OIDC code exchange automatically — the route just
-needs to render. With TanStack Router:
+`signIn()` lands on `/callback`. The provider finishes the OIDC code exchange
+automatically — the route just needs to render. Wire it the way your framework routes:
+
+<Tabs groupId="framework" persist items={['Vite', 'TanStack Router', 'TanStack Start', 'Next.js']}>
+
+<Tab value="Vite">
+
+No router — render a callback view when the path matches:
+
+```tsx title="src/App.tsx"
+if (window.location.pathname === "/callback") return <p>Finishing sign in…</p>;
+```
+
+</Tab>
+
+<Tab value="TanStack Router">
+
+```tsx title="src/router.tsx"
+const callbackRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/callback",
+  component: () => <p>Finishing sign in…</p>,
+});
+```
+
+</Tab>
+
+<Tab value="TanStack Start">
 
 ```tsx title="src/routes/callback.tsx"
 import { createFileRoute } from "@tanstack/react-router";
-export const Route = createFileRoute("/callback")({ component: () => null });
+export const Route = createFileRoute("/callback")({
+  component: () => <p>Finishing sign in…</p>,
+});
 ```
+
+</Tab>
+
+<Tab value="Next.js">
+
+```tsx title="app/callback/page.tsx"
+// Server Component — the provider in app/providers.tsx finishes the exchange.
+export default function CallbackPage() {
+  return <p>Finishing sign in…</p>;
+}
+```
+
+</Tab>
+
+</Tabs>
 
 ## 6. Sign in, and read the user
 

--- a/docs/src/components/mdx.tsx
+++ b/docs/src/components/mdx.tsx
@@ -1,9 +1,14 @@
 import defaultMdxComponents from "fumadocs-ui/mdx";
+import { Tab, Tabs } from "fumadocs-ui/components/tabs";
 import type { MDXComponents } from "mdx/types";
 
+// `defaultMdxComponents` provides Card/Callout/etc. but not Tabs/Tab — register
+// them globally so every MDX page can use <Tabs>/<Tab> without a per-file import.
 export function getMDXComponents(components?: MDXComponents): MDXComponents {
   return {
     ...defaultMdxComponents,
+    Tab,
+    Tabs,
     ...components,
   };
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,5 +10,8 @@ Each is a standalone app — see its README to run it.
 | [`tanstack-start`](./tanstack-start) | TanStack Start (SSR): one SSR-safe provider + `beforeLoad` route guards. |
 | [`nextjs`](./nextjs) | Next.js App Router: client provider boundary + callback route. |
 
+> The webhook user-sync and RBAC shown in `tanstack-router-spa` are **framework-agnostic** —
+> the `convex/` backend code is identical everywhere, so a Vite or Next.js app wires them the same way.
+
 In this monorepo each example depends on the package via `convex-logto: workspace:*`.
 Standalone, install it from npm: `npm i convex-logto @logto/react`.

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -15,7 +15,7 @@ Convex backend via `api.logto.config`.
    - **Redirect URI** → `http://localhost:3000/callback`
    - **Post sign-out redirect URI** → `http://localhost:3000`
 
-   Also rotate the tenant's OIDC signing key to **RSA** (Tenant settings → OIDC configs → rotate private key → RSA). Convex rejects Logto's default ES384, so this is required; otherwise `getUserIdentity()` returns `null`. Note its **endpoint** and **App ID** for the next step.
+   Also rotate the tenant's OIDC signing key to **RSA** (Tenant settings → OIDC configs → **Rotate private keys** → choose RSA). Convex rejects Logto's default ES384, so this is required; otherwise `getUserIdentity()` returns `null`. Note its **endpoint** and **App ID** for the next step.
 4. Point that deployment at your Logto app:
    ```bash
    npx convex env set LOGTO_ENDPOINT https://auth.example.com
@@ -38,3 +38,6 @@ Convex backend via `api.logto.config`.
   `next/navigation`.
 - **The callback route** (`app/callback/page.tsx`) is a plain Server Component (no
   `"use client"` needed) that just renders; the provider finishes the OIDC exchange.
+
+> **Want webhook user-sync?** It's framework-agnostic — the `convex/` backend code is
+> identical across examples. See the [`tanstack-router-spa`](../tanstack-router-spa) example.

--- a/examples/tanstack-router-spa/README.md
+++ b/examples/tanstack-router-spa/README.md
@@ -13,7 +13,7 @@ All three ways to use auth: declarative `<Authenticated>` gating, the `useLogtoA
    - **Redirect URI** → `http://localhost:5173/callback`
    - **Post sign-out redirect URI** → `http://localhost:5173`
 
-   Also rotate the tenant's OIDC signing key to **RSA** (Tenant settings → OIDC configs → rotate private key → RSA). Convex rejects Logto's default ES384, so this is required; otherwise `getUserIdentity()` returns `null`. Note its **endpoint** and **App ID** for the next step.
+   Also rotate the tenant's OIDC signing key to **RSA** (Tenant settings → OIDC configs → **Rotate private keys** → choose RSA). Convex rejects Logto's default ES384, so this is required; otherwise `getUserIdentity()` returns `null`. Note its **endpoint** and **App ID** for the next step.
 4. Point that deployment at your Logto app — the one place config lives:
    ```bash
    npx convex env set LOGTO_ENDPOINT https://your-logto.example.com

--- a/examples/tanstack-start/README.md
+++ b/examples/tanstack-start/README.md
@@ -18,7 +18,7 @@ reading auth from router context.
    - **Redirect URI** → `http://localhost:3000/callback`
    - **Post sign-out redirect URI** → `http://localhost:3000`
 
-   Also rotate the tenant's OIDC signing key to **RSA** (Tenant settings → OIDC configs → rotate private key → RSA). Convex rejects Logto's default ES384, so this is required; otherwise `getUserIdentity()` returns `null`. Note its **endpoint** and **App ID** for the next step.
+   Also rotate the tenant's OIDC signing key to **RSA** (Tenant settings → OIDC configs → **Rotate private keys** → choose RSA). Convex rejects Logto's default ES384, so this is required; otherwise `getUserIdentity()` returns `null`. Note its **endpoint** and **App ID** for the next step.
 4. Point that deployment at your Logto app — the one place config lives:
    ```bash
    npx convex env set LOGTO_ENDPOINT https://your-logto.example.com

--- a/examples/vite-react/README.md
+++ b/examples/vite-react/README.md
@@ -13,7 +13,7 @@ The smallest working setup: one provider, and Convex's `<Authenticated>` / `<Una
    - **Redirect URI** → `http://localhost:5173/callback`
    - **Post sign-out redirect URI** → `http://localhost:5173`
 
-   Also rotate the tenant's OIDC signing key to **RSA** (Tenant settings → OIDC configs → rotate private key → RSA). Convex rejects Logto's default ES384, so this is required; otherwise `getUserIdentity()` returns `null`. Note its **endpoint** and **App ID** for the next step.
+   Also rotate the tenant's OIDC signing key to **RSA** (Tenant settings → OIDC configs → **Rotate private keys** → choose RSA). Convex rejects Logto's default ES384, so this is required; otherwise `getUserIdentity()` returns `null`. Note its **endpoint** and **App ID** for the next step.
 4. Point that deployment at your Logto app — the one place config lives:
    ```bash
    npx convex env set LOGTO_ENDPOINT https://your-logto.example.com

--- a/packages/convex-logto/README.md
+++ b/packages/convex-logto/README.md
@@ -22,6 +22,11 @@ pnpm add convex-logto @logto/react
 
 ## Quick start
 
+The snippets below use **Vite**. For the exact env var, provider placement, and
+callback wiring for each framework — Vite, TanStack Router, TanStack Start, and
+Next.js — see the [Next.js note](#nextjs-note) and the runnable
+[examples](https://github.com/Fanzzzd/convex-logto/tree/main/examples).
+
 ### 1. Create a Logto app
 
 In Logto Console → **Applications** → **Create application** → under **Single page app** pick your framework (e.g. **React**) — **not** a **Third-party app**. A third-party app is for letting *other people's* apps sign in through your Logto; it withholds the `profile` / `email` scopes this package requests, so sign-in fails with `invalid_scope`. The app type can't be changed after creation.
@@ -33,7 +38,7 @@ Note the **endpoint** (e.g. `https://auth.example.com`) and the **App ID**, and 
 
 `signIn()` returns to the redirect URI and `signOut()` to the post-sign-out URI, so remember to add both.
 
-**Required — use an RSA signing key.** Convex only accepts ID tokens signed with **RS256** (or EdDSA); Logto signs with **ES384** by default, which Convex silently rejects (sign-in looks fine, but `ctx.auth.getUserIdentity()` returns `null`). Rotate it once per tenant: Logto Console → **Tenant settings → OIDC configs** → **OIDC private keys** → **Rotate private key** → choose **RSA**. Logto keeps the old key during a transition, so existing sessions stay signed in.
+**Required — use an RSA signing key.** Convex only accepts ID tokens signed with **RS256** (or EdDSA); Logto signs with **ES384** by default, which Convex silently rejects (sign-in looks fine, but `ctx.auth.getUserIdentity()` returns `null`). Rotate it once per tenant: in the Logto Console, open **Tenant settings → OIDC configs**, click **Rotate private keys**, and choose **RSA** as the signing algorithm. Logto keeps the old key during a transition, so existing sessions stay signed in.
 
 ### 2. Set the config on your Convex deployment (only place needed)
 

--- a/packages/convex-logto/src/react.tsx
+++ b/packages/convex-logto/src/react.tsx
@@ -181,7 +181,11 @@ export type ConvexLogtoProviderProps = {
   resources?: string[];
   /** Where to go once sign-in completes. Default `/`. */
   afterSignIn?: string;
-  /** Soft navigation (e.g. your router's navigate). Falls back to a hard redirect. */
+  /**
+   * Soft navigation (e.g. your router's navigate). Optional for plain Vite;
+   * recommended for any router (TanStack/Next) so post-sign-in is a soft nav,
+   * not a full reload that drops router state. Falls back to a hard redirect.
+   */
   navigate?: (to: string) => void;
   children: ReactNode;
 };


### PR DESCRIPTION
## Summary

Make the docs explicit for **every** supported framework. The docs were a single generic track that silently assumed Vite + TanStack (`import.meta.env.VITE_CONVEX_URL` and a `createFileRoute` callback in the core Quick start), so a Next.js or plain-Vite developer had to reverse-engineer their env var, provider placement, callback wiring, and `navigate` need — and the examples were nearly unlinked from the docs.

Following Better Auth's pattern: core pages + **per-framework tabbed code**.

### Changes

- **Quick start** Steps 4–5 use Fumadocs `<Tabs groupId="framework" persist>` across **Vite / TanStack Router / TanStack Start / Next.js** — each tab gives the exact env var (`VITE_` vs `NEXT_PUBLIC_`), provider placement (incl. the Next `"use client"` boundary), callback wiring, and `navigate` prop, and links to its runnable example. The choice syncs across the page and persists across visits.
- **Register `Tabs`/`Tab`** in `docs/src/components/mdx.tsx` — `defaultMdxComponents` provides Card/Callout but **not** Tabs/Tab (verified against `fumadocs-ui`; caught by a failing `docs build`).
- **index**: a `<Cards>` grid surfacing the four examples + an Examples entry in "Where to next".
- **`navigate` prop**: documented as recommended for any router (TanStack/Next), not merely optional (`api-reference.mdx` + `react.tsx` JSDoc).
- **Smaller**: ESM-only practical-impact note; README Vite-default callout; webhook-sync framework-agnostic note in examples; **RSA rotation path aligned with the current Logto docs** ("Tenant settings → OIDC configs → Rotate private keys → RSA") across docs + all example READMEs.

### Verification

- `pnpm --filter docs build` — 8 pages prerender, Tabs/Cards compile (a missing-`Tab` error surfaced first and was fixed by registering the component).
- `pnpm exec turbo run format:check check-types build test --filter=convex-logto` — green (24 tests; the `react.tsx` change is JSDoc-only).
- **No version change / no changeset** — docs + JSDoc + README only, so merging does not publish.

### Not included (follow-up)

- Regression test for the SSR-safe `LoadingLogtoClient` mount (review nice-to-have).
- React Native / Expo support (the next milestone).
