### PR TITLE
fix: remount LogtoProvider across loading→ready so a signIn during config load can't pin isLoading

### DIFF
--- a/.changeset/fix-stuck-login-loading.md
+++ b/.changeset/fix-stuck-login-loading.md
@@ -1,0 +1,5 @@
+---
+"convex-logto": patch
+---
+
+Fix the app hanging on a loading spinner when `signIn()` is called before the backend config has finished loading (the "stuck on the login button" symptom). During config load the provider mounts an inert Logto client; a `signIn()` in that window poisoned `@logto/react`'s `loadingCount` (its `signIn` increments but never resets, and the inert method never navigates away), and that count survived the swap to the real client — pinning `isLoading` true forever. The `LogtoProvider` is now remounted across the loading→ready transition, so any state built against the inert client is discarded.

--- a/packages/convex-logto/package.json
+++ b/packages/convex-logto/package.json
@@ -91,6 +91,7 @@
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.2.3",
     "convex": "^1.38.0",
+    "happy-dom": "^20.10.6",
     "oxfmt": "^0.54.0",
     "oxlint": "^1.69.0",
     "publint": "^0.3.21",

--- a/packages/convex-logto/src/react.loading-remount.test.tsx
+++ b/packages/convex-logto/src/react.loading-remount.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment happy-dom
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { useLogto } from "@logto/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { ConvexLogtoProvider } from "./react";
+
+// React's act() needs this flag when driven without a test-framework integration.
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+// The bug and its fix live entirely in this package's <LogtoProvider> keying, so we
+// stub Convex out — ConvexProviderWithAuth just renders children (keeping the probe
+// under the real <LogtoProvider>), and useConvexAuth is never reached in this path.
+vi.mock("convex/react", () => ({
+  ConvexProviderWithAuth: ({ children }: { children: unknown }) => children,
+  useConvexAuth: () => ({ isLoading: true, isAuthenticated: false }),
+}));
+
+// The "real" Logto client used once config is ready. isAuthenticated resolves false
+// (no network, no storage) so the provider's mount effect decrements loadingCount;
+// the rest is the minimal surface @logto/react may touch after the swap.
+vi.mock("@logto/browser", () => ({
+  default: class {
+    async isAuthenticated() {
+      return false;
+    }
+    async signIn() {}
+    async isSignInRedirected() {
+      return false;
+    }
+    async handleSignInCallback() {}
+    async getIdTokenClaims() {
+      return undefined;
+    }
+  },
+}));
+
+let captured: {
+  isLoading: boolean;
+  signIn: (uri: string) => Promise<void>;
+} | null = null;
+function Probe() {
+  const { isLoading, signIn } = useLogto();
+  captured = { isLoading, signIn };
+  return null;
+}
+
+afterEach(() => {
+  captured = null;
+});
+
+const flush = () => act(async () => void (await Promise.resolve()));
+
+// Regression for the "stuck on the login button" report: calling signIn() while the
+// inert loading-client is mounted poisons @logto/react's loadingCount (signIn never
+// resets it and the inert method doesn't navigate). That count is provider state, so
+// without remounting on the loading→ready swap it pins isLoading true forever. The
+// `key` on <LogtoProvider> drops it. Fails on the un-keyed provider, passes with it.
+it("recovers isLoading after a signIn during config load", async () => {
+  let resolveConfig!: (c: { endpoint: string; appId: string }) => void;
+  const configPromise = new Promise<{ endpoint: string; appId: string }>(
+    (r) => {
+      resolveConfig = r;
+    },
+  );
+  const fakeClient = { query: () => configPromise } as never;
+
+  const root = createRoot(document.createElement("div"));
+  await act(async () => {
+    root.render(
+      <ConvexLogtoProvider client={fakeClient} configQuery={"cfg" as never}>
+        <Probe />
+      </ConvexLogtoProvider>,
+    );
+  });
+
+  // Config still loading: the inert client holds isLoading true.
+  expect(captured?.isLoading).toBe(true);
+
+  // Poison: signIn while the inert client is up (a no-op that never navigates here).
+  await act(async () => {
+    await captured!.signIn("http://localhost/callback");
+  });
+  expect(captured?.isLoading).toBe(true);
+
+  // Config arrives → the keyed provider remounts with the real client, dropping the
+  // poisoned loadingCount, so isLoading must recover.
+  await act(async () => {
+    resolveConfig({
+      endpoint: "https://example.logto.app",
+      appId: "app1234567890",
+    });
+    await configPromise;
+  });
+  // Let the remount's mount effect run isAuthenticated() and decrement loadingCount.
+  for (let i = 0; i < 10; i++) await flush();
+
+  expect(captured?.isLoading).toBe(false);
+
+  await act(async () => {
+    root.unmount();
+  });
+});

