### PR TITLE
docs+test: cover native API in reference; lock down webhook route contract

### DIFF
--- a/.changeset/readme-native-install.md
+++ b/.changeset/readme-native-install.md
@@ -1,0 +1,8 @@
+---
+"convex-logto": patch
+---
+
+Docs: the README install command now covers React Native / Expo. The npm front
+page only showed `pnpm add convex-logto @logto/react`, which installs the wrong
+Logto peer for native apps — they need `@logto/rn`. Added a one-line note pointing
+native users at `@logto/rn` (everything else is identical). No code change.

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: API reference
-description: Every export from convex-logto and convex-logto/react, with signatures.
+description: Every export from convex-logto, convex-logto/react, and convex-logto/native, with signatures.
 ---
 
 ## Exports
@@ -14,6 +14,8 @@ description: Every export from convex-logto and convex-logto/react, with signatu
 | `verifyLogtoSignature(key, body, sig)` | `convex-logto` | Low-level signature check, for custom routing. |
 | `ConvexLogtoProvider` | `convex-logto/react` | Logto + Convex + auto sign-in callback in one provider. Pulls Logto config from the backend via `configQuery`. |
 | `useLogtoAuth()` | `convex-logto/react` | `{ isAuthenticated, isLoading, user, signIn, signOut }`. |
+| `ConvexLogtoProvider` | `convex-logto/native` | React Native / Expo provider (on `@logto/rn`). Same `configQuery` model; no callback route. |
+| `useLogtoAuth()` | `convex-logto/native` | Native `{ isAuthenticated, isLoading, user, signIn, signOut }`; `signOut()` takes no argument. |
 
 ## Backend
 
