### PR TITLE
fix: recover from a failed /callback exchange instead of throwing (no more blank-screen on stale callback)

### DIFF
--- a/.changeset/callback-stale-url-no-throw.md
+++ b/.changeset/callback-stale-url-no-throw.md
@@ -1,0 +1,9 @@
+---
+"convex-logto": patch
+---
+
+Don't crash the app on a stale or replayed `/callback` URL whose code exchange fails.
+
+When a sign-in session was still in storage (an abandoned or earlier sign-in) and the page landed on a stale/replayed `/callback?code=…&state=…` — a bookmark, the Back button, or a link from a previous deploy — `@logto/react` ran the exchange and it failed with a state mismatch. The provider surfaced that by **throwing during render**, which blanked any app whose error boundary sits inside `<ConvexLogtoProvider>` (or that has none).
+
+Following how `react-oidc-context` and `@auth0/auth0-react` handle the redirect callback, a failed exchange is now treated as recoverable, not fatal: it is logged (`console.error`) and the provider returns to the app — the user lands logged-out and can start sign-in again — instead of throwing. Genuine OIDC setup errors (an `error=` in the callback URL) still surface loudly as before.

--- a/packages/convex-logto/src/callback.test.ts
+++ b/packages/convex-logto/src/callback.test.ts
@@ -56,29 +56,52 @@ describe("classifySignInSearch", () => {
 });
 
 describe("callbackResolved (#14: a /callback URL must never wait forever)", () => {
-  it("keeps waiting only while not authenticated and not timed out", () => {
+  it("keeps waiting only while not authenticated, not timed out, and not errored", () => {
     // The genuine in-flight exchange: hold the page until one signal arrives.
-    expect(callbackResolved({ isAuthenticated: false, timedOut: false })).toBe(
-      false,
-    );
+    expect(
+      callbackResolved({
+        isAuthenticated: false,
+        timedOut: false,
+        errored: false,
+      }),
+    ).toBe(false);
   });
 
   it("resolves as soon as the client is authenticated", () => {
     // Covers BOTH a successful first-time exchange (SDK flips this true as it
     // finishes) AND a stale/replayed callback URL where the user is already
     // authenticated and no exchange — hence no SDK callback — will ever run.
-    expect(callbackResolved({ isAuthenticated: true, timedOut: false })).toBe(
-      true,
-    );
+    expect(
+      callbackResolved({
+        isAuthenticated: true,
+        timedOut: false,
+        errored: false,
+      }),
+    ).toBe(true);
   });
 
   it("resolves on the timeout safety net even if never authenticated", () => {
     // The rare lost-session case: no exchange, no error, no auth — leave anyway.
-    expect(callbackResolved({ isAuthenticated: false, timedOut: true })).toBe(
-      true,
-    );
-    expect(callbackResolved({ isAuthenticated: true, timedOut: true })).toBe(
-      true,
-    );
+    expect(
+      callbackResolved({
+        isAuthenticated: false,
+        timedOut: true,
+        errored: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("resolves (returns to the app) on a failed exchange instead of crashing", () => {
+    // A stale/replayed callback: the SDK ran the exchange and it failed (state
+    // mismatch / spent code / lost sign-in session). Must resolve, not throw —
+    // matching react-oidc-context / @auth0/auth0-react, which never crash the app
+    // on a callback failure. The provider logs it and returns to the app.
+    expect(
+      callbackResolved({
+        isAuthenticated: false,
+        timedOut: false,
+        errored: true,
+      }),
+    ).toBe(true);
   });
 });

--- a/packages/convex-logto/src/callback.ts
+++ b/packages/convex-logto/src/callback.ts
@@ -55,10 +55,16 @@ export function classifySignInSearch(search: string): SignInOutcome {
  *   it finishes) AND an already-authenticated replay (true on entry, no exchange).
  * - `timedOut`: the rare `!isAuthenticated && !isSignInRedirected` case (no session,
  *   no error ever arrives) — a safety net so the page can't spin indefinitely.
+ * - `errored`: the exchange ran and failed — a state mismatch on a stale/replayed
+ *   callback URL, a spent code, or a lost sign-in session. The popular auto-callback
+ *   providers (`react-oidc-context`, `@auth0/auth0-react`) put such a failure into
+ *   state and never throw during render, so a stale callback can't crash the app; we
+ *   mirror that by treating it as resolved (return to the app) rather than fatal.
  */
 export function callbackResolved(state: {
   isAuthenticated: boolean;
   timedOut: boolean;
+  errored: boolean;
 }): boolean {
-  return state.isAuthenticated || state.timedOut;
+  return state.isAuthenticated || state.timedOut || state.errored;
 }

--- a/packages/convex-logto/src/react.tsx
+++ b/packages/convex-logto/src/react.tsx
@@ -194,28 +194,34 @@ function CodeExchange({
     return () => clearTimeout(timer);
   }, [isAuthenticated, isLoading]);
 
-  // Resolve once: a successful exchange flips `isAuthenticated` true, an
-  // already-authenticated replay is true on entry, and the timeout covers the rare
-  // lost-session case. Idempotent via the ref so overlapping signals don't double-fire.
+  // Resolve once. Success flips `isAuthenticated`; an already-authenticated replay is
+  // true on entry; the timeout covers a silent lost session; and a failed exchange
+  // (`error`) is recoverable, not fatal. The popular auto-callback providers
+  // (react-oidc-context, @auth0/auth0-react) put a callback failure into state and
+  // never throw during render, so a stale/replayed `/callback` — state mismatch, spent
+  // code, lost sign-in session — can't crash the app. We mirror that: log it and return
+  // to the app (the user lands logged-out and can start sign-in again) rather than
+  // throwing, which would blank any tree not wrapped in an error boundary above the
+  // provider. Idempotent via the ref so overlapping signals don't double-fire.
   const resolved = useRef(false);
   useEffect(() => {
     if (resolved.current) return;
-    if (callbackResolved({ isAuthenticated, timedOut })) {
+    if (
+      callbackResolved({ isAuthenticated, timedOut, errored: error != null })
+    ) {
+      if (error)
+        console.error(
+          `convex-logto: completing Logto sign-in failed (${error.message}). ` +
+            `The callback URL was likely stale or the sign-in session was lost — ` +
+            `start sign-in again.`,
+          error,
+        );
       resolved.current = true;
       onDone();
       goAfterSignIn();
     }
-  }, [isAuthenticated, timedOut, onDone, goAfterSignIn]);
+  }, [error, isAuthenticated, timedOut, onDone, goAfterSignIn]);
 
-  // Surface a failed exchange instead of hanging the page on "finishing sign in".
-  if (error) {
-    throw new Error(
-      `convex-logto: completing Logto sign-in failed (${error.message}). ` +
-        `The callback URL was likely stale or the sign-in session was lost — ` +
-        `start sign-in again.`,
-      { cause: error },
-    );
-  }
   return null;
 }
 


### PR DESCRIPTION
## Problem (customer-reported, reproduced live)

A stale/replayed `/callback?code=…&state=…` URL — a bookmark, the Back button, or a link from a **previous deploy** — could **blank the whole app**, not just hang.

Root cause: `@logto/react`'s `isSignInRedirected()` only checks that a `signInSession` exists and the path matches the `redirectUri` — it does **not** verify code/state. So if a sign-in session was still in storage (an abandoned/earlier sign-in) and the page landed on a stale callback, the SDK ran the exchange, it failed with `State mismatched in the callback URI`, and `CodeExchange` **threw that error during render**. Any app whose error boundary sits inside `<ConvexLogtoProvider>` (or that has none) unmounts to a blank screen.

Reproduced in a real browser:
- ✅ revisit callback while authenticated → fine
- ✅ stale callback, no session → 10s timeout recovers (the #14 net)
- 💥 **lingering sign-in session + stale callback → `root` empty / blank crash**

## Fix — adopt the popular providers' approach

`react-oidc-context` and `@auth0/auth0-react` both run the redirect callback automatically and, on failure, **put the error in state and never throw during render** (then clean the URL). This PR mirrors that: a failed exchange is recoverable, not fatal — `CodeExchange` now **logs it (`console.error`) and returns to the app** (`goAfterSignIn`), where the user lands logged-out and can start sign-in again. Genuine OIDC setup errors (an `error=` in the URL) still surface loudly via `classifySignInSearch`.

The `errored` signal is folded into the pure `callbackResolved` helper (unit-tested).

## Verification

Same trigger that blanked the app on `0.3.4`, re-run against this build:
- `root` non-empty, navigates back to `/`, **`pageErrors: 0`** (crash gone)
- the `State mismatched` error now appears only in `console.error` (caught, not thrown)

`test` (48) / `check-types` / `lint` / `format:check` / `build` all green.