--- a/packages/convex-logto/src/react.tsx
+++ b/packages/convex-logto/src/react.tsx
@@ -94,10 +94,10 @@ function useAuthFromLogto() {
 
 // An inert Logto client mounted only while the backend config loads. Its
 // `isAuthenticated()` never resolves, so @logto/react's loadingCount stays > 0 —
-// `isLoading` holds true and there's no signed-out flash — until the real client
-// swaps in once config arrives. A Proxy covers every method @logto/react binds,
-// and it touches no `window`, so the whole provider tree is safe to render on the
-// server (SSR) and during the first client paint.
+// `isLoading` holds true and there's no signed-out flash — until the provider
+// remounts with the real client once config arrives. A Proxy covers every method
+// @logto/react binds, and it touches no `window`, so the whole provider tree is safe
+// to render on the server (SSR) and during the first client paint.
 type LogtoClientClass = NonNullable<LogtoProviderProps["LogtoClientClass"]>;
 const pendingForever = new Promise<never>(() => {});
 const LoadingLogtoClient = function () {
@@ -275,7 +275,9 @@ export function ConvexLogtoProvider({
   children,
 }: ConvexLogtoProviderProps) {
   // One-shot fetch (config is per-deployment, fixed at runtime). Until it lands we
-  // mount the same tree with an inert client, so there's no remount when it does.
+  // mount the tree with an inert client; the LogtoProvider is keyed on loading→ready
+  // so it remounts when config arrives, dropping any @logto/react state built against
+  // the inert client (e.g. a loadingCount poisoned by a signIn during load).
   const [state, setState] = useState<ConfigState>({ status: "loading" });
 
   useEffect(() => {
@@ -322,6 +324,11 @@ export function ConvexLogtoProvider({
   const ready = state.status === "ready";
   return (
     <LogtoProvider
+      // Remount across loading→ready: a signIn called while the inert client is up
+      // poisons @logto/react's loadingCount (signIn never resets it and the inert
+      // method doesn't navigate), and that count is provider state that would survive
+      // an in-place client swap — pinning isLoading true forever. Keying drops it.
+      key={ready ? "ready" : "loading"}
       config={logtoConfig}
       {...(ready ? {} : { LogtoClientClass: LoadingLogtoClient })}
     >

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,7 +200,7 @@ importers:
         version: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
       vitest:
         specifier: ^3.2.6
-        version: 3.2.6(@edge-runtime/vm@5.0.0)(@types/debug@4.1.13)(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)
+        version: 3.2.6(@edge-runtime/vm@5.0.0)(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@20.10.6)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)
 
   examples/tanstack-start:
     dependencies:
@@ -305,6 +305,9 @@ importers:
       convex:
         specifier: ^1.38.0
         version: 1.41.0(react@19.2.7)
+      happy-dom:
+        specifier: ^20.10.6
+        version: 20.10.6
       oxfmt:
         specifier: ^0.54.0
         version: 0.54.0
@@ -328,7 +331,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.6(@edge-runtime/vm@5.0.0)(@types/debug@4.1.13)(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)
+        version: 3.2.6(@edge-runtime/vm@5.0.0)(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@20.10.6)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0)
 
 packages:
 
@@ -3235,6 +3238,12 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
 
@@ -3494,6 +3503,10 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -3877,6 +3890,10 @@ packages:
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
   env-runner@0.1.14:
@@ -4359,6 +4376,10 @@ packages:
     peerDependenciesMeta:
       crossws:
         optional: true
+
+  happy-dom@20.10.6:
+    resolution: {integrity: sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==}
+    engines: {node: '>=20.0.0'}
 
   has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
@@ -6391,6 +6412,10 @@ packages:
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   whatwg-url-minimum@0.1.2:
     resolution: {integrity: sha512-XPEm0XFQWNVG292lII1PrRRJl3sItrs7CettZ4ncYxuDVpLyy+NwlGyut2hXI0JswcJUxeCH+CyOJK0ZzAXD6A==}
 
@@ -6425,6 +6450,18 @@ packages:
 
   ws@8.20.1:
     resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -9563,6 +9600,12 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.21
+
   '@types/yargs-parser@21.0.3': {}
 
   '@types/yargs@17.0.35':
@@ -9798,7 +9841,7 @@ snapshots:
       react-refresh: 0.14.2
     optionalDependencies:
       '@babel/runtime': 7.29.7
-      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(typescript@5.8.3)
+      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.7(react@19.2.7))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -9850,6 +9893,10 @@ snapshots:
       node-int64: 0.4.0
 
   buffer-from@1.1.2: {}
+
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 22.19.21
 
   bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
@@ -10158,6 +10205,8 @@ snapshots:
 
   entities@6.0.1: {}
 
+  entities@7.0.1: {}
+
   env-runner@0.1.14:
     dependencies:
       crossws: 0.4.6(srvx@0.11.16)
@@ -10371,7 +10420,7 @@ snapshots:
 
   expo-crypto@56.0.4(expo@56.0.12):
     dependencies:
-      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(typescript@5.8.3)
+      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.7(react@19.2.7))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(typescript@5.9.3)
 
   expo-file-system@56.0.8(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7)):
     dependencies:
@@ -10399,7 +10448,7 @@ snapshots:
 
   expo-keep-awake@56.0.3(expo@56.0.12)(react@19.2.7):
     dependencies:
-      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(typescript@5.8.3)
+      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.7(react@19.2.7))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(typescript@5.9.3)
       react: 19.2.7
 
   expo-modules-autolinking@56.0.16(typescript@5.8.3):
@@ -10448,7 +10497,7 @@ snapshots:
 
   expo-secure-store@56.0.4(expo@56.0.12):
     dependencies:
-      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(typescript@5.8.3)
+      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.7(react@19.2.7))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(typescript@5.9.3)
 
   expo-server@56.0.5: {}
 
@@ -10788,6 +10837,19 @@ snapshots:
       srvx: 0.11.16
     optionalDependencies:
       crossws: 0.4.6(srvx@0.11.16)
+
+  happy-dom@20.10.6:
+    dependencies:
+      '@types/node': 22.19.21
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-flag@3.0.0: {}
 
@@ -13194,7 +13256,7 @@ snapshots:
     optionalDependencies:
       vite: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
 
-  vitest@3.2.6(@edge-runtime/vm@5.0.0)(@types/debug@4.1.13)(@types/node@22.19.21)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0):
+  vitest@3.2.6(@edge-runtime/vm@5.0.0)(@types/debug@4.1.13)(@types/node@22.19.21)(happy-dom@20.10.6)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.48.0)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
@@ -13223,6 +13285,7 @@ snapshots:
       '@edge-runtime/vm': 5.0.0
       '@types/debug': 4.1.13
       '@types/node': 22.19.21
