### PR TITLE
fix: resolve /callback hang on a stale or already-authenticated callback URL (#14)

### DIFF
--- a/.changeset/fix-callback-stale-url-hang.md
+++ b/.changeset/fix-callback-stale-url-hang.md
@@ -1,0 +1,7 @@
+---
+"convex-logto": patch
+---
+
+Fix the Logto sign-in callback hanging forever on a stale or already-authenticated `/callback` URL.
+
+`ConvexLogtoProvider` decided "a code exchange is in progress, keep waiting" purely from the URL (`?code=&state=`), but `@logto/react` only runs the exchange when `!isAuthenticated && isSignInRedirected(url)`. Re-opening an already-consumed callback URL — by refresh, Back button, or a bookmark, most often while already signed in — left the page stuck on the loading state with no navigation, because the SDK's exchange callback never fires. The provider now resolves the callback from the SDK's observable auth state (with a timeout safety net for a lost sign-in session) instead of waiting for an exchange that will never happen (#14).

--- a/packages/convex-logto/src/callback.test.ts
+++ b/packages/convex-logto/src/callback.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { classifySignInSearch } from "./callback";
+import { callbackResolved, classifySignInSearch } from "./callback";
 
 describe("classifySignInSearch", () => {
   it("ignores URLs without a `state` param (not a sign-in redirect)", () => {
@@ -52,5 +52,33 @@ describe("classifySignInSearch", () => {
       expect(outcome.message).toContain("server_error");
       expect(outcome.message).not.toContain("Single-page app");
     }
+  });
+});
+
+describe("callbackResolved (#14: a /callback URL must never wait forever)", () => {
+  it("keeps waiting only while not authenticated and not timed out", () => {
+    // The genuine in-flight exchange: hold the page until one signal arrives.
+    expect(callbackResolved({ isAuthenticated: false, timedOut: false })).toBe(
+      false,
+    );
+  });
+
+  it("resolves as soon as the client is authenticated", () => {
+    // Covers BOTH a successful first-time exchange (SDK flips this true as it
+    // finishes) AND a stale/replayed callback URL where the user is already
+    // authenticated and no exchange — hence no SDK callback — will ever run.
+    expect(callbackResolved({ isAuthenticated: true, timedOut: false })).toBe(
+      true,
+    );
+  });
+
+  it("resolves on the timeout safety net even if never authenticated", () => {
+    // The rare lost-session case: no exchange, no error, no auth — leave anyway.
+    expect(callbackResolved({ isAuthenticated: false, timedOut: true })).toBe(
+      true,
+    );
+    expect(callbackResolved({ isAuthenticated: true, timedOut: true })).toBe(
+      true,
+    );
   });
 });

--- a/packages/convex-logto/src/callback.ts
+++ b/packages/convex-logto/src/callback.ts
@@ -42,3 +42,23 @@ export function classifySignInSearch(search: string): SignInOutcome {
   // A successful redirect carries both `code` and `state`.
   return params.has("code") ? { kind: "pending" } : { kind: "none" };
 }
+
+/**
+ * Should a `/callback` landing stop waiting and return to the app? The URL only
+ * tells us a redirect *looks* pending; `@logto/react` actually exchanges the code
+ * only when `!isAuthenticated && isSignInRedirected(url)`. When that's false — the
+ * user is already authenticated (a stale/replayed callback URL), or the sign-in
+ * session was lost — the exchange never runs and its callback never fires, so we
+ * must resolve from observable state instead of waiting forever (#14):
+ *
+ * - `isAuthenticated`: covers both a successful exchange (the SDK flips it true as
+ *   it finishes) AND an already-authenticated replay (true on entry, no exchange).
+ * - `timedOut`: the rare `!isAuthenticated && !isSignInRedirected` case (no session,
+ *   no error ever arrives) — a safety net so the page can't spin indefinitely.
+ */
+export function callbackResolved(state: {
+  isAuthenticated: boolean;
+  timedOut: boolean;
+}): boolean {
+  return state.isAuthenticated || state.timedOut;
+}

--- a/packages/convex-logto/src/react.tsx
+++ b/packages/convex-logto/src/react.tsx
@@ -17,13 +17,25 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { nextAuthLoading } from "./auth-loading";
-import { type SignInOutcome, classifySignInSearch } from "./callback";
+import {
+  type SignInOutcome,
+  callbackResolved,
+  classifySignInSearch,
+} from "./callback";
 import type { LogtoConfigQueryRef, LogtoPublicConfig } from "./config";
 
 const CALLBACK_PATH = "/callback";
+
+// Safety net for a `/callback` URL that will never exchange and never error (the
+// sign-in session was lost): after this long, give up waiting and return to the
+// app rather than spinning forever. A real exchange resolves in well under this
+// (the SDK flips `isAuthenticated` as it finishes), so this only bites the rare
+// stuck case. See {@link callbackResolved} and #14.
+const STALE_CALLBACK_TIMEOUT_MS = 10_000;
 
 /** Bridges Logto's ID token into the `useAuth` shape `ConvexProviderWithAuth` expects. */
 function useAuthFromLogto() {
@@ -126,24 +138,27 @@ function LogtoCallback({
         : classifySignInSearch(window.location.search),
     [],
   );
-  // This component renders on every route, so once the exchange succeeds we latch
-  // it finished and unmount <CodeExchange> — otherwise it lingers off `/callback`,
-  // keeping the SDK's callback hook alive over an already-consumed code.
-  const [exchanged, setExchanged] = useState(false);
+  // This component renders on every route and `outcome` is frozen at mount, so once
+  // the callback resolves we latch it done and unmount <CodeExchange> — otherwise it
+  // lingers off `/callback`, keeping the SDK's callback hook alive over a spent code.
+  const [done, setDone] = useState(false);
 
   useEffect(() => {
     // The user cancelled / there was no session — just return to the app.
-    if (outcome.kind === "benign") goAfterSignIn();
+    if (outcome.kind === "benign") {
+      setDone(true);
+      goAfterSignIn();
+    }
   }, [outcome, goAfterSignIn]);
 
   if (outcome.kind === "error")
     throw new Error(`convex-logto: ${outcome.message}`);
   // Only a real `?code=` callback runs the token exchange; benign/error redirects
   // never touch the SDK, so a cancelled sign-in can't poison the next one.
-  if (outcome.kind === "pending" && !exchanged)
+  if (outcome.kind === "pending" && !done)
     return (
       <CodeExchange
-        onExchanged={() => setExchanged(true)}
+        onDone={() => setDone(true)}
         goAfterSignIn={goAfterSignIn}
       />
     );
@@ -152,19 +167,46 @@ function LogtoCallback({
 
 /** Runs the code→token exchange for a real `/callback?code=…` landing. */
 function CodeExchange({
-  onExchanged,
+  onDone,
   goAfterSignIn,
 }: {
-  onExchanged: () => void;
+  onDone: () => void;
   goAfterSignIn: () => void;
 }) {
-  // Fires once when the code→token exchange succeeds: stop rendering this handler
-  // (so the spent code is never re-submitted), then continue into the app.
-  useHandleSignInCallback(() => {
-    onExchanged();
-    goAfterSignIn();
-  });
-  const { error } = useLogto();
+  const { isAuthenticated, isLoading, error } = useLogto();
+  // Rendering the hook is what makes @logto/react run the code→token exchange. We
+  // deliberately do NOT navigate from its callback: on a stale/replayed callback URL
+  // the SDK won't exchange (already authenticated, or the sign-in session is gone),
+  // so that callback never fires (#14). We resolve from observable state instead.
+  useHandleSignInCallback(() => {});
+
+  // Safety net for a callback that resolves on its own (lost session: no exchange,
+  // no error, never authenticated). Arm the countdown ONLY while the SDK is idle and
+  // unauthenticated — an in-flight exchange holds `isLoading` true, which cancels and
+  // re-arms the timer, so a slow-but-legit sign-in is never abandoned mid-exchange.
+  const [timedOut, setTimedOut] = useState(false);
+  useEffect(() => {
+    if (isAuthenticated || isLoading) return;
+    const timer = setTimeout(
+      () => setTimedOut(true),
+      STALE_CALLBACK_TIMEOUT_MS,
+    );
+    return () => clearTimeout(timer);
+  }, [isAuthenticated, isLoading]);
+
+  // Resolve once: a successful exchange flips `isAuthenticated` true, an
+  // already-authenticated replay is true on entry, and the timeout covers the rare
+  // lost-session case. Idempotent via the ref so overlapping signals don't double-fire.
+  const resolved = useRef(false);
+  useEffect(() => {
+    if (resolved.current) return;
+    if (callbackResolved({ isAuthenticated, timedOut })) {
+      resolved.current = true;
+      onDone();
+      goAfterSignIn();
+    }
+  }, [isAuthenticated, timedOut, onDone, goAfterSignIn]);
+
   // Surface a failed exchange instead of hanging the page on "finishing sign in".
   if (error) {
     throw new Error(

--- a/packages/convex-logto/src/webhooks.test-d.ts
+++ b/packages/convex-logto/src/webhooks.test-d.ts
@@ -1,0 +1,32 @@
+// Type-level coverage for `logtoSync`. Named `.test-d.ts` so `tsc --noEmit`
+// (the `check-types` script) type-checks it, while `vitest run` and the tsup
+// build both ignore it. The point: the `ctx as GenericMutationCtx<DataModel>`
+// cast inside logtoSync must keep `ctx.db` typed to the caller's DataModel —
+// a refactor that degrades it to `any` makes the @ts-expect-error below unused,
+// and `tsc` then fails.
+import { defineSchema, defineTable } from "convex/server";
+import type { DataModelFromSchemaDefinition } from "convex/server";
+import { v } from "convex/values";
+import { expectTypeOf } from "vitest";
+import { logtoSync } from "./webhooks";
+import type { LogtoUserEntity, LogtoWebhookPayload } from "./webhooks";
+
+// A concrete DataModel, shaped like a user's generated `convex/_generated/dataModel`.
+const schema = defineSchema({
+  users: defineTable({ authId: v.string() }).index("by_authId", ["authId"]),
+});
+type DataModel = DataModelFromSchemaDefinition<typeof schema>;
+
+logtoSync<DataModel>({
+  "User.Data.Updated": async (ctx, user, payload) => {
+    // A table in the DataModel is queryable...
+    void ctx.db.query("users");
+    // ...and one that isn't is a type error. If `ctx.db` ever degrades to `any`,
+    // this stops erroring and the directive goes unused → `tsc` fails.
+    // @ts-expect-error — "posts" is not a table in this DataModel
+    void ctx.db.query("posts");
+
+    expectTypeOf(user).toEqualTypeOf<LogtoUserEntity>();
+    expectTypeOf(payload).toEqualTypeOf<LogtoWebhookPayload>();
+  },
+});

--- a/packages/convex-logto/src/webhooks.test.ts
+++ b/packages/convex-logto/src/webhooks.test.ts
@@ -1,7 +1,11 @@
 import { createHmac } from "node:crypto";
 import { httpRouter } from "convex/server";
 import { describe, expect, it, vi } from "vitest";
-import { registerLogtoWebhook, verifyLogtoSignature } from "./webhooks";
+import {
+  logtoSync,
+  registerLogtoWebhook,
+  verifyLogtoSignature,
+} from "./webhooks";
 
 const signingKey = "whsec_test_signing_key_1234567890";
 const body = JSON.stringify({
@@ -201,5 +205,97 @@ describe("registerLogtoWebhook route", () => {
     );
     expect(res.status).toBe(200);
     expect(runMutation).toHaveBeenCalledTimes(1);
+  });
+});
+
+// `logtoSync` returns an internal mutation; Convex attaches the raw handler as
+// `._handler`, which lets us drive the dispatch logic directly with a fake ctx
+// (no Convex runtime). Type-level coverage of the `ctx.db` cast lives in
+// webhooks.test-d.ts (checked by `tsc`, not vitest).
+type SyncHandler = (
+  ctx: unknown,
+  args: { payload: unknown },
+) => Promise<unknown>;
+const callSync = (
+  sync: unknown,
+  ctx: unknown,
+  payload: unknown,
+): Promise<unknown> =>
+  // Bracket access: `_handler` is convex's internal, not part of its public type.
+  (sync as unknown as Record<string, SyncHandler>)["_handler"](ctx, {
+    payload,
+  });
+
+describe("logtoSync dispatch", () => {
+  it("dispatches an event to its handler with (ctx, user, payload)", async () => {
+    const seen: Array<{ ctx: unknown; user: unknown; payload: unknown }> = [];
+    const { sync } = logtoSync({
+      "User.Data.Updated": async (ctx, user, payload) => {
+        seen.push({ ctx, user, payload });
+      },
+    });
+    const ctx = { db: {} };
+    const payload = {
+      event: "User.Data.Updated",
+      hookId: "h",
+      createdAt: "t",
+      data: { id: "u1", primaryEmail: "a@b.com" },
+    };
+    await callSync(sync, ctx, payload);
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.ctx).toBe(ctx); // ctx forwarded verbatim (the `as` cast is identity at runtime)
+    expect(seen[0]?.user).toEqual({ id: "u1", primaryEmail: "a@b.com" });
+    expect(seen[0]?.payload).toBe(payload);
+  });
+
+  it("synthesizes { id } from params.userId for User.Deleted (data: null)", async () => {
+    let got: unknown;
+    const { sync } = logtoSync({
+      "User.Deleted": async (_ctx, user) => {
+        got = user;
+      },
+    });
+    await callSync(
+      sync,
+      { db: {} },
+      {
+        event: "User.Deleted",
+        hookId: "h",
+        createdAt: "t",
+        data: null,
+        params: { userId: "u2" },
+      },
+    );
+    expect(got).toEqual({ id: "u2" });
+  });
+
+  it("is a no-op (resolves null) when no handler is mapped for the event", async () => {
+    const { sync } = logtoSync({});
+    await expect(
+      callSync(
+        sync,
+        { db: {} },
+        {
+          event: "User.Created",
+          hookId: "h",
+          createdAt: "t",
+          data: { id: "u3" },
+        },
+      ),
+    ).resolves.toBeNull();
+  });
+
+  it("throws on a payload that isn't a known User.* event", async () => {
+    const { sync } = logtoSync({ "User.Created": async () => {} });
+    await expect(
+      callSync(
+        sync,
+        { db: {} },
+        {
+          event: "Organization.Created",
+          data: { id: "o1" },
+        },
+      ),
+    ).rejects.toThrow(/known Logto User\.\* event/);
   });
 });


### PR DESCRIPTION
## What

Fixes #14 — the Logto sign-in callback hanging forever on a stale or already-authenticated `/callback` URL.

## Why

`ConvexLogtoProvider` decided "a code exchange is in progress, keep waiting" purely from the URL (`?code=&state=`), but `@logto/react` only runs the exchange when `!isAuthenticated && isSignInRedirected(url)`. Re-opening an already-consumed callback URL — refresh, Back button, or a bookmark, most often **while already signed in** — left the page stuck on the loading state forever, because the SDK's exchange callback never fires.

This is the mirror of #11: that was "exchange in progress, reported as logged-out"; this is "no exchange will happen, but we wait for one anyway."

## How

`CodeExchange` still renders `useHandleSignInCallback` (that's what *drives* the exchange), but **navigation now resolves from the SDK's observable state** via a new pure helper `callbackResolved({ isAuthenticated, timedOut })` instead of waiting on the SDK success callback:

- **`isAuthenticated`** — covers a successful exchange (the SDK flips it true as it finishes) *and* the already-authenticated replay (true on entry, no exchange).
- **timeout safety net** (`STALE_CALLBACK_TIMEOUT_MS = 10s`) — covers the rare lost-session case (no exchange, no error). It is **gated on `!isLoading`**, so an in-flight exchange cancels/prevents it and a slow-but-legit sign-in is never abandoned mid-exchange.

Approach matches how Auth0 / MSAL / Supabase / WorkOS AuthKit (and the sibling `@convex-dev/workos-authkit`) handle the redirect: keep full automation, drive off SDK state. Native is unaffected (no callback route).

## Verification

- **Real-browser field test** (Playwright against a live Logto tenant): real sign-in lands authenticated; replaying the real `/callback?code=…&state=…` URL while signed in now recovers in ~30 ms (was an infinite hang on the old build); the lost-session variant recovers via the 10 s safety net; the old build reproducibly hung.
- New unit tests: `callbackResolved` resolution matrix.
- Two independent Codex reviews: the first caught the timer firing during a slow exchange (fixed by the `!isLoading` gate); the re-review verdict is **SHIP, findings none**.
- `lint` / `format:check` / `check-types` / `test` (46) / `build` / `lint:package` all green.

Also includes test-only coverage for `logtoSync` (dispatch + a `.test-d.ts` guard locking `ctx.db` inference), unrelated to the runtime fix.

Closes #14.
