### PR TITLE
fix: hold loading across sign-in so the logged-out tick can't bounce guards (#11)

### DIFF
--- a/.changeset/fix-callback-loading-window.md
+++ b/.changeset/fix-callback-loading-window.md
@@ -1,0 +1,25 @@
+---
+"convex-logto": patch
+---
+
+Fix a transient `{ isLoading: false, isAuthenticated: false }` window right after
+sign-in that made `useLogtoAuth()` look logged-out while Convex was still
+validating the freshly-issued ID token. A TanStack Router `beforeLoad` guard (or
+any auth gate that acts on that tick) would redirect the just-signed-in user away
+— and bounce into an infinite loop if the sign-in route auto-restarts `signIn()`
+(issue #11).
+
+Both entries are fixed:
+
+- **Web (`convex-logto/react`):** the bridge keeps reporting `isLoading: true`
+  while a sign-in callback is in flight (an unconsumed `code` in the URL and Logto
+  not yet authenticated), so guards wait the validation window out instead of
+  seeing a state indistinguishable from a clean logout.
+- **Native (`convex-logto/native`):** `@logto/rn` flips `isAuthenticated` true the
+  instant `signIn()` resolves, with no loading signal of its own. The bridge now
+  emits one loading frame on that transition — reported as not-yet-authenticated —
+  so Convex resets cleanly to "validating" instead of surfacing the logged-out
+  tick, with no auth churn once the token validates.
+
+Post-login token refreshes still don't flicker the identity, and a genuine
+logged-out visit still settles to signed-out as before.

--- a/docs/content/docs/auth-in-your-app.mdx
+++ b/docs/content/docs/auth-in-your-app.mdx
@@ -165,7 +165,9 @@ A few things make this robust:
 
 - **Check `isLoading` first.** `isAuthenticated` is `false` while auth is still
   settling, so without the `if (context.auth.isLoading) return` you'd redirect a
-  signed-in user on every reload.
+  signed-in user on every reload — and bounce a just-returned user mid sign-in
+  callback. The bridge keeps `isLoading` `true` across that whole validation
+  window, so the guard waits instead of redirecting.
 - **The `router.invalidate()` effect is required** — it's what re-runs the guard
   when auth resolves. Depend on `[auth.isLoading, auth.isAuthenticated]`.
 - **Give the route a `pendingComponent`** (with `defaultPendingMs: 0`) so the

--- a/packages/convex-logto/src/auth-loading.test.ts
+++ b/packages/convex-logto/src/auth-loading.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { nativeAuthState, nextAuthLoading } from "./auth-loading";
+import { classifySignInSearch } from "./callback";
+
+// The whole point of both helpers: the bridge must never report
+// `{ isLoading:false, isAuthenticated:false }` (a settled logged-out state) during
+// the window between "IdP authenticated" and "Convex validated" — that frame is
+// what Convex turns into the transient tick that bounced route guards (issue #11).
+
+describe("nextAuthLoading — web latch (issue #11)", () => {
+  // Drive a scripted @logto/react sequence through the latch; track reported loading.
+  function reportLoading(
+    steps: Array<{ providerLoading: boolean; authFlowPending: boolean }>,
+  ): boolean[] {
+    let settled = false;
+    return steps.map((s) => {
+      const next = nextAuthLoading(
+        settled,
+        s.providerLoading,
+        s.authFlowPending,
+      );
+      settled = next.settled;
+      return next.isLoading;
+    });
+  }
+
+  it("holds loading across the /callback?code= exchange, no logged-out tick", () => {
+    // Frames on a callback landing: boot → settles-but-not-authed *before* the
+    // exchange (the old early-latch trap) → exchange → authed → soft-nav home.
+    const code = "?code=abc&state=xyz";
+    const pending = (search: string, isAuthenticated: boolean) =>
+      !isAuthenticated && classifySignInSearch(search).kind === "pending";
+    const loading = reportLoading([
+      { providerLoading: true, authFlowPending: pending(code, false) },
+      { providerLoading: false, authFlowPending: pending(code, false) }, // ← old bug latched here
+      { providerLoading: true, authFlowPending: pending(code, false) },
+      { providerLoading: false, authFlowPending: pending(code, true) }, // authed
+      { providerLoading: false, authFlowPending: pending("", true) }, // soft-navved home
+    ]);
+    expect(loading).toEqual([true, true, true, false, false]);
+  });
+
+  it("settles to not-loading for a genuine logged-out visit (nothing pending)", () => {
+    expect(nextAuthLoading(false, true, false)).toEqual({
+      settled: false,
+      isLoading: true,
+    }); // still booting
+    expect(nextAuthLoading(false, false, false)).toEqual({
+      settled: true,
+      isLoading: false,
+    }); // settled signed-out
+  });
+
+  it("does not flicker once settled (post-login provider-loading churn)", () => {
+    // Authenticated and settled; @logto/react blips providerLoading true. The latch
+    // holds — we keep reporting not-loading instead of dropping back to loading.
+    expect(nextAuthLoading(true, true, false)).toEqual({
+      settled: true,
+      isLoading: false,
+    });
+  });
+});
+
+describe("nativeAuthState — native transition pulse (issue #11)", () => {
+  // [isInitialized, isAuthenticated, seenAuthenticated] over a sign-in.
+  const seq: Array<[boolean, boolean, boolean]> = [
+    [false, false, false], // booting (!isInitialized)
+    [true, false, false], // initialized, logged out
+    [true, true, false], // signIn just resolved: auth-flip render (seen lags)
+    [true, true, true], // settled: effect committed seenAuthenticated
+  ];
+
+  it("pulses exactly one loading frame on the auth flip, reported NOT authenticated", () => {
+    const frames = seq.map(([init, auth, seen]) =>
+      nativeAuthState(init, auth, seen),
+    );
+    expect(frames).toEqual([
+      { isLoading: true, isAuthenticated: false }, // boot
+      { isLoading: false, isAuthenticated: false }, // logged out (real state)
+      { isLoading: true, isAuthenticated: false }, // pulse: loading, NOT yet authed
+      { isLoading: false, isAuthenticated: true }, // settled authed
+    ]);
+    // The auth-flip frame (index 2) reports loading, not a logged-out tick: a guard
+    // sees loading and waits instead of bouncing the just-signed-in user.
+    expect(frames[2]).toEqual({ isLoading: true, isAuthenticated: false });
+  });
+
+  it("never reports authenticated while loading (no churn-causing frame)", () => {
+    for (const [init, auth, seen] of [
+      [false, true, false],
+      [true, true, false],
+      [false, false, true],
+    ] as Array<[boolean, boolean, boolean]>) {
+      const f = nativeAuthState(init, auth, seen);
+      if (f.isLoading) expect(f.isAuthenticated).toBe(false);
+    }
+  });
+
+  it("re-arms after logout so the next login pulses again", () => {
+    // signed out from an authed state: isAuthenticated false, seen still true.
+    expect(nativeAuthState(true, false, true)).toEqual({
+      isLoading: false,
+      isAuthenticated: false,
+    });
+    // next login flip: seen back to false → pulses loading again.
+    expect(nativeAuthState(true, true, false)).toEqual({
+      isLoading: true,
+      isAuthenticated: false,
+    });
+  });
+});

--- a/packages/convex-logto/src/auth-loading.ts
+++ b/packages/convex-logto/src/auth-loading.ts
@@ -1,0 +1,75 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Loading-state latch for the Logto→Convex auth bridge — shared by the web
+ * (`react.tsx`) and native (`native.tsx`) entries.
+ *
+ * `authFlowPending` means "a sign-in handshake is underway and the IdP has not
+ * authenticated yet" (web: a `/callback?code=` exchange in flight; native: a
+ * `signIn()` in flight). While it's true we keep reporting `isLoading: true`, so
+ * Convex's `ConvexProviderWithAuth` holds its internal auth state at `null`
+ * (validating) instead of pinning it to `false` (logged out). That pin is what
+ * produced a transient `{ isLoading: false, isAuthenticated: false }` — read by
+ * route guards as a clean logout — right after the IdP authenticated but before
+ * Convex validated the token (issue #11).
+ *
+ * `settled` latches on the first non-loading, non-pending render and stays true,
+ * which also rides out the `isLoading` churn `@logto/react` emits around every
+ * SDK call after login (native's `@logto/rn` has no such churn, so there the
+ * latch is just harmless consistency).
+ */
+export function nextAuthLoading(
+  prevSettled: boolean,
+  providerLoading: boolean,
+  authFlowPending: boolean,
+): { settled: boolean; isLoading: boolean } {
+  const settled = prevSettled || (!providerLoading && !authFlowPending);
+  return { settled, isLoading: !settled || authFlowPending };
+}
+
+/**
+ * Native (`@logto/rn`) auth state for the Convex bridge.
+ *
+ * Native has no `isLoading` churn and flips `isAuthenticated` straight to true the
+ * instant `signIn()` resolves — and with Convex's auth pinned `false` from being
+ * logged out, that flip surfaced the transient `{ isLoading:false,
+ * isAuthenticated:false }` tick (issue #11). There's no pre-auth signal to latch on
+ * (no `/callback` URL, no in-flight flag we can rely on across React scheduling), so
+ * instead we detect the transition: `seenAuthenticated` lags `isAuthenticated` by
+ * one committed render, so `isAuthenticated && !seenAuthenticated` is true on exactly
+ * the render Logto first authenticates.
+ *
+ * On that one render we report loading — but as **not-yet-authenticated**. That makes
+ * Convex reset its pinned `false` to `null` (validating) without starting `setAuth()`
+ * during the loading pulse, so the settled frame does a single clean validation
+ * instead of a `clearAuth()`+`setAuth()` churn cycle. The returned `isAuthenticated`
+ * is therefore never true while loading — there's never a `{ loading:true, auth:true }`
+ * frame.
+ */
+export function nativeAuthState(
+  isInitialized: boolean,
+  isAuthenticated: boolean,
+  seenAuthenticated: boolean,
+): { isLoading: boolean; isAuthenticated: boolean } {
+  const isLoading = !isInitialized || (isAuthenticated && !seenAuthenticated);
+  return { isLoading, isAuthenticated: isAuthenticated && !isLoading };
+}
+
+/**
+ * The native bridge's loading state (`native.tsx`), as a hook so it's unit-testable
+ * without mocking `@logto/rn`. `seenAuthenticated` is state, not a ref, so committing
+ * it drives the settle re-render after the one-frame loading pulse (see
+ * `nativeAuthState`). The effect only writes when the value actually changes, so it
+ * converges in one extra render and never loops.
+ */
+export function useNativeAuthState(
+  isInitialized: boolean,
+  isAuthenticated: boolean,
+): { isLoading: boolean; isAuthenticated: boolean } {
+  const [seenAuthenticated, setSeenAuthenticated] = useState(false);
+  useEffect(() => {
+    if (seenAuthenticated !== isAuthenticated)
+      setSeenAuthenticated(isAuthenticated);
+  }, [isAuthenticated, seenAuthenticated]);
+  return nativeAuthState(isInitialized, isAuthenticated, seenAuthenticated);
+}

--- a/packages/convex-logto/src/native.tsx
+++ b/packages/convex-logto/src/native.tsx
@@ -19,6 +19,7 @@ import {
   useMemo,
   useState,
 } from "react";
+import { useNativeAuthState } from "./auth-loading";
 import type { LogtoConfigQueryRef, LogtoPublicConfig } from "./config";
 
 /**
@@ -26,15 +27,22 @@ import type { LogtoConfigQueryRef, LogtoPublicConfig } from "./config";
  * expects — the React Native counterpart of `useAuthFromLogto` in `react.tsx`.
  *
  * `@logto/rn` exposes `getIdToken()` (the raw JWT Convex validates) just like the
- * web SDK, but differs in two ways the bridge accounts for:
- *   - it has no `isLoading`; `isInitialized` is a one-way false→true latch, so we
- *     map `isLoading: !isInitialized` directly (no "settle latch" needed on web);
+ * web SDK, but differs in ways the bridge accounts for:
+ *   - it has no `isLoading` churn; `isInitialized` is a one-way false→true latch;
+ *   - it flips `isAuthenticated` true the instant `signIn()` resolves, so we feed a
+ *     one-render loading pulse on that transition via `useNativeAuthState` (#11);
  *   - it has no top-level `clearAccessToken`, so the force-refresh path reaches it
  *     through the underlying `client` (`@logto/client`'s `LogtoClient`).
  */
 function useAuthFromLogto() {
   const { isAuthenticated, isInitialized, getIdToken, getAccessToken, client } =
     useLogto();
+
+  // One loading frame on the render Logto first authenticates, reported as
+  // not-yet-authenticated, so Convex resets cleanly instead of surfacing the
+  // logged-out tick (issue #11; see `useNativeAuthState`).
+  const { isLoading, isAuthenticated: reportedAuthenticated } =
+    useNativeAuthState(isInitialized, isAuthenticated);
 
   const fetchAccessToken = useCallback(
     async ({ forceRefreshToken }: { forceRefreshToken: boolean }) => {
@@ -57,8 +65,12 @@ function useAuthFromLogto() {
   );
 
   return useMemo(
-    () => ({ isLoading: !isInitialized, isAuthenticated, fetchAccessToken }),
-    [isInitialized, isAuthenticated, fetchAccessToken],
+    () => ({
+      isLoading,
+      isAuthenticated: reportedAuthenticated,
+      fetchAccessToken,
+    }),
+    [isLoading, reportedAuthenticated, fetchAccessToken],
   );
 }
 

--- a/packages/convex-logto/src/react.tsx
+++ b/packages/convex-logto/src/react.tsx
@@ -19,6 +19,7 @@ import {
   useMemo,
   useState,
 } from "react";
+import { nextAuthLoading } from "./auth-loading";
 import { type SignInOutcome, classifySignInSearch } from "./callback";
 import type { LogtoConfigQueryRef, LogtoPublicConfig } from "./config";
 
@@ -34,13 +35,24 @@ function useAuthFromLogto() {
     clearAccessToken,
   } = useLogto();
 
+  // A `/callback?code=` exchange is in flight: the SDK has the code but hasn't
+  // authenticated yet. Hold `isLoading` true through it so Convex never sees a
+  // transient logged-out tick that route guards mistake for a sign-out (#11).
+  const search = typeof window === "undefined" ? "" : window.location.search;
+  const authFlowPending =
+    !isAuthenticated && classifySignInSearch(search).kind === "pending";
+
   // `@logto/react` toggles `isLoading` around every SDK call; forwarding that to
-  // Convex creates a token-fetch ↔ loading feedback loop that flickers the
-  // identity. Latch on the first settle and ignore the churn after.
+  // Convex flickers the identity. Latch on the first settle and ignore the churn.
   const [settled, setSettled] = useState(false);
+  const { settled: shouldSettle, isLoading: reportedLoading } = nextAuthLoading(
+    settled,
+    isLoading,
+    authFlowPending,
+  );
   useEffect(() => {
-    if (!isLoading) setSettled(true);
-  }, [isLoading]);
+    if (shouldSettle) setSettled(true);
+  }, [shouldSettle]);
 
   const fetchAccessToken = useCallback(
     async ({ forceRefreshToken }: { forceRefreshToken: boolean }) => {
@@ -63,8 +75,8 @@ function useAuthFromLogto() {
   );
 
   return useMemo(
-    () => ({ isLoading: !settled, isAuthenticated, fetchAccessToken }),
-    [settled, isAuthenticated, fetchAccessToken],
+    () => ({ isLoading: reportedLoading, isAuthenticated, fetchAccessToken }),
+    [reportedLoading, isAuthenticated, fetchAccessToken],
   );
 }
 


### PR DESCRIPTION
## Problem

Closes #11. Right after sign-in, `useLogtoAuth()` briefly reported `{ isLoading: false, isAuthenticated: false }` while Convex was still validating the freshly-issued ID token — indistinguishable from a clean logout. A TanStack Router `beforeLoad` guard (or any auth gate acting on that tick) redirected the just-signed-in user away, and a sign-in route that auto-restarts `signIn()` turned it into an infinite `/callback`↔`/signin` loop. The same bug class affected **both** the web (`/react`) and native (`/native`) entries.

## Fix

All loading logic now lives in one internal module, `src/auth-loading.ts` (not exported from the public `/react` or `/native` types):

- **Web** (`react.tsx`): hold `isLoading: true` while a `/callback?code=` exchange is in flight (`classifySignInSearch(search).kind === "pending"` and not yet authenticated), then latch `settled` to ignore `@logto/react`'s post-login `isLoading` churn.
- **Native** (`native.tsx`): `@logto/rn` flips `isAuthenticated` true the instant `signIn()` resolves with no loading signal of its own, so `useNativeAuthState` detects that transition and emits **one** loading frame reported as *not-yet-authenticated* — Convex resets its pinned `false` → `null` (validating) without a `clearAuth()` + `setAuth()` churn cycle.

Web uses a URL signal native lacks; the divergence is intentional and correct.

## Verification

- New unit tests in `auth-loading.test.ts` pin both #11 frame sequences.
- Web fix verified end-to-end against a live Logto sign-in: buggy build = 22 callback hits/loop; fixed build = 1 callback → authenticated home.
- Full gate green: `check-types`, `test` (39 passing), `lint`, `format:check`, `build`, `lint:package`.
- Independent adversarial review (Codex) on the final diff: all checks PASS — no setAuth churn, no infinite loop, no auth-before-validation, no raw-Logto leak.