@@ -92,4 +94,44 @@ Returns `{ isAuthenticated, isLoading, user, signIn, signOut }`.
 
 ```tsx
 const { isAuthenticated, isLoading, user, signIn, signOut } = useLogtoAuth();
+```
+
+## Native (`convex-logto/native`)
+
+For React Native / Expo, built on [`@logto/rn`](https://github.com/logto-io/react-native).
+The backend exports above are identical — only the frontend provider differs. Full
+walkthrough in [React Native (Expo)](/docs/react-native).
+
+### `ConvexLogtoProvider` (native)
+
+Wires Logto to Convex on native: pulls `{ endpoint, appId }` from the backend via
+`configQuery`. There is **no callback route** — `signIn` opens the system browser and
+resolves when the deep link returns.
+
+```tsx
+<ConvexLogtoProvider
+  client={convex}
+  configQuery={api.logto.config}
+  redirectUri="io.logto://callback"
+>
+  <App />
+</ConvexLogtoProvider>
+```
+
+| Prop | Required | Purpose |
+| --- | --- | --- |
+| `client` | yes | Your `ConvexReactClient`. |
+| `configQuery` | yes | Ref to the `logtoConfigQuery()` export, e.g. `api.logto.config`. |
+| `redirectUri` | **yes** | Native callback URI — your `app.json` `scheme` plus a path (e.g. `io.logto://callback`), registered on the Logto app. The default for `signIn()`. |
+| `fallback` | — | Rendered during the one-time config fetch, before the Convex provider mounts. Default `null`. |
+| `scopes` / `resources` | — | Extra OIDC scopes / API resources. `openid`, `profile`, `offline_access`, and `email` are always included. |
+
+### `useLogtoAuth()` (native)
+
+Returns `{ isAuthenticated, isLoading, user, signIn, signOut }`. `signIn(redirectUri?)`
+defaults to the provider's `redirectUri`; **`signOut()` takes no argument** — on native
+it revokes the tokens and clears local storage (no browser / federated sign-out).
+
+```tsx
+const { isAuthenticated, user, signIn, signOut } = useLogtoAuth();
 ```

--- a/docs/content/docs/webhook-sync.mdx
+++ b/docs/content/docs/webhook-sync.mdx
@@ -127,18 +127,39 @@ export default http;
 
 ## 4. Create the webhook in Logto
 
-Logto Console → **Webhooks** → new webhook pointed at
-`<your-convex-site-url>/logto/webhook` (your Convex **HTTP Actions** URL, e.g.
-`https://happy-otter-123.convex.site/logto/webhook`). Subscribe to the events you
-handle — `User.Data.Updated`, `User.SuspensionStatus.Updated`, and `User.Deleted` —
-then copy the **Signing key**, the one Logto value that _is_ a secret:
+Logto Console → **Webhooks** → **Create webhook**, pointed at
+`<your-convex-site-url>/logto/webhook`. That's your Convex **HTTP Actions** URL —
+the `.convex.site` one, **not** `.convex.cloud` — e.g.
+`https://happy-otter-123.convex.site/logto/webhook`. Find it in the Convex dashboard
+on your deployment's **Settings** page (it lists both URLs); each deployment has its
+own, so use the dev URL while developing and the prod URL in production.
+
+Under the **Data mutation** events, subscribe to the ones you handle —
+`User.Data.Updated`, `User.SuspensionStatus.Updated`, and `User.Deleted`. Subscribing
+to `User.Created` as well is harmless: with no handler mapped for it the route just
+answers `200` and does nothing — new rows come from your authenticated mutation
+(section 2), not the webhook.
+
+Then copy the **Signing key**, the one Logto value that _is_ a secret:
 
 ```bash
 npx convex env set LOGTO_WEBHOOK_SIGNING_KEY <signing-key>
 ```
 
-The signature is verified with Web Crypto (HMAC-SHA256) inside the Convex runtime;
-bad signatures get a 401.
+The signature is verified with Web Crypto (HMAC-SHA256) inside the Convex runtime.
+
+**Confirm it's wired.** The definitive check is a real event: change a test user's
+profile in Logto (fires `User.Data.Updated`), then watch your Convex logs
+(dashboard → **Logs**, or `npx convex logs`) for `POST /logto/webhook`. Logto's
+**Send test payload** button is a quick reachability check too — though it sends a
+synthetic payload, so read the status it gets back rather than expecting a `200`:
+
+| Status | Meaning |
+| --- | --- |
+| `200` | Verified and dispatched to your `sync` mutation. |
+| `400` | Body wasn't valid JSON, or wasn't a recognized `User.*` event. |
+| `401` | Signature didn't match — wrong (or unset) `LOGTO_WEBHOOK_SIGNING_KEY`. |
+| `500` | `LOGTO_WEBHOOK_SIGNING_KEY` isn't set on the deployment. |
 
 ## RBAC
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,4 +15,7 @@ Each is a standalone app — see its README to run it.
 > the `convex/` backend code is identical everywhere, so a Vite, Next.js, or Expo app wires them the same way.
 
 In this monorepo each example depends on the package via `convex-logto: workspace:*`.
-Standalone, install it from npm: `npm i convex-logto @logto/react`.
+Standalone, install it from npm with the Logto peer for your platform:
+
+- Web (Vite / Next.js / TanStack): `npm i convex-logto @logto/react`
+- React Native / Expo: `npm i convex-logto @logto/rn` (plus the Expo modules — see the [`expo`](./expo) README)

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,9 +9,10 @@ Each is a standalone app — see its README to run it.
 | [`tanstack-router-spa`](./tanstack-router-spa) | TanStack Router (SPA): declarative gating + `beforeLoad` route guards (auth outside render), **plus a webhook-synced users table with role-based access (RBAC)**. |
 | [`tanstack-start`](./tanstack-start) | TanStack Start (SSR): one SSR-safe provider + `beforeLoad` route guards. |
 | [`nextjs`](./nextjs) | Next.js App Router: client provider boundary + callback route. |
+| [`expo`](./expo) | Expo (React Native): native auth via `convex-logto/native` — deep-link sign-in, no callback route. |
 
 > The webhook user-sync and RBAC shown in `tanstack-router-spa` are **framework-agnostic** —
-> the `convex/` backend code is identical everywhere, so a Vite or Next.js app wires them the same way.
+> the `convex/` backend code is identical everywhere, so a Vite, Next.js, or Expo app wires them the same way.
 
 In this monorepo each example depends on the package via `convex-logto: workspace:*`.
 Standalone, install it from npm: `npm i convex-logto @logto/react`.

--- a/packages/convex-logto/README.md
+++ b/packages/convex-logto/README.md
@@ -18,7 +18,9 @@ It uses Logto's **ID token** over OIDC, so Convex auto-discovers the signing key
 pnpm add convex-logto @logto/react
 ```
 
-`convex` and `react` are peers you already have.
+`convex` and `react` are peers you already have. For **React Native / Expo**, install
+`@logto/rn` in place of `@logto/react` — everything else is the same (see
+[React Native / Expo](#react-native--expo)).
 
 ## Quick start
 

--- a/packages/convex-logto/src/webhooks.test.ts
+++ b/packages/convex-logto/src/webhooks.test.ts
@@ -1,6 +1,7 @@
 import { createHmac } from "node:crypto";
-import { describe, expect, it } from "vitest";
-import { verifyLogtoSignature } from "./webhooks";
+import type { HttpRouter } from "convex/server";
+import { describe, expect, it, vi } from "vitest";
+import { registerLogtoWebhook, verifyLogtoSignature } from "./webhooks";
 
 const signingKey = "whsec_test_signing_key_1234567890";
 const body = JSON.stringify({
@@ -26,6 +27,16 @@ describe("verifyLogtoSignature", () => {
         signingKey,
         body,
         sign(signingKey, body).toUpperCase(),
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts a valid signature with surrounding whitespace (trimmed)", async () => {
+    expect(
+      await verifyLogtoSignature(
+        signingKey,
+        body,
+        `  ${sign(signingKey, body)}\n`,
       ),
     ).toBe(true);
   });
@@ -66,5 +77,112 @@ describe("verifyLogtoSignature", () => {
 
   it("rejects an empty signature", async () => {
     expect(await verifyLogtoSignature(signingKey, body, "")).toBe(false);
+  });
+
+  it("rejects a too-short hex signature", async () => {
+    expect(await verifyLogtoSignature(signingKey, body, "abc123")).toBe(false);
+  });
+
+  it("rejects a 64-char signature with a non-hex character", async () => {
+    // Same length as a real digest, so only the hex-shape guard can reject it.
+    const nonHex = `g${sign(signingKey, body).slice(1)}`;
+    expect(await verifyLogtoSignature(signingKey, body, nonHex)).toBe(false);
+  });
+});
+
+// The handler registered via `http.route` is an `httpActionGeneric` wrapper;
+// convex attaches the raw `(ctx, request) => Response` function as `._handler`,
+// which lets us assert the route's status-code contract without a Convex runtime.
+type RouteHandler = (
+  ctx: { runMutation: (ref: unknown, args: unknown) => Promise<unknown> },
+  request: Request,
+) => Promise<Response>;
+
+function captureWebhookRoute(options?: {
+  path?: string;
+  signingKey?: string;
+}): RouteHandler {
+  let registered: { handler?: { _handler?: RouteHandler } } | undefined;
+  const http = {
+    route: (route: { handler?: { _handler?: RouteHandler } }) => {
+      registered = route;
+    },
+  } as unknown as HttpRouter;
+  // `sync` is only forwarded to `ctx.runMutation`; an opaque ref is enough here.
+  registerLogtoWebhook(http, {} as never, options);
+  const handler = registered?.handler?._handler;
+  if (!handler) throw new Error("webhook route handler was not captured");
+  return handler;
+}
+
+const post = (signature: string, payload: string) =>
+  new Request("http://convex.test/logto/webhook", {
+    method: "POST",
+    headers: signature ? { "logto-signature-sha-256": signature } : {},
+    body: payload,
+  });
+
+describe("registerLogtoWebhook route", () => {
+  it("returns 500 when the signing key is empty/unset", async () => {
+    const handler = captureWebhookRoute({ signingKey: "" });
+    const runMutation = vi.fn();
+    const res = await handler(
+      { runMutation },
+      post(sign(signingKey, body), body),
+    );
+    expect(res.status).toBe(500);
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 on a bad signature, without dispatching", async () => {
+    const handler = captureWebhookRoute({ signingKey });
+    const runMutation = vi.fn();
+    const res = await handler(
+      { runMutation },
+      post(sign("wrong_key", body), body),
+    );
+    expect(res.status).toBe(401);
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on a malformed JSON body (valid signature)", async () => {
+    const handler = captureWebhookRoute({ signingKey });
+    const malformed = "{not json";
+    const runMutation = vi.fn();
+    const res = await handler(
+      { runMutation },
+      post(sign(signingKey, malformed), malformed),
+    );
+    expect(res.status).toBe(400);
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on an unknown event (valid signature)", async () => {
+    const handler = captureWebhookRoute({ signingKey });
+    const unknown = JSON.stringify({
+      event: "Organization.Created",
+      data: { id: "org_1" },
+    });
+    const runMutation = vi.fn();
+    const res = await handler(
+      { runMutation },
+      post(sign(signingKey, unknown), unknown),
+    );
+    expect(res.status).toBe(400);
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 and dispatches the parsed payload on a valid delivery", async () => {
+    const handler = captureWebhookRoute({ signingKey });
+    const runMutation = vi.fn().mockResolvedValue(null);
+    const res = await handler(
+      { runMutation },
+      post(sign(signingKey, body), body),
+    );
+    expect(res.status).toBe(200);
+    expect(runMutation).toHaveBeenCalledTimes(1);
+    expect(runMutation).toHaveBeenCalledWith(expect.anything(), {
+      payload: expect.objectContaining({ event: "User.Created" }),
+    });
   });
 });

--- a/packages/convex-logto/src/webhooks.test.ts
+++ b/packages/convex-logto/src/webhooks.test.ts
@@ -1,5 +1,5 @@
 import { createHmac } from "node:crypto";
-import type { HttpRouter } from "convex/server";
+import { httpRouter } from "convex/server";
 import { describe, expect, it, vi } from "vitest";
 import { registerLogtoWebhook, verifyLogtoSignature } from "./webhooks";
 
@@ -90,9 +90,12 @@ describe("verifyLogtoSignature", () => {
   });
 });
 
-// The handler registered via `http.route` is an `httpActionGeneric` wrapper;
-// convex attaches the raw `(ctx, request) => Response` function as `._handler`,
-// which lets us assert the route's status-code contract without a Convex runtime.
+// `registerLogtoWebhook` calls `http.route` with an `httpActionGeneric` wrapper.
+// We register it on a real `httpRouter()` and resolve it back with `http.lookup`
+// — the same path + method matching Convex's runtime uses — so a route registered
+// at the wrong path or method fails these tests, not just a status-code regression.
+// Convex attaches the raw `(ctx, request) => Response` as `._handler`, which lets
+// us drive the handler directly without a Convex runtime.
 type RouteHandler = (
   ctx: { runMutation: (ref: unknown, args: unknown) => Promise<unknown> },
   request: Request,
@@ -102,15 +105,16 @@ function captureWebhookRoute(options?: {
   path?: string;
   signingKey?: string;
 }): RouteHandler {
-  let registered: { handler?: { _handler?: RouteHandler } } | undefined;
-  const http = {
-    route: (route: { handler?: { _handler?: RouteHandler } }) => {
-      registered = route;
-    },
-  } as unknown as HttpRouter;
+  const http = httpRouter();
   // `sync` is only forwarded to `ctx.runMutation`; an opaque ref is enough here.
   registerLogtoWebhook(http, {} as never, options);
-  const handler = registered?.handler?._handler;
+  const path = options?.path ?? "/logto/webhook";
+  const match = http.lookup(path, "POST");
+  if (!match) throw new Error(`no POST route registered at ${path}`);
+  // Bracket access: `_handler` is convex's internal, not part of its public type.
+  const handler = (match[0] as unknown as Record<string, RouteHandler>)[
+    "_handler"
+  ];
   if (!handler) throw new Error("webhook route handler was not captured");
   return handler;
 }
@@ -184,5 +188,18 @@ describe("registerLogtoWebhook route", () => {
     expect(runMutation).toHaveBeenCalledWith(expect.anything(), {
       payload: expect.objectContaining({ event: "User.Created" }),
     });
+  });
+
+  it("honors a custom path and dispatches there", async () => {
+    // captureWebhookRoute looks up this exact path, so it already asserts the
+    // `path` option is wired through; confirm the handler then works end-to-end.
+    const handler = captureWebhookRoute({ signingKey, path: "/hooks/logto" });
+    const runMutation = vi.fn().mockResolvedValue(null);
+    const res = await handler(
+      { runMutation },
+      post(sign(signingKey, body), body),
+    );
+    expect(res.status).toBe(200);
+    expect(runMutation).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
A second review pass (after 0.3.1), this time focused on **tests** and **examples/docs accuracy** — areas the first pass didn't deeply cover. Two source-grounded agents reviewed; both confirmed the source + the recent native changes (signOut/redirectUri/fallback/RSA/env vars/links) are accurate. Three concrete gaps were worth closing:

### Docs drift (I'd introduced these adding the native entry)
- **`api-reference.mdx` was web-only** — no `convex-logto/native`. A native user checking the reference for the **required** `redirectUri`, `fallback`, or the no-arg native `signOut()` found nothing. Added a native section (provider prop table + native `useLogtoAuth`).
- **`examples/README.md` listed 4 of 5 examples** — missing the Expo row. Added.

### Test coverage (security boundary)
- **`registerLogtoWebhook`'s HTTP contract was untested.** The unit `verifyLogtoSignature` was well covered, but nothing verified the *route* returns **401 on a bad signature (and never dispatches)**, 500 on no key, 400 on malformed/unknown bodies, 200 + dispatch on a valid one. Added all five via the handler's raw `._handler` seam (no convex-test infra needed). Also added `verifyLogtoSignature` malformed-hex / whitespace-trim edges. **24 → 32 tests.**

### Consciously deferred (reported, not built — to stay simple)
- A **native bridge unit test** (signIn-redirect-throw, forceRefreshToken sequence) would need new `vi.mock('@logto/rn')` + renderer infra; the example already typechecks against the real native API and the logic mirrors the SSR-tested web bridge. Worth a follow-up if desired.
- The `logtoConfigQuery` 'lazy' test is mildly weak (asserts `toBeDefined` rather than invoking the handler); config coverage is otherwise strong.

Docs + tests only — **no changeset, no release.** Verified: pkg gate (lint/check-types/build/lint:package) green, 32 tests pass, docs build green.