+      happy-dom: 20.10.6
     transitivePeerDependencies:
       - jiti
       - less
@@ -13255,6 +13318,8 @@ snapshots:
 
   whatwg-fetch@3.6.20: {}
 
+  whatwg-mimetype@3.0.0: {}
+
   whatwg-url-minimum@0.1.2: {}
 
   whatwg-url@5.0.0:
@@ -13280,6 +13345,8 @@ snapshots:
   ws@7.5.11: {}
 
   ws@8.20.1: {}
+
+  ws@8.21.0: {}
 
   xcode@3.0.1:
     dependencies:


### PR DESCRIPTION
## The bug ("stuck on the login button")

While the backend config (`configQuery`) is loading, `ConvexLogtoProvider` mounts an **inert** Logto client so `isLoading` stays true (no signed-out flash). If app code calls `signIn()` during that window, the app hangs on a loading state forever.

**Mechanism** (confirmed against `@logto/react@4.0.14` source + a real-browser repro):
- `LogtoProvider` keeps `loadingCount` as **provider-level state**; the client-swap effect only ever decrements it once.
- `@logto/react` wraps `signIn` as `proxy(..., resetLoadingState=false)` — it increments `loadingCount` and **never** decrements (the real `signIn` normally navigates away). The inert `signIn` is a no-op that doesn't navigate.
- So a `signIn()` during load leaves `loadingCount` at 2; on the config→ready swap the same provider instance persists and the real-client effect decrements only once → `loadingCount` stuck at 1 → **`isLoading` pinned true forever**.

Only `signIn` poisons permanently (every other method uses `resetLoadingState=true` and self-heals). Reachable via the public `useLogtoAuth().signIn` with no `ready` gate — fits the original "click login does nothing / stuck on the login button" report (apps with an always-visible login button not gated on `isLoading`, or a mount-time auto-`signIn()`).

## The fix (one line)

```tsx
<LogtoProvider key={ready ? "ready" : "loading"} ...>
```

Keying the provider on the loading→ready transition **remounts** it, discarding the poisoned `@logto/react` state (`loadingCount`, `error`, `isAuthenticated`) at the exact boundary where the inert client becomes invalid. The remount is one-way and one-time; the `ConvexReactClient` is prop-owned and stable, and Convex hasn't authenticated during loading, so the remount is safe (no WS drop, no flash — children show the loading state during this window anyway).

Alternatives considered and rejected (after a discussion with Codex): gating `signIn` (partial — only covers our API path, and "drop vs queue" is a separate product call) and removing the inert client entirely (too broad — regresses the SSR/no-flash contract).

## Verification

- **Real-browser 3-way differential** (actual `@logto/react` + the exact inert client): control (no signIn) → `false`; current code + signIn-during-load → **stuck true**; keyed provider + same signIn → `false`.
- **Regression test** (`react.loading-remount.test.tsx`, happy-dom): fails on the un-keyed provider ("expected true to be false"), passes with the key.
- Full suite (48 tests), typecheck, lint, format:check, build, publint/attw all green.

Adds `happy-dom` as a devDep (needed for the effect-driven render test; the repo had no DOM test env). Changeset: patch.