### PR TITLE
feat: add same-site cookie transport for session mode

### DIFF
--- a/.changeset/lovely-brooms-lead.md
+++ b/.changeset/lovely-brooms-lead.md
@@ -1,0 +1,5 @@
+---
+"convex-logto": minor
+---
+
+Add an optional same-site HttpOnly cookie transport for session mode, including SSR seeding and Next.js, TanStack Start, and Convex HTTP action mounts.

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -114,8 +114,9 @@ The returned handler also has `getInitialToken(request)`. It returns
 `{ initialToken, initialSessionId, headers }`; call it at most once per incoming
 document request and always forward `headers` to the SSR response so the rotated
 `Set-Cookie` is not lost, then pass the two initial values to
-`ConvexLogtoSessionProvider`. Concurrent requests are best-effort: transient
-refresh contention returns an empty seed without clearing the cookie.
+`ConvexLogtoSessionProvider`. Concurrent requests are best-effort: every failed
+seed returns empty without changing the cookie, while the browser `/token` route
+authoritatively clears a genuinely dead session.
 
 ### `assertUserHasActiveSession(ctx, component)`
 

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -14,6 +14,10 @@ description: Every export from convex-logto, convex-logto/react, convex-logto/re
 | `verifyLogtoSignature(key, body, sig)` | `convex-logto` | Low-level signature check, for custom routing. |
 | `logtoSessionApi(component, opts?)` | `convex-logto` | [Session mode](/docs/session-mode): builds the five public auth functions backed by the session component. |
 | `assertUserHasActiveSession(ctx, component)` | `convex-logto` | Session mode: throw unless the caller still has a live (unrevoked) session. |
+| `createLogtoSessionCookieHandler(opts)` | `convex-logto` | Four-route standard-fetch handler for the optional same-site HttpOnly cookie transport. |
+| `createLogtoSessionCookieTransport(api, opts?)` | `convex-logto` | Framework-free browser adapter used by the session provider's `cookieTransport` prop. |
+| `assertLogtoSessionCookieCompatibility(opts)` | `convex-logto` | Loud Safari/device-binding compatibility guard. |
+| `LOGTO_SESSION_COOKIE_*`, `LOGTO_SESSION_CSRF_*` | `convex-logto` | Fixed cookie name/base path and CSRF header/value constants. |
 | `ConvexLogtoProvider` | `convex-logto/react` | Logto + Convex + auto sign-in callback in one provider. Static `config` or backend `configQuery`. |
 | `useLogtoAuth()` | `convex-logto/react` | `{ isAuthenticated, isLoading, user, signIn, signOut }`. |
 | default | `convex-logto/convex.config` | The session component, for `app.use(logto)` in `convex/convex.config.ts`. |
@@ -86,6 +90,29 @@ export const { signIn, callback, refresh, signOut, sessionValid } =
 Options: `scopes` / `resources` (server-configured — the browser can't request
 its own), `reuseWindowMs` (default 10s), and `endpoint` / `appId` /
 `clientSecret` env overrides.
+
+### `createLogtoSessionCookieHandler(opts)`
+
+Builds the [session mode cookie transport](/docs/session-mode#httponly-cookie-transport-optional)
+as a standard `(Request) => Promise<Response>` handler. Options are:
+
+- `sessionApi` — the same `api.auth` module passed to the provider;
+- `action(reference, args)` — calls the referenced public Convex action;
+- `allowedOrigins` — non-empty exact browser-origin allowlist;
+- `basePath` — default `/api/logto-session`;
+- `deviceBinding` — mirrors the device-binding flag so Safari can reject the
+  incompatible combination loudly.
+
+The four final path segments are `sign-in`, `callback`, `token`, and `sign-out`.
+Actual calls require POST, `x-convex-logto-csrf: 1`, and an allowed `Origin`;
+approved preflights receive credentialed CORS headers. The cookie is fixed to
+`__Host-convex-logto-session; HttpOnly; Secure; SameSite=Lax; Path=/` and rolls
+on every successful token rotation.
+
+The returned handler also has `getInitialToken(request)`. It returns
+`{ initialToken, initialSessionId, headers }`; forward `headers` to the SSR
+response so the rotated `Set-Cookie` is not lost, then pass the two initial
+values to `ConvexLogtoSessionProvider`.
 
 ### `assertUserHasActiveSession(ctx, component)`
 
@@ -169,6 +196,8 @@ in the bundle — it talks to the functions from `logtoSessionApi(...)`.
 | `afterSignIn` | — | Where to land after sign-in. Default `/`. `signIn({ returnTo })` overrides it. |
 | `navigate` | — | Your router's navigate (prefer replace-style) for soft post-sign-in navigation. Falls back to a hard `location.replace`. |
 | `tokenStorage` | — | Where the ID token persists: `"session"` (default, per-tab; reload without a round-trip), `"memory"` (strictest), `"local"`. |
+| `cookieTransport` | — | `{ endpoint?, fetch?, deviceBinding? }`; use the same-site handler instead of exposing the rotating session token to JavaScript. |
+| `initialToken` / `initialSessionId` | — | Paired SSR seed returned by `handler.getInitialToken(request)`. |
 | `reactiveRevocation` | — | Subscribe to session liveness; drop auth live on revocation. Default `true`. |
 | `onAuthError` | — | Recoverable sign-in failures (stale/forged callback, Logto unreachable). Also logged to the console. |
 

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -106,13 +106,16 @@ as a standard `(Request) => Promise<Response>` handler. Options are:
 The four final path segments are `sign-in`, `callback`, `token`, and `sign-out`.
 Actual calls require POST, `x-convex-logto-csrf: 1`, and an allowed `Origin`;
 approved preflights receive credentialed CORS headers. The cookie is fixed to
-`__Host-convex-logto-session; HttpOnly; Secure; SameSite=Lax; Path=/` and rolls
-on every successful token rotation.
+`__Host-convex-logto-session=<encoded-token>; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=16416000`
+and rolls on every successful token rotation. Each roll renews the 190-day
+maximum age, matching the component's idle-session garbage collection window.
 
 The returned handler also has `getInitialToken(request)`. It returns
-`{ initialToken, initialSessionId, headers }`; forward `headers` to the SSR
-response so the rotated `Set-Cookie` is not lost, then pass the two initial
-values to `ConvexLogtoSessionProvider`.
+`{ initialToken, initialSessionId, headers }`; call it at most once per incoming
+document request and always forward `headers` to the SSR response so the rotated
+`Set-Cookie` is not lost, then pass the two initial values to
+`ConvexLogtoSessionProvider`. Concurrent requests are best-effort: transient
+refresh contention returns an empty seed without clearing the cookie.
 
 ### `assertUserHasActiveSession(ctx, component)`
 

--- a/docs/content/docs/session-mode.mdx
+++ b/docs/content/docs/session-mode.mdx
@@ -117,14 +117,17 @@ on the **same site**, the cookie transport puts that credential in a
 `__Host-convex-logto-session` cookie with fixed attributes:
 
 ```text
-HttpOnly; Secure; SameSite=Lax; Path=/
+__Host-convex-logto-session=<encoded-token>; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=16416000
 ```
 
 JavaScript never receives the credential—not in a response body and not in
-storage—and every successful `/token` rotation rolls the cookie. The short-lived
-ID token still has to reach Convex from JavaScript, so this closes the long-lived
-session-token exfiltration path rather than claiming to make arbitrary XSS
-harmless.
+storage—and every successful `/token` rotation rolls the cookie and renews its
+190-day maximum age. That sliding lifetime matches the component's idle-session
+garbage collection, so cookie transport persists across browser restarts just
+like the default localStorage credential while the server session remains live.
+The short-lived ID token still has to reach Convex from JavaScript, so this
+closes the long-lived session-token exfiltration path rather than claiming to
+make arbitrary XSS harmless.
 
 The exported handler is a standard `(Request) => Promise<Response>` function
 with four routes under `/api/logto-session` by default:
@@ -251,9 +254,10 @@ only for an exact allowed origin.
 
 `handler.getInitialToken(request)` is the server-only SSR path. It reads the
 cookie, rotates it, and returns `{ initialToken, initialSessionId, headers }`.
-Always forward its `headers` to the page response—the `Set-Cookie` header is the
-next one-time credential. If your rendering hook cannot control response
-headers, let the browser use `/token` instead.
+Call it at most once per incoming document request and always forward its
+`headers` to the page response—the `Set-Cookie` header is the next one-time
+credential. If your rendering hook cannot control response headers, let the
+browser use `/token` instead.
 The seed is best-effort under concurrent renders: a request that encounters an
 in-flight refresh returns an empty seed and leaves the cookie intact for the
 client to refresh after hydration.
@@ -270,7 +274,7 @@ import { logtoCookieHandler } from "~/server/logto-cookie";
 
 const seedSession = createServerFn().handler(async () => {
   const seed = await logtoCookieHandler.getInitialToken(getRequest());
-  setResponseHeaders(seed.headers);
+  setResponseHeaders(Object.fromEntries(seed.headers));
   return {
     initialToken: seed.initialToken,
     initialSessionId: seed.initialSessionId,
@@ -375,7 +379,7 @@ destroy the grant.
 | `afterSignIn` | `"/"` | Where to land after sign-in; `signIn({ returnTo })` overrides. |
 | `navigate` | hard replace | Your router's navigate for soft post-sign-in navigation. |
 | `tokenStorage` | `"session"` | Where the ID token persists: `"session"` (per-tab, zero-round-trip reload), `"memory"` (strictest), `"local"`. |
-| `cookieTransport` | — | `{ endpoint?, deviceBinding? }`: move the rotating session token into the same-site HttpOnly cookie handler. |
+| `cookieTransport` | — | `{ endpoint?, fetch?, deviceBinding? }`: move the rotating session token into a persistent same-site HttpOnly cookie whose 190-day lifetime renews on every rotation. |
 | `initialToken` / `initialSessionId` | — | Paired values from `handler.getInitialToken(request)` for authenticated SSR/hydration. |
 | `reactiveRevocation` | `true` | Subscribe to session liveness and drop auth live on revocation. |
 | `onAuthError` | — | Recoverable sign-in failures (stale/forged callback, Logto down). |

--- a/docs/content/docs/session-mode.mdx
+++ b/docs/content/docs/session-mode.mdx
@@ -254,6 +254,9 @@ cookie, rotates it, and returns `{ initialToken, initialSessionId, headers }`.
 Always forward its `headers` to the page response—the `Set-Cookie` header is the
 next one-time credential. If your rendering hook cannot control response
 headers, let the browser use `/token` instead.
+The seed is best-effort under concurrent renders: a request that encounters an
+in-flight refresh returns an empty seed and leaves the cookie intact for the
+client to refresh after hydration.
 
 For example, a TanStack Start server function can seed the root loader:
 

--- a/docs/content/docs/session-mode.mdx
+++ b/docs/content/docs/session-mode.mdx
@@ -258,9 +258,9 @@ Call it at most once per incoming document request and always forward its
 `headers` to the page response—the `Set-Cookie` header is the next one-time
 credential. If your rendering hook cannot control response headers, let the
 browser use `/token` instead.
-The seed is best-effort under concurrent renders: a request that encounters an
-in-flight refresh returns an empty seed and leaves the cookie intact for the
-client to refresh after hydration.
+The seed is best-effort under concurrent renders: every failed seed returns
+empty without changing the cookie. The client refreshes after hydration, and
+the browser `/token` route authoritatively clears a genuinely dead session.
 
 For example, a TanStack Start server function can seed the root loader:
 

--- a/docs/content/docs/session-mode.mdx
+++ b/docs/content/docs/session-mode.mdx
@@ -25,7 +25,10 @@ browser, refresh token in `localStorage`):
 | Frontend dependencies | `@logto/react` | none beyond `convex` + `react` |
 | Logto config in the bundle | endpoint + app id | nothing |
 
-Works on any static host/CDN — no cookie domain, no server for the frontend.
+The default localStorage transport works on any static host/CDN — no cookie
+domain or frontend server required. Apps with a same-site server endpoint can
+optionally move the rotating session token into an HttpOnly cookie; that upgrade
+is covered below.
 
 ## Setup
 
@@ -106,6 +109,196 @@ const { isAuthenticated, isLoading, user, signIn, signOut } = useLogtoAuth();
 // signOut() — revokes the grant, clears every tab, ends the Logto SSO session
 ```
 
+## HttpOnly cookie transport (optional)
+
+The default one-time token is safe to rotate from `localStorage`, but an XSS bug
+can still copy it before the next rotation. If your app can serve an auth endpoint
+on the **same site**, the cookie transport puts that credential in a
+`__Host-convex-logto-session` cookie with fixed attributes:
+
+```text
+HttpOnly; Secure; SameSite=Lax; Path=/
+```
+
+JavaScript never receives the credential—not in a response body and not in
+storage—and every successful `/token` rotation rolls the cookie. The short-lived
+ID token still has to reach Convex from JavaScript, so this closes the long-lived
+session-token exfiltration path rather than claiming to make arbitrary XSS
+harmless.
+
+The exported handler is a standard `(Request) => Promise<Response>` function
+with four routes under `/api/logto-session` by default:
+
+| Route | Purpose |
+| --- | --- |
+| `sign-in` | Create the Logto authorization URL. |
+| `callback` | Exchange the authorization code and set the first cookie. |
+| `token` | Rotate the cookie and return a fresh ID token. |
+| `sign-out` | Revoke the grant and expire the cookie. |
+
+Every application request has one fixed CSRF policy: `POST`, the
+`x-convex-logto-csrf: 1` custom header, and an exact match in `allowedOrigins`.
+Cross-origin same-site mounts also get credentialed CORS responses; wildcards
+are never accepted.
+
+### Shared handler
+
+Next.js and TanStack Start can call the existing public Convex actions with
+`ConvexHttpClient`:
+
+```ts title="src/server/logto-cookie.ts"
+import { ConvexHttpClient } from "convex/browser";
+import { createLogtoSessionCookieHandler } from "convex-logto";
+import { api } from "../../convex/_generated/api";
+
+const convex = new ConvexHttpClient(process.env.CONVEX_URL!);
+
+export const logtoCookieHandler = createLogtoSessionCookieHandler({
+  sessionApi: api.auth,
+  action: (reference, args) => convex.action(reference, args),
+  allowedOrigins: [process.env.APP_ORIGIN!],
+  basePath: "/api/logto",
+});
+```
+
+`allowedOrigins` contains browser origins (`https://app.example.com`), not URL
+paths. Keep `CONVEX_URL` server-only.
+
+### Next.js App Router
+
+Mount the handler in a catch-all Route Handler:
+
+```ts title="app/api/logto/[route]/route.ts"
+import { logtoCookieHandler } from "@/server/logto-cookie";
+
+export const POST = logtoCookieHandler;
+export const OPTIONS = logtoCookieHandler;
+```
+
+Then enable the browser half on the existing provider:
+
+```tsx
+<ConvexLogtoSessionProvider
+  client={convex}
+  sessionApi={api.auth}
+  cookieTransport={{ endpoint: "/api/logto" }}
+>
+  <App />
+</ConvexLogtoSessionProvider>
+```
+
+The user-facing callback page remains `/callback`; after Logto redirects there,
+the provider POSTs the code to `/api/logto/callback`.
+
+### TanStack Start
+
+TanStack Start server routes also receive a standard `Request`:
+
+```ts title="src/routes/api/logto/$.ts"
+import { createFileRoute } from "@tanstack/react-router";
+import { logtoCookieHandler } from "~/server/logto-cookie";
+
+export const Route = createFileRoute("/api/logto/$")({
+  server: {
+    handlers: {
+      POST: ({ request }) => logtoCookieHandler(request),
+      OPTIONS: ({ request }) => logtoCookieHandler(request),
+    },
+  },
+});
+```
+
+Use the same provider configuration shown for Next.js.
+
+### Convex HTTP action on a custom domain
+
+Convex can host the standard handler directly. Use a custom domain that shares
+the frontend's site—for example `app.example.com` and `api.example.com`. A
+default `*.convex.site` endpoint is cross-site to your app and is intentionally
+not a cookie-transport deployment.
+
+```ts title="convex/http.ts"
+import { createLogtoSessionCookieHandler } from "convex-logto";
+import { httpRouter } from "convex/server";
+import { api } from "./_generated/api";
+import { httpAction } from "./_generated/server";
+
+const http = httpRouter();
+const cookieAction = httpAction(async (ctx, request) => {
+  const handler = createLogtoSessionCookieHandler({
+    sessionApi: api.auth,
+    action: (reference, args) => ctx.runAction(reference, args),
+    allowedOrigins: [process.env.APP_ORIGIN!],
+    basePath: "/api/logto",
+  });
+  return handler(request);
+});
+
+http.route({ pathPrefix: "/api/logto/", method: "POST", handler: cookieAction });
+http.route({
+  pathPrefix: "/api/logto/",
+  method: "OPTIONS",
+  handler: cookieAction,
+});
+export default http;
+```
+
+Point `cookieTransport.endpoint` at the absolute custom-domain URL. The adapter
+uses `credentials: "include"`; the handler returns a credentialed CORS response
+only for an exact allowed origin.
+
+### Authenticated first paint with `initialToken`
+
+`handler.getInitialToken(request)` is the server-only SSR path. It reads the
+cookie, rotates it, and returns `{ initialToken, initialSessionId, headers }`.
+Always forward its `headers` to the page response—the `Set-Cookie` header is the
+next one-time credential. If your rendering hook cannot control response
+headers, let the browser use `/token` instead.
+
+For example, a TanStack Start server function can seed the root loader:
+
+```tsx
+import { createServerFn } from "@tanstack/react-start";
+import {
+  getRequest,
+  setResponseHeaders,
+} from "@tanstack/react-start/server";
+import { logtoCookieHandler } from "~/server/logto-cookie";
+
+const seedSession = createServerFn().handler(async () => {
+  const seed = await logtoCookieHandler.getInitialToken(getRequest());
+  setResponseHeaders(seed.headers);
+  return {
+    initialToken: seed.initialToken,
+    initialSessionId: seed.initialSessionId,
+  };
+});
+
+// In the root route: loader: () => seedSession()
+const seed = Route.useLoaderData();
+<ConvexLogtoSessionProvider
+  client={convex}
+  sessionApi={api.auth}
+  cookieTransport={{ endpoint: "/api/logto" }}
+  initialToken={seed.initialToken}
+  initialSessionId={seed.initialSessionId}
+>
+  <App />
+</ConvexLogtoSessionProvider>;
+```
+
+The server and hydration snapshots start authenticated, so Convex can accept the
+seeded ID token on the first paint without a browser `/token` round-trip.
+
+### Safari and device binding
+
+Cookie transport and software device binding are mutually exclusive on Safari:
+ITP can retain the cookie while evicting its IndexedDB-held key. Pass the same
+`deviceBinding: true` flag to the handler and `cookieTransport` configuration;
+Safari throws an explicit configuration error rather than silently dropping
+either protection. Device binding itself is tracked separately and is not
+implemented by the cookie adapter.
+
 ## Reactive revocation
 
 Every session's liveness is a Convex subscription. The moment a session is
@@ -179,6 +372,8 @@ destroy the grant.
 | `afterSignIn` | `"/"` | Where to land after sign-in; `signIn({ returnTo })` overrides. |
 | `navigate` | hard replace | Your router's navigate for soft post-sign-in navigation. |
 | `tokenStorage` | `"session"` | Where the ID token persists: `"session"` (per-tab, zero-round-trip reload), `"memory"` (strictest), `"local"`. |
+| `cookieTransport` | — | `{ endpoint?, deviceBinding? }`: move the rotating session token into the same-site HttpOnly cookie handler. |
+| `initialToken` / `initialSessionId` | — | Paired values from `handler.getInitialToken(request)` for authenticated SSR/hydration. |
 | `reactiveRevocation` | `true` | Subscribe to session liveness and drop auth live on revocation. |
 | `onAuthError` | — | Recoverable sign-in failures (stale/forged callback, Logto down). |
 

--- a/packages/convex-logto/README.md
+++ b/packages/convex-logto/README.md
@@ -205,6 +205,15 @@ server-side revocation with `assertUserHasActiveSession` — in the
 [Session mode docs][session-mode-docs] and the runnable
 [`vite-react-session`][session-example] example.
 
+Apps with a same-site server endpoint can additionally mount
+`createLogtoSessionCookieHandler()` and pass
+`cookieTransport={{ endpoint: "/api/logto" }}` to the provider. That moves the
+rotating credential into a rolling `__Host-` HttpOnly cookie, enforces fixed
+POST + custom-header + Origin CSRF checks, and supports SSR seeding through
+`handler.getInitialToken(request)`. See the session-mode guide for Next.js,
+TanStack Start, and Convex custom-domain mounts, plus the Safari device-binding
+exclusion.
+
 [session-mode-docs]: https://github.com/Fanzzzd/convex-logto/blob/main/docs/content/docs/session-mode.mdx
 [session-example]: https://github.com/Fanzzzd/convex-logto/tree/main/examples/vite-react-session
 
@@ -260,6 +269,7 @@ Convex validates an OIDC **ID token**. Logto's access tokens are typed `at+jwt`,
 | `verifyLogtoSignature(key, body, sig)` | `convex-logto` | Low-level signature check, for custom routing. |
 | `logtoSessionApi(component, opts?)` | `convex-logto` | [Session mode](#session-mode): builds the five public auth functions backed by the session component. |
 | `assertUserHasActiveSession(ctx, component)` | `convex-logto` | Session mode: throw unless the caller still has a live (unrevoked) session. |
+| `createLogtoSessionCookieHandler(opts)` | `convex-logto` | Four-route standard-fetch handler for the optional same-site HttpOnly cookie transport. |
 | `ConvexLogtoProvider` | `convex-logto/react` | Logto + Convex + auto sign-in callback in one provider. Static `config` or backend `configQuery`. |
 | `useLogtoAuth()` | `convex-logto/react` | `{ isAuthenticated, isLoading, user, signIn, signOut }`. |
 | default | `convex-logto/convex.config` | The session component, for `app.use(logto)`. |

--- a/packages/convex-logto/README.md
+++ b/packages/convex-logto/README.md
@@ -208,8 +208,9 @@ server-side revocation with `assertUserHasActiveSession` — in the
 Apps with a same-site server endpoint can additionally mount
 `createLogtoSessionCookieHandler()` and pass
 `cookieTransport={{ endpoint: "/api/logto" }}` to the provider. That moves the
-rotating credential into a rolling `__Host-` HttpOnly cookie, enforces fixed
-POST + custom-header + Origin CSRF checks, and supports SSR seeding through
+rotating credential into a persistent rolling `__Host-` HttpOnly cookie whose
+190-day lifetime matches server-side idle GC. It enforces fixed POST +
+custom-header + Origin CSRF checks and supports SSR seeding through
 `handler.getInitialToken(request)`. See the session-mode guide for Next.js,
 TanStack Start, and Convex custom-domain mounts, plus the Safari device-binding
 exclusion.

--- a/packages/convex-logto/src/component/core.test.ts
+++ b/packages/convex-logto/src/component/core.test.ts
@@ -13,6 +13,7 @@ import {
   generatePkce,
   generateToken,
   hashToken,
+  rotateTokenHashes,
   terminal,
   toBase64Url,
   transient,
@@ -193,6 +194,23 @@ describe("decideRefresh", () => {
 
   it("previous token inside the window with a fresh cached ID token → cached", () => {
     expect(decide("previous", {})).toEqual({ outcome: "cached" });
+  });
+
+  it("rotation via a previous match keeps the superseded current token valid", () => {
+    expect(decide("previous", {})).toEqual({ outcome: "cached" });
+    const rotated = rotateTokenHashes(base.tokenHash, "candidate");
+    expect(rotated).toEqual({
+      tokenHash: "candidate",
+      prevTokenHash: "current",
+    });
+    expect(
+      decideRefresh({
+        presentedHash: "current",
+        session: { ...base, ...rotated, rotatedAt: NOW },
+        now: NOW,
+        reuseWindowMs: DEFAULT_REUSE_WINDOW_MS,
+      }),
+    ).toEqual({ outcome: "cached" });
   });
 
   it("previous token inside the window but cached ID token near expiry → refresh-previous", () => {

--- a/packages/convex-logto/src/component/core.ts
+++ b/packages/convex-logto/src/component/core.ts
@@ -211,6 +211,17 @@ export function decideRefresh(options: {
   return { outcome: "refresh-previous" };
 }
 
+/** Rotate while keeping the superseded current generation as the grace token. */
+export function rotateTokenHashes(
+  currentTokenHash: string,
+  candidateHash: string,
+): { tokenHash: string; prevTokenHash: string } {
+  return {
+    tokenHash: candidateHash,
+    prevTokenHash: currentTokenHash,
+  };
+}
+
 // --- error taxonomy ---------------------------------------------------------
 //
 // Terminal: the session/transaction is gone for good — the client clears its

--- a/packages/convex-logto/src/component/lib.ts
+++ b/packages/convex-logto/src/component/lib.ts
@@ -19,6 +19,7 @@ import {
   generatePkce,
   generateToken,
   hashToken,
+  rotateTokenHashes,
   terminal,
   transient,
 } from "./core.js";
@@ -429,11 +430,11 @@ export const beginRefresh = internalMutation({
         };
       }
       case "cached": {
-        // Rotate locally: presented (previous) token becomes prev again, the
-        // candidate becomes current. No Logto round-trip.
+        // Rotate locally while retaining the superseded current generation as
+        // the grace token. The presented token may itself be the older grace
+        // generation, so retaining it would orphan a concurrent response.
         await ctx.db.patch(session._id, {
-          tokenHash: args.candidateHash,
-          prevTokenHash: args.presentedHash,
+          ...rotateTokenHashes(session.tokenHash, args.candidateHash),
           rotatedAt: args.now,
         });
         return {
@@ -474,8 +475,10 @@ export const completeRefresh = internalMutation({
     const session = id && (await ctx.db.get(id));
     if (!session) return null; // killed concurrently (webhook revocation) — nothing to write
     await ctx.db.patch(session._id, {
-      tokenHash: args.candidateHash,
-      prevTokenHash: args.presentedHash,
+      // The refresh claim prevents any other rotation before completion, so
+      // this is the generation superseded by the candidate even when refresh
+      // began by presenting the previous generation.
+      ...rotateTokenHashes(session.tokenHash, args.candidateHash),
       rotatedAt: args.now,
       refreshingSince: undefined,
       lastIdToken: args.idToken,

--- a/packages/convex-logto/src/index.ts
+++ b/packages/convex-logto/src/index.ts
@@ -14,6 +14,20 @@ export {
   type LogtoSessionComponent,
 } from "./session";
 export {
+  LOGTO_SESSION_COOKIE_BASE_PATH,
+  LOGTO_SESSION_COOKIE_NAME,
+  LOGTO_SESSION_CSRF_HEADER,
+  LOGTO_SESSION_CSRF_VALUE,
+  assertLogtoSessionCookieCompatibility,
+  createLogtoSessionCookieHandler,
+  createLogtoSessionCookieTransport,
+  type LogtoSessionAction,
+  type LogtoSessionCookieHandler,
+  type LogtoSessionCookieHandlerOptions,
+  type LogtoSessionCookieSeed,
+  type LogtoSessionCookieTransportOptions,
+} from "./session-cookie";
+export {
   logtoSync,
   registerLogtoWebhook,
   verifyLogtoSignature,

--- a/packages/convex-logto/src/react-session.tsx
+++ b/packages/convex-logto/src/react-session.tsx
@@ -25,7 +25,7 @@ import {
   type TokenStorageKind,
 } from "./session-client";
 import {
-  COOKIE_SESSION_MARKER,
+  createCookieSessionMarker,
   createLogtoSessionCookieTransport,
   type LogtoSessionCookieTransportOptions,
 } from "./session-cookie";
@@ -181,10 +181,7 @@ export function ConvexLogtoSessionProvider({
       // legacy localStorage credential and makes reload attempt the /token
       // route even though JavaScript cannot inspect the HttpOnly cookie.
       initialSession: usesCookieTransport
-        ? {
-            token: COOKIE_SESSION_MARKER,
-            sessionId: initialSessionId ?? "",
-          }
+        ? createCookieSessionMarker(storage.readSession(), initialSessionId)
         : undefined,
       navigate: (to) => {
         const soft = navigateRef.current;

--- a/packages/convex-logto/src/react-session.tsx
+++ b/packages/convex-logto/src/react-session.tsx
@@ -81,7 +81,8 @@ export type ConvexLogtoSessionProviderProps = {
   tokenStorage?: TokenStorageKind;
   /**
    * Move the rotating session token into the same-site handler's HttpOnly
-   * cookie. The browser keeps only a non-secret session marker in localStorage.
+   * cookie. The browser keeps only a non-secret session marker in localStorage;
+   * each rotation renews the persistent cookie's 190-day idle lifetime.
    */
   cookieTransport?: LogtoSessionCookieTransportOptions;
   /** Fresh ID token returned by `handler.getInitialToken(request)` during SSR. */
@@ -277,13 +278,14 @@ function RevocationWatcher() {
     engine.getServerSnapshot,
   );
   const sessionId = snapshot.sessionId;
+  const hasSessionId = sessionId !== null && sessionId.length > 0;
   const valid = useQuery(
     sessionApi.sessionValid,
-    sessionId !== null ? { sessionId } : "skip",
+    hasSessionId ? { sessionId } : "skip",
   );
   useEffect(() => {
-    if (sessionId !== null && valid === false) engine.handleRevoked();
-  }, [engine, sessionId, valid]);
+    if (hasSessionId && valid === false) engine.handleRevoked();
+  }, [engine, hasSessionId, valid]);
   return null;
 }
 

--- a/packages/convex-logto/src/react-session.tsx
+++ b/packages/convex-logto/src/react-session.tsx
@@ -24,6 +24,11 @@ import {
   type SessionTransport,
   type TokenStorageKind,
 } from "./session-client";
+import {
+  COOKIE_SESSION_MARKER,
+  createLogtoSessionCookieTransport,
+  type LogtoSessionCookieTransportOptions,
+} from "./session-cookie";
 import type { LogtoSessionApi } from "./session";
 
 const DEFAULT_CALLBACK_PATH = "/callback";
@@ -70,10 +75,19 @@ export type ConvexLogtoSessionProviderProps = {
    * Where the short-lived ID token persists. `"session"` (default): per-tab
    * sessionStorage — an unexpired token makes reload a zero-round-trip
    * authenticate. `"memory"`: strictest, every reload refreshes. `"local"`:
-   * shared across tabs and restarts. The session token itself always lives in
-   * localStorage — it's one-time and stored hashed server-side.
+   * shared across tabs and restarts. By default the one-time session token
+   * lives in localStorage; `cookieTransport` moves it into an HttpOnly cookie.
    */
   tokenStorage?: TokenStorageKind;
+  /**
+   * Move the rotating session token into the same-site handler's HttpOnly
+   * cookie. The browser keeps only a non-secret session marker in localStorage.
+   */
+  cookieTransport?: LogtoSessionCookieTransportOptions;
+  /** Fresh ID token returned by `handler.getInitialToken(request)` during SSR. */
+  initialToken?: string | null;
+  /** Stable session id returned alongside `initialToken`. */
+  initialSessionId?: string | null;
   /**
    * Subscribe to server-side session liveness and drop auth the moment the
    * session is revoked (sign-out elsewhere, reuse detection, webhook
@@ -109,10 +123,31 @@ export function ConvexLogtoSessionProvider({
   afterSignIn = "/",
   navigate,
   tokenStorage = "session",
+  cookieTransport,
+  initialToken,
+  initialSessionId,
   reactiveRevocation = true,
   onAuthError,
   children,
 }: ConvexLogtoSessionProviderProps) {
+  const usesCookieTransport = cookieTransport !== undefined;
+  const hasInitialToken = initialToken != null;
+  const hasInitialSessionId = initialSessionId != null;
+  if (hasInitialToken !== hasInitialSessionId) {
+    throw new Error(
+      "convex-logto: initialToken and initialSessionId must be provided together.",
+    );
+  }
+  if (hasInitialToken && !usesCookieTransport) {
+    throw new Error(
+      "convex-logto: SSR initialToken seeding requires cookieTransport.",
+    );
+  }
+
+  const cookieEndpoint = cookieTransport?.endpoint;
+  const cookieFetch = cookieTransport?.fetch;
+  const cookieDeviceBinding = cookieTransport?.deviceBinding;
+
   // The engine must survive re-renders, but `navigate`/`onAuthError` are often
   // inline arrows with a fresh identity each render — route them through refs
   // so the engine stays stable and still always calls the latest one.
@@ -127,12 +162,30 @@ export function ConvexLogtoSessionProvider({
     // Namespace storage by deployment so two dev apps on the same origin
     // (localhost) don't cross-read each other's sessions.
     const namespace = clientNamespace(client);
+    const storage = new SessionStorageArea(namespace, tokenStorage);
+    const transport = usesCookieTransport
+      ? createLogtoSessionCookieTransport(sessionApi, {
+          endpoint: cookieEndpoint,
+          fetch: cookieFetch,
+          deviceBinding: cookieDeviceBinding,
+        })
+      : (client as SessionTransport);
     return new SessionAuthEngine({
-      transport: client as SessionTransport,
+      transport,
       api: sessionApi,
-      storage: new SessionStorageArea(namespace, tokenStorage),
+      storage,
       callbackPath,
       afterSignIn,
+      initialToken: initialToken ?? undefined,
+      // Cookie mode always writes a non-secret marker. That both overwrites a
+      // legacy localStorage credential and makes reload attempt the /token
+      // route even though JavaScript cannot inspect the HttpOnly cookie.
+      initialSession: usesCookieTransport
+        ? {
+            token: COOKIE_SESSION_MARKER,
+            sessionId: initialSessionId ?? "",
+          }
+        : undefined,
       navigate: (to) => {
         const soft = navigateRef.current;
         if (soft) soft(to);
@@ -140,7 +193,19 @@ export function ConvexLogtoSessionProvider({
       },
       onAuthError: (error) => onAuthErrorRef.current?.(error),
     });
-  }, [client, sessionApi, callbackPath, tokenStorage, afterSignIn]);
+  }, [
+    client,
+    sessionApi,
+    callbackPath,
+    tokenStorage,
+    afterSignIn,
+    usesCookieTransport,
+    cookieEndpoint,
+    cookieFetch,
+    cookieDeviceBinding,
+    initialToken,
+    initialSessionId,
+  ]);
 
   useEffect(() => {
     engine.start();
@@ -288,3 +353,4 @@ export function useLogtoAuth(): LogtoSessionAuth {
 
 export type { LogtoSessionApi } from "./session";
 export type { TokenStorageKind } from "./session-client";
+export type { LogtoSessionCookieTransportOptions } from "./session-cookie";

--- a/packages/convex-logto/src/session-client.test.ts
+++ b/packages/convex-logto/src/session-client.test.ts
@@ -16,6 +16,10 @@ import {
   type TokenStorageKind,
 } from "./session-client";
 import type { LogtoSessionApi } from "./session";
+import {
+  COOKIE_SESSION_MARKER,
+  createCookieSessionMarker,
+} from "./session-cookie";
 
 // --- harness -----------------------------------------------------------------
 
@@ -73,6 +77,9 @@ function makeHarness(options?: {
   afterSignIn?: string;
   initialToken?: string;
   initialSession?: StoredSession;
+  storedIdToken?: string;
+  storedSession?: StoredSession;
+  cookieBootstrap?: { initialSessionId?: string | null };
 }) {
   const handlers: Handlers = {
     signIn: vi.fn(),
@@ -88,6 +95,14 @@ function makeHarness(options?: {
     "test",
     options?.tokenStorage ?? "session",
   );
+  if (options?.storedSession) storage.writeSession(options.storedSession);
+  if (options?.storedIdToken) storage.writeIdToken(options.storedIdToken);
+  const initialSession = options?.cookieBootstrap
+    ? createCookieSessionMarker(
+        storage.readSession(),
+        options.cookieBootstrap.initialSessionId,
+      )
+    : options?.initialSession;
   const navigate = vi.fn();
   const onAuthError = vi.fn();
   const engine = new SessionAuthEngine({
@@ -97,7 +112,7 @@ function makeHarness(options?: {
     callbackPath: "/callback",
     afterSignIn: options?.afterSignIn ?? "/",
     initialToken: options?.initialToken,
-    initialSession: options?.initialSession,
+    initialSession,
     navigate,
     onAuthError,
     sleep: () => Promise.resolve(), // skip retry backoff in tests
@@ -219,6 +234,27 @@ describe("mount", () => {
     expect(snapshot.status).toBe("authenticated");
     expect(snapshot.sessionId).toBe("s1");
     expect(snapshot.user?.sub).toBe("alice");
+    expect(handlers.refresh).not.toHaveBeenCalled();
+  });
+
+  it("cookie reload with a fresh cached token preserves the stored session id", async () => {
+    const { engine, storage, handlers } = makeHarness({
+      storedSession: {
+        token: "legacy-session-secret",
+        sessionId: "real-session-id",
+      },
+      storedIdToken: freshToken("alice"),
+      cookieBootstrap: {},
+    });
+    expect(storage.readSession()).toEqual({
+      token: COOKIE_SESSION_MARKER,
+      sessionId: "real-session-id",
+    });
+
+    engine.start();
+    const snapshot = await settled(engine);
+    expect(snapshot.status).toBe("authenticated");
+    expect(snapshot.sessionId).toBe("real-session-id");
     expect(handlers.refresh).not.toHaveBeenCalled();
   });
 

--- a/packages/convex-logto/src/session-client.test.ts
+++ b/packages/convex-logto/src/session-client.test.ts
@@ -12,6 +12,7 @@ import {
   SessionStorageArea,
   type SessionSnapshot,
   type SessionTransport,
+  type StoredSession,
   type TokenStorageKind,
 } from "./session-client";
 import type { LogtoSessionApi } from "./session";
@@ -70,6 +71,8 @@ type Handlers = {
 function makeHarness(options?: {
   tokenStorage?: TokenStorageKind;
   afterSignIn?: string;
+  initialToken?: string;
+  initialSession?: StoredSession;
 }) {
   const handlers: Handlers = {
     signIn: vi.fn(),
@@ -93,6 +96,8 @@ function makeHarness(options?: {
     storage,
     callbackPath: "/callback",
     afterSignIn: options?.afterSignIn ?? "/",
+    initialToken: options?.initialToken,
+    initialSession: options?.initialSession,
     navigate,
     onAuthError,
     sleep: () => Promise.resolve(), // skip retry backoff in tests
@@ -179,6 +184,25 @@ describe("SessionStorageArea", () => {
 // --- mount paths -------------------------------------------------------------
 
 describe("mount", () => {
+  it("SSR initialToken authenticates the server snapshot and hydrates storage", () => {
+    const token = freshToken("ssr-user");
+    const { engine, storage } = makeHarness({
+      initialToken: token,
+      initialSession: { token: "cookie-session", sessionId: "session-id-1" },
+    });
+    expect(engine.getServerSnapshot()).toEqual({
+      status: "authenticated",
+      sessionId: "session-id-1",
+      user: expect.objectContaining({ sub: "ssr-user" }),
+    });
+    expect(engine.getSnapshot()).toEqual(engine.getServerSnapshot());
+    expect(storage.readIdToken()).toBe(token);
+    expect(storage.readSession()).toEqual({
+      token: "cookie-session",
+      sessionId: "session-id-1",
+    });
+  });
+
   it("nothing stored → unauthenticated, no network", async () => {
     const { engine, handlers } = makeHarness();
     engine.start();

--- a/packages/convex-logto/src/session-client.test.ts
+++ b/packages/convex-logto/src/session-client.test.ts
@@ -258,6 +258,58 @@ describe("mount", () => {
     expect(handlers.refresh).not.toHaveBeenCalled();
   });
 
+  it("cookie reload with an empty session id refreshes once to recover it", async () => {
+    const { engine, storage, handlers } = makeHarness({
+      storedSession: {
+        token: COOKIE_SESSION_MARKER,
+        sessionId: "",
+      },
+      storedIdToken: freshToken("alice"),
+    });
+    handlers.refresh.mockResolvedValue({
+      ...sessionResult(2, "alice"),
+      sessionToken: COOKIE_SESSION_MARKER,
+    });
+
+    engine.start();
+    const snapshot = await settled(engine);
+    expect(handlers.refresh).toHaveBeenCalledTimes(1);
+    expect(handlers.refresh).toHaveBeenCalledWith({
+      sessionToken: COOKIE_SESSION_MARKER,
+    });
+    expect(snapshot.status).toBe("authenticated");
+    expect(snapshot.sessionId).toBe("session-id-2");
+    expect(snapshot.user?.sub).toBe("alice");
+    expect(storage.readSession()).toEqual({
+      token: COOKIE_SESSION_MARKER,
+      sessionId: "session-id-2",
+    });
+  });
+
+  it("empty-id recovery falls back to a fresh cached token on transient failure", async () => {
+    const cached = freshToken("alice");
+    const { engine, storage, handlers } = makeHarness({
+      storedSession: {
+        token: COOKIE_SESSION_MARKER,
+        sessionId: "",
+      },
+      storedIdToken: cached,
+    });
+    handlers.refresh.mockRejectedValue(transientError());
+
+    engine.start();
+    const snapshot = await settled(engine);
+    expect(handlers.refresh).toHaveBeenCalledTimes(3);
+    expect(snapshot.status).toBe("authenticated");
+    expect(snapshot.sessionId).toBe("");
+    expect(snapshot.user?.sub).toBe("alice");
+    expect(storage.readIdToken()).toBe(cached);
+    expect(storage.readSession()).toEqual({
+      token: COOKIE_SESSION_MARKER,
+      sessionId: "",
+    });
+  });
+
   it("session with a stale ID token → refresh → authenticated, rotation persisted", async () => {
     const { engine, storage, handlers } = makeHarness();
     storage.writeSession({ token: "t1", sessionId: "s1" });

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -388,8 +388,26 @@ export class SessionAuthEngine {
   private async restore(): Promise<void> {
     const cached = this.options.storage.readIdToken();
     if (cached !== null && this.isFresh(cached)) {
-      this.setAuthenticated(cached);
-      return;
+      const session = this.options.storage.readSession();
+      if (session?.sessionId !== "") {
+        this.setAuthenticated(cached);
+        return;
+      }
+      // Cookie mode can know that a session exists before SSR or a rotation has
+      // supplied its stable id. Recover it now instead of authenticating with
+      // reactive revocation silently disabled. Mark the cached token
+      // unacceptable so refreshIdToken actually presents the cookie.
+      const recovered = await this.refreshIdToken(cached);
+      if (recovered !== null) {
+        this.setAuthenticated(recovered);
+        return;
+      }
+      // A transient refresh keeps storage intact: use the still-fresh cached
+      // token as a degraded fallback. Terminal failures already cleared it.
+      if (this.options.storage.readSession() !== null) {
+        this.setAuthenticated(cached);
+        return;
+      }
     }
     if (this.options.storage.readSession() !== null) {
       const idToken = await this.refreshIdToken(null);

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -60,7 +60,7 @@ export function sessionErrorKind(error: unknown): "terminal" | "transient" {
 
 // --- storage -----------------------------------------------------------------
 
-type StoredSession = { token: string; sessionId: string };
+export type StoredSession = { token: string; sessionId: string };
 type StoredTransaction = { state: string };
 
 /**
@@ -200,6 +200,10 @@ export type SessionEngineOptions = {
   storage: SessionStorageArea;
   callbackPath: string;
   afterSignIn: string;
+  /** Fresh SSR-seeded ID token. */
+  initialToken?: string;
+  /** Session marker paired with `initialToken` (cookie transport uses a sentinel). */
+  initialSession?: StoredSession;
   /** Replace-style navigation; falls back to `location.replace`. */
   navigate?: (to: string) => void;
   onAuthError?: (error: Error) => void;
@@ -228,7 +232,8 @@ const SERVER_SNAPSHOT: SessionSnapshot = {
  * Transitions are one-way per mount — no isLoading churn by construction.
  */
 export class SessionAuthEngine {
-  private snapshot: SessionSnapshot = SERVER_SNAPSHOT;
+  private snapshot: SessionSnapshot;
+  private serverSnapshot: SessionSnapshot;
   private listeners = new Set<() => void>();
   private started = false;
   private inflightRefresh: Promise<string | null> | null = null;
@@ -242,6 +247,22 @@ export class SessionAuthEngine {
     this.sleep =
       options.sleep ??
       ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+    if (options.initialSession) {
+      options.storage.writeSession(options.initialSession);
+    }
+    if (options.initialToken) {
+      options.storage.writeIdToken(options.initialToken);
+      this.snapshot = {
+        status: "authenticated",
+        sessionId: options.initialSession?.sessionId ?? null,
+        user: decodeJwtPayload(options.initialToken) ?? undefined,
+      };
+    } else {
+      this.snapshot = SERVER_SNAPSHOT;
+    }
+    // React's hydration snapshot must match what the server rendered even if
+    // the live client state changes before hydration finishes.
+    this.serverSnapshot = this.snapshot;
   }
 
   /** The localStorage key cross-tab sign-outs land on — for `storage` event filtering. */
@@ -258,7 +279,7 @@ export class SessionAuthEngine {
 
   getSnapshot = (): SessionSnapshot => this.snapshot;
 
-  getServerSnapshot = (): SessionSnapshot => SERVER_SNAPSHOT;
+  getServerSnapshot = (): SessionSnapshot => this.serverSnapshot;
 
   private setSnapshot(next: SessionSnapshot): void {
     this.snapshot = next;

--- a/packages/convex-logto/src/session-cookie.test.ts
+++ b/packages/convex-logto/src/session-cookie.test.ts
@@ -282,6 +282,44 @@ describe("SSR seed", () => {
     expect(seed.headers.get("set-cookie")).toBeNull();
     expect(action).not.toHaveBeenCalled();
   });
+
+  it("clears the cookie and returns an empty seed after a terminal error", async () => {
+    const { handler, handlers } = makeHarness();
+    handlers.refresh.mockRejectedValueOnce(
+      new ConvexError({
+        kind: "terminal",
+        code: "session_not_found",
+        message: "gone",
+      }),
+    );
+    const seed = await handler.getInitialToken(
+      new Request(`${APP_ORIGIN}/dashboard`, {
+        headers: { Cookie: cookie("spent") },
+      }),
+    );
+    expect(seed.initialToken).toBeNull();
+    expect(seed.initialSessionId).toBeNull();
+    expect(seed.headers.get("set-cookie")).toContain("Max-Age=0");
+  });
+
+  it("leaves the cookie intact and returns an empty seed after a transient error", async () => {
+    const { handler, handlers } = makeHarness();
+    handlers.refresh.mockRejectedValueOnce(
+      new ConvexError({
+        kind: "transient",
+        code: "refresh_in_flight",
+        message: "retry shortly",
+      }),
+    );
+    const seed = await handler.getInitialToken(
+      new Request(`${APP_ORIGIN}/dashboard`, {
+        headers: { Cookie: cookie("still-valid") },
+      }),
+    );
+    expect(seed.initialToken).toBeNull();
+    expect(seed.initialSessionId).toBeNull();
+    expect(seed.headers.get("set-cookie")).toBeNull();
+  });
 });
 
 describe("browser transport", () => {

--- a/packages/convex-logto/src/session-cookie.test.ts
+++ b/packages/convex-logto/src/session-cookie.test.ts
@@ -1,0 +1,350 @@
+import { ConvexError } from "convex/values";
+import { describe, expect, it, vi } from "vitest";
+import type { LogtoSessionApi } from "./session";
+import {
+  COOKIE_SESSION_MARKER,
+  LOGTO_SESSION_COOKIE_NAME,
+  LOGTO_SESSION_CSRF_HEADER,
+  LOGTO_SESSION_CSRF_VALUE,
+  assertLogtoSessionCookieCompatibility,
+  createLogtoSessionCookieHandler,
+  createLogtoSessionCookieTransport,
+  type LogtoSessionAction,
+} from "./session-cookie";
+
+const APP_ORIGIN = "https://app.example.com";
+const BASE_PATH = "/api/logto";
+
+const api = {
+  signIn: { fn: "signIn" },
+  callback: { fn: "callback" },
+  refresh: { fn: "refresh" },
+  signOut: { fn: "signOut" },
+  sessionValid: { fn: "sessionValid" },
+} as unknown as LogtoSessionApi;
+
+type HandlerName = "signIn" | "callback" | "refresh" | "signOut";
+type Handlers = Record<HandlerName, ReturnType<typeof vi.fn>>;
+
+function makeHarness(options?: { deviceBinding?: boolean }) {
+  const handlers: Handlers = {
+    signIn: vi.fn().mockResolvedValue({
+      url: "https://auth.example.com/oidc/auth?state=state-1",
+    }),
+    callback: vi.fn().mockResolvedValue({
+      idToken: "id-token-1",
+      sessionToken: "session-token-1",
+      sessionId: "session-id-1",
+      returnTo: "/dashboard",
+    }),
+    refresh: vi.fn().mockResolvedValue({
+      idToken: "id-token-2",
+      sessionToken: "session-token-2",
+      sessionId: "session-id-1",
+    }),
+    signOut: vi.fn().mockResolvedValue({
+      endSessionUrl: "https://auth.example.com/oidc/session/end",
+    }),
+  };
+  const action = vi.fn((reference: unknown, args: unknown) => {
+    const name = (reference as { fn: HandlerName }).fn;
+    return handlers[name](args);
+  }) as unknown as LogtoSessionAction;
+  const handler = createLogtoSessionCookieHandler({
+    sessionApi: api,
+    action,
+    allowedOrigins: [APP_ORIGIN],
+    basePath: BASE_PATH,
+    deviceBinding: options?.deviceBinding,
+  });
+  return { handler, handlers, action };
+}
+
+function cookie(value: string): string {
+  return `${LOGTO_SESSION_COOKIE_NAME}=${encodeURIComponent(value)}`;
+}
+
+function request(
+  route: "sign-in" | "callback" | "token" | "sign-out",
+  options?: {
+    method?: string;
+    origin?: string | null;
+    csrf?: string | null;
+    cookie?: string;
+    userAgent?: string;
+    body?: Record<string, unknown>;
+  },
+): Request {
+  const method = options?.method ?? "POST";
+  const headers = new Headers();
+  if (options?.origin !== null)
+    headers.set("Origin", options?.origin ?? APP_ORIGIN);
+  if (options?.csrf !== null)
+    headers.set(
+      LOGTO_SESSION_CSRF_HEADER,
+      options?.csrf ?? LOGTO_SESSION_CSRF_VALUE,
+    );
+  if (options?.cookie) headers.set("Cookie", options.cookie);
+  if (options?.userAgent) headers.set("User-Agent", options.userAgent);
+  if (method === "POST") headers.set("Content-Type", "application/json");
+  return new Request(`${APP_ORIGIN}${BASE_PATH}/${route}`, {
+    method,
+    headers,
+    body: method === "POST" ? JSON.stringify(options?.body ?? {}) : undefined,
+  });
+}
+
+describe("fixed CSRF policy", () => {
+  it("rejects every non-POST application request", async () => {
+    const { handler, action } = makeHarness();
+    const response = await handler(request("token", { method: "GET" }));
+    expect(response.status).toBe(405);
+    expect(response.headers.get("allow")).toBe("POST, OPTIONS");
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing or wrong custom header", async () => {
+    const { handler, action } = makeHarness();
+    expect((await handler(request("token", { csrf: null }))).status).toBe(403);
+    expect((await handler(request("token", { csrf: "wrong" }))).status).toBe(
+      403,
+    );
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it("rejects a missing or unlisted Origin", async () => {
+    const { handler, action } = makeHarness();
+    expect((await handler(request("token", { origin: null }))).status).toBe(
+      403,
+    );
+    expect(
+      (await handler(request("token", { origin: "https://attacker.example" })))
+        .status,
+    ).toBe(403);
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it("answers a valid credentialed CORS preflight", async () => {
+    const { handler, action } = makeHarness();
+    const response = await handler(
+      new Request(`${APP_ORIGIN}${BASE_PATH}/token`, {
+        method: "OPTIONS",
+        headers: {
+          Origin: APP_ORIGIN,
+          "Access-Control-Request-Method": "POST",
+          "Access-Control-Request-Headers": `${LOGTO_SESSION_CSRF_HEADER}, content-type`,
+        },
+      }),
+    );
+    expect(response.status).toBe(204);
+    expect(response.headers.get("access-control-allow-origin")).toBe(
+      APP_ORIGIN,
+    );
+    expect(response.headers.get("access-control-allow-credentials")).toBe(
+      "true",
+    );
+    expect(action).not.toHaveBeenCalled();
+  });
+});
+
+describe("cookie session flows", () => {
+  it("sign-in calls the existing action without touching a cookie", async () => {
+    const { handler, handlers } = makeHarness();
+    const response = await handler(
+      request("sign-in", {
+        body: {
+          redirectUri: `${APP_ORIGIN}/callback`,
+          returnTo: "/dashboard",
+        },
+      }),
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      url: "https://auth.example.com/oidc/auth?state=state-1",
+    });
+    expect(response.headers.get("set-cookie")).toBeNull();
+    expect(handlers.signIn).toHaveBeenCalledWith({
+      redirectUri: `${APP_ORIGIN}/callback`,
+      returnTo: "/dashboard",
+    });
+  });
+
+  it("callback moves the session token into a strict __Host- cookie", async () => {
+    const { handler, handlers } = makeHarness();
+    const response = await handler(
+      request("callback", {
+        body: {
+          code: "code-1",
+          state: "state-1",
+          redirectUri: `${APP_ORIGIN}/callback`,
+        },
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("set-cookie")).toBe(
+      `${LOGTO_SESSION_COOKIE_NAME}=session-token-1; Path=/; HttpOnly; Secure; SameSite=Lax`,
+    );
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body).toEqual({
+      idToken: "id-token-1",
+      sessionId: "session-id-1",
+      returnTo: "/dashboard",
+    });
+    expect(JSON.stringify(body)).not.toContain("session-token-1");
+    expect(handlers.callback).toHaveBeenCalledWith({
+      code: "code-1",
+      state: "state-1",
+      redirectUri: `${APP_ORIGIN}/callback`,
+    });
+  });
+
+  it("token presents the cookie and rolls it on every successful rotation", async () => {
+    const { handler, handlers } = makeHarness();
+    const response = await handler(
+      request("token", { cookie: cookie("session-token-1") }),
+    );
+    expect(response.status).toBe(200);
+    expect(handlers.refresh).toHaveBeenCalledWith({
+      sessionToken: "session-token-1",
+    });
+    expect(response.headers.get("set-cookie")).toBe(
+      `${LOGTO_SESSION_COOKIE_NAME}=session-token-2; Path=/; HttpOnly; Secure; SameSite=Lax`,
+    );
+    await expect(response.json()).resolves.toEqual({
+      idToken: "id-token-2",
+      sessionId: "session-id-1",
+    });
+  });
+
+  it("sign-out revokes through the existing action and expires the cookie", async () => {
+    const { handler, handlers } = makeHarness();
+    const response = await handler(
+      request("sign-out", {
+        cookie: cookie("session-token-2"),
+        body: { postLogoutRedirectUri: APP_ORIGIN },
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(handlers.signOut).toHaveBeenCalledWith({
+      sessionToken: "session-token-2",
+      postLogoutRedirectUri: APP_ORIGIN,
+    });
+    expect(response.headers.get("set-cookie")).toBe(
+      `${LOGTO_SESSION_COOKIE_NAME}=; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0`,
+    );
+    await expect(response.json()).resolves.toEqual({
+      endSessionUrl: "https://auth.example.com/oidc/session/end",
+    });
+  });
+
+  it("clears a terminal token cookie", async () => {
+    const { handler, handlers } = makeHarness();
+    handlers.refresh.mockRejectedValueOnce(
+      new ConvexError({
+        kind: "terminal",
+        code: "session_not_found",
+        message: "gone",
+      }),
+    );
+    const response = await handler(
+      request("token", { cookie: cookie("spent") }),
+    );
+    expect(response.status).toBe(401);
+    expect(response.headers.get("set-cookie")).toContain("Max-Age=0");
+  });
+});
+
+describe("SSR seed", () => {
+  it("returns a fresh initialToken and the rolled Set-Cookie header", async () => {
+    const { handler, handlers } = makeHarness();
+    const seed = await handler.getInitialToken(
+      new Request(`${APP_ORIGIN}/dashboard`, {
+        headers: { Cookie: cookie("session-token-1") },
+      }),
+    );
+    expect(handlers.refresh).toHaveBeenCalledWith({
+      sessionToken: "session-token-1",
+    });
+    expect(seed.initialToken).toBe("id-token-2");
+    expect(seed.initialSessionId).toBe("session-id-1");
+    expect(seed.headers.get("set-cookie")).toContain(
+      `${LOGTO_SESSION_COOKIE_NAME}=session-token-2`,
+    );
+  });
+
+  it("returns an empty seed without a cookie and does no work", async () => {
+    const { handler, action } = makeHarness();
+    const seed = await handler.getInitialToken(
+      new Request(`${APP_ORIGIN}/dashboard`),
+    );
+    expect(seed.initialToken).toBeNull();
+    expect(seed.initialSessionId).toBeNull();
+    expect(seed.headers.get("set-cookie")).toBeNull();
+    expect(action).not.toHaveBeenCalled();
+  });
+});
+
+describe("browser transport", () => {
+  it("sends credentials + CSRF header and exposes only a non-secret marker", async () => {
+    const fetcher = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.endsWith("/callback")) {
+        return Response.json({
+          idToken: "id-token-1",
+          sessionId: "session-id-1",
+          returnTo: "/dashboard",
+        });
+      }
+      throw new Error(`unexpected route ${url}`);
+    }) as typeof globalThis.fetch;
+    const transport = createLogtoSessionCookieTransport(api, {
+      endpoint: BASE_PATH,
+      fetch: fetcher,
+    });
+    const result = await transport.action(api.callback, {
+      code: "code-1",
+      state: "state-1",
+      redirectUri: `${APP_ORIGIN}/callback`,
+    });
+    expect(result).toEqual({
+      idToken: "id-token-1",
+      sessionId: "session-id-1",
+      returnTo: "/dashboard",
+      sessionToken: COOKIE_SESSION_MARKER,
+    });
+    const [, init] = fetcher.mock.calls[0]!;
+    expect(init?.method).toBe("POST");
+    expect(init?.credentials).toBe("include");
+    expect(new Headers(init?.headers).get(LOGTO_SESSION_CSRF_HEADER)).toBe(
+      LOGTO_SESSION_CSRF_VALUE,
+    );
+  });
+});
+
+describe("Safari device-binding exclusion", () => {
+  const safari =
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
+    "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.5 Safari/605.1.15";
+
+  it("throws loudly instead of degrading either protection", () => {
+    expect(() =>
+      assertLogtoSessionCookieCompatibility({
+        deviceBinding: true,
+        userAgent: safari,
+      }),
+    ).toThrow(/cannot be enabled together on Safari/);
+  });
+
+  it("also enforces the exclusion in the fetch handler", async () => {
+    const { handler, action } = makeHarness({ deviceBinding: true });
+    await expect(
+      handler(
+        request("token", {
+          cookie: cookie("session-token-1"),
+          userAgent: safari,
+        }),
+      ),
+    ).rejects.toThrow(/cannot be enabled together on Safari/);
+    expect(action).not.toHaveBeenCalled();
+  });
+});

--- a/packages/convex-logto/src/session-cookie.test.ts
+++ b/packages/convex-logto/src/session-cookie.test.ts
@@ -338,7 +338,7 @@ describe("SSR seed", () => {
     expect(action).not.toHaveBeenCalled();
   });
 
-  it("clears the cookie and returns an empty seed after a terminal error", async () => {
+  it("leaves the cookie intact and returns an empty seed after a terminal error", async () => {
     const { handler, handlers } = makeHarness();
     handlers.refresh.mockRejectedValueOnce(
       new ConvexError({
@@ -354,8 +354,7 @@ describe("SSR seed", () => {
     );
     expect(seed.initialToken).toBeNull();
     expect(seed.initialSessionId).toBeNull();
-    expect(seed.headers.get("set-cookie")).toContain("Max-Age=0");
-    expect(seed.headers.get("set-cookie")).toContain("Path=/");
+    expect(seed.headers.get("set-cookie")).toBeNull();
   });
 
   it("leaves the cookie intact and returns an empty seed after a transient error", async () => {

--- a/packages/convex-logto/src/session-cookie.test.ts
+++ b/packages/convex-logto/src/session-cookie.test.ts
@@ -1,5 +1,7 @@
+import { anyApi, getFunctionName, type FunctionReference } from "convex/server";
 import { ConvexError } from "convex/values";
 import { describe, expect, it, vi } from "vitest";
+import { SESSION_GC_AFTER_MS } from "./component/core";
 import type { LogtoSessionApi } from "./session";
 import {
   COOKIE_SESSION_MARKER,
@@ -15,13 +17,7 @@ import {
 const APP_ORIGIN = "https://app.example.com";
 const BASE_PATH = "/api/logto";
 
-const api = {
-  signIn: { fn: "signIn" },
-  callback: { fn: "callback" },
-  refresh: { fn: "refresh" },
-  signOut: { fn: "signOut" },
-  sessionValid: { fn: "sessionValid" },
-} as unknown as LogtoSessionApi;
+const api = anyApi.auth as unknown as LogtoSessionApi;
 
 type HandlerName = "signIn" | "callback" | "refresh" | "signOut";
 type Handlers = Record<HandlerName, ReturnType<typeof vi.fn>>;
@@ -47,7 +43,9 @@ function makeHarness(options?: { deviceBinding?: boolean }) {
     }),
   };
   const action = vi.fn((reference: unknown, args: unknown) => {
-    const name = (reference as { fn: HandlerName }).fn;
+    const name = getFunctionName(
+      reference as FunctionReference<"action">,
+    ).split(":")[1] as HandlerName;
     return handlers[name](args);
   }) as unknown as LogtoSessionAction;
   const handler = createLogtoSessionCookieHandler({
@@ -62,6 +60,13 @@ function makeHarness(options?: { deviceBinding?: boolean }) {
 
 function cookie(value: string): string {
   return `${LOGTO_SESSION_COOKIE_NAME}=${encodeURIComponent(value)}`;
+}
+
+function persistentCookie(value: string): string {
+  return (
+    `${cookie(value)}; Path=/; HttpOnly; Secure; SameSite=Lax; ` +
+    `Max-Age=${SESSION_GC_AFTER_MS / 1000}`
+  );
 }
 
 function request(
@@ -147,6 +152,55 @@ describe("fixed CSRF policy", () => {
   });
 });
 
+describe("request validation", () => {
+  it("returns 400 without logging or dispatching malformed action arguments", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { handler, action } = makeHarness();
+    const cases: Array<{
+      route: Parameters<typeof request>[0];
+      body: Record<string, unknown>;
+      cookie?: string;
+      message: string;
+    }> = [
+      {
+        route: "sign-in",
+        body: { redirectUri: 42 },
+        message: "redirectUri must be a non-empty string",
+      },
+      {
+        route: "sign-in",
+        body: { redirectUri: "not a URL" },
+        message: "redirectUri must use the calling browser origin",
+      },
+      {
+        route: "sign-out",
+        body: { postLogoutRedirectUri: 42 },
+        cookie: cookie("session-token-1"),
+        message:
+          "postLogoutRedirectUri must be a non-empty string when provided",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const response = await handler(
+        request(testCase.route, {
+          body: testCase.body,
+          cookie: testCase.cookie,
+        }),
+      );
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error: testCase.message,
+      });
+    }
+    expect(action).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});
+
 describe("cookie session flows", () => {
   it("sign-in calls the existing action without touching a cookie", async () => {
     const { handler, handlers } = makeHarness();
@@ -182,7 +236,7 @@ describe("cookie session flows", () => {
     );
     expect(response.status).toBe(200);
     expect(response.headers.get("set-cookie")).toBe(
-      `${LOGTO_SESSION_COOKIE_NAME}=session-token-1; Path=/; HttpOnly; Secure; SameSite=Lax`,
+      persistentCookie("session-token-1"),
     );
     const body = (await response.json()) as Record<string, unknown>;
     expect(body).toEqual({
@@ -208,7 +262,7 @@ describe("cookie session flows", () => {
       sessionToken: "session-token-1",
     });
     expect(response.headers.get("set-cookie")).toBe(
-      `${LOGTO_SESSION_COOKIE_NAME}=session-token-2; Path=/; HttpOnly; Secure; SameSite=Lax`,
+      persistentCookie("session-token-2"),
     );
     await expect(response.json()).resolves.toEqual({
       idToken: "id-token-2",
@@ -251,6 +305,7 @@ describe("cookie session flows", () => {
     );
     expect(response.status).toBe(401);
     expect(response.headers.get("set-cookie")).toContain("Max-Age=0");
+    expect(response.headers.get("set-cookie")).toContain("Path=/");
   });
 });
 
@@ -300,6 +355,7 @@ describe("SSR seed", () => {
     expect(seed.initialToken).toBeNull();
     expect(seed.initialSessionId).toBeNull();
     expect(seed.headers.get("set-cookie")).toContain("Max-Age=0");
+    expect(seed.headers.get("set-cookie")).toContain("Path=/");
   });
 
   it("leaves the cookie intact and returns an empty seed after a transient error", async () => {
@@ -323,8 +379,9 @@ describe("SSR seed", () => {
 });
 
 describe("browser transport", () => {
-  it("sends credentials + CSRF header and exposes only a non-secret marker", async () => {
-    const fetcher = vi.fn(async (input: string | URL | Request) => {
+  it("dispatches fresh Convex proxy references by name and exposes only a non-secret marker", async () => {
+    expect(api.callback).not.toBe(api.callback);
+    const fetchMock = vi.fn<typeof globalThis.fetch>(async (input) => {
       const url = String(input);
       if (url.endsWith("/callback")) {
         return Response.json({
@@ -334,10 +391,10 @@ describe("browser transport", () => {
         });
       }
       throw new Error(`unexpected route ${url}`);
-    }) as typeof globalThis.fetch;
+    });
     const transport = createLogtoSessionCookieTransport(api, {
       endpoint: BASE_PATH,
-      fetch: fetcher,
+      fetch: fetchMock,
     });
     const result = await transport.action(api.callback, {
       code: "code-1",
@@ -350,7 +407,7 @@ describe("browser transport", () => {
       returnTo: "/dashboard",
       sessionToken: COOKIE_SESSION_MARKER,
     });
-    const [, init] = fetcher.mock.calls[0]!;
+    const [, init] = fetchMock.mock.calls[0]!;
     expect(init?.method).toBe("POST");
     expect(init?.credentials).toBe("include");
     expect(new Headers(init?.headers).get(LOGTO_SESSION_CSRF_HEADER)).toBe(

--- a/packages/convex-logto/src/session-cookie.ts
+++ b/packages/convex-logto/src/session-cookie.ts
@@ -1,7 +1,7 @@
 import type { FunctionReference } from "convex/server";
 import { ConvexError } from "convex/values";
 import { isSafeReturnTo } from "./callback";
-import type { SessionTransport } from "./session-client";
+import type { SessionTransport, StoredSession } from "./session-client";
 import type { LogtoSessionApi } from "./session";
 
 /** Fixed host-only cookie used by the session cookie transport. */
@@ -21,6 +21,20 @@ export const LOGTO_SESSION_COOKIE_BASE_PATH = "/api/logto-session";
  * still needs a non-secret marker so it knows a cookie-backed session exists.
  */
 export const COOKIE_SESSION_MARKER = "cookie-session";
+
+/**
+ * Replace a JavaScript-visible session credential with the cookie marker while
+ * retaining the stable id used by reactive revocation checks.
+ */
+export function createCookieSessionMarker(
+  existingSession: StoredSession | null,
+  initialSessionId?: string | null,
+): StoredSession {
+  return {
+    token: COOKIE_SESSION_MARKER,
+    sessionId: initialSessionId ?? existingSession?.sessionId ?? "",
+  };
+}
 
 type SessionAction = FunctionReference<"action">;
 
@@ -550,8 +564,11 @@ export function createLogtoSessionCookieHandler(
           headers,
         };
       } catch (error) {
-        if (errorData(error)?.kind !== "terminal") throw error;
-        headers.set("Set-Cookie", clearCookieHeader());
+        const data = errorData(error);
+        if (data === null) throw error;
+        if (data.kind === "terminal") {
+          headers.set("Set-Cookie", clearCookieHeader());
+        }
         return {
           initialToken: null,
           initialSessionId: null,

--- a/packages/convex-logto/src/session-cookie.ts
+++ b/packages/convex-logto/src/session-cookie.ts
@@ -76,7 +76,8 @@ export type LogtoSessionCookieHandler = {
   /**
    * Best-effort SSR seed. Call at most once per incoming document request and
    * always forward the returned headers. Concurrent requests that contend for
-   * refresh return an empty seed while leaving the cookie intact.
+   * refresh return an empty seed. Only a successful rotation emits Set-Cookie;
+   * every failure leaves the incoming cookie untouched for browser recovery.
    */
   getInitialToken(request: Request): Promise<LogtoSessionCookieSeed>;
 };
@@ -587,11 +588,7 @@ export function createLogtoSessionCookieHandler(
           headers,
         };
       } catch (error) {
-        const data = errorData(error);
-        if (data === null) throw error;
-        if (data.kind === "terminal") {
-          headers.set("Set-Cookie", clearCookieHeader());
-        }
+        if (errorData(error) === null) throw error;
         return {
           initialToken: null,
           initialSessionId: null,

--- a/packages/convex-logto/src/session-cookie.ts
+++ b/packages/convex-logto/src/session-cookie.ts
@@ -1,0 +1,663 @@
+import type { FunctionReference } from "convex/server";
+import { ConvexError } from "convex/values";
+import { isSafeReturnTo } from "./callback";
+import type { SessionTransport } from "./session-client";
+import type { LogtoSessionApi } from "./session";
+
+/** Fixed host-only cookie used by the session cookie transport. */
+export const LOGTO_SESSION_COOKIE_NAME = "__Host-convex-logto-session";
+
+/** Fixed non-simple request header required on every state-changing request. */
+export const LOGTO_SESSION_CSRF_HEADER = "x-convex-logto-csrf";
+
+/** Fixed value for {@link LOGTO_SESSION_CSRF_HEADER}. */
+export const LOGTO_SESSION_CSRF_VALUE = "1";
+
+/** Default mount point for the four cookie transport routes. */
+export const LOGTO_SESSION_COOKIE_BASE_PATH = "/api/logto-session";
+
+/**
+ * The cookie credential never enters JavaScript. The existing session engine
+ * still needs a non-secret marker so it knows a cookie-backed session exists.
+ */
+export const COOKIE_SESSION_MARKER = "cookie-session";
+
+type SessionAction = FunctionReference<"action">;
+
+/** The action-calling slice shared by ConvexHttpClient and an HTTP action ctx. */
+export type LogtoSessionAction = <Action extends SessionAction>(
+  action: Action,
+  args: Action["_args"],
+) => Promise<Action["_returnType"]>;
+
+export type LogtoSessionCookieHandlerOptions = {
+  /** The module re-exporting `logtoSessionApi(...)`, e.g. `api.auth`. */
+  sessionApi: LogtoSessionApi;
+  /** Call a public Convex action (usually `client.action` or `ctx.runAction`). */
+  action: LogtoSessionAction;
+  /** Exact browser origins allowed to call the handler. Wildcards are rejected. */
+  allowedOrigins: readonly string[];
+  /** Mount point containing `sign-in`, `callback`, `token`, and `sign-out`. */
+  basePath?: string;
+  /**
+   * Mirror the session provider's future device-binding flag. Safari cannot
+   * safely combine its ITP storage behavior with this cookie transport.
+   */
+  deviceBinding?: boolean;
+};
+
+export type LogtoSessionCookieSeed = {
+  /** Fresh ID token to pass to `ConvexLogtoSessionProvider`. */
+  initialToken: string | null;
+  /** Stable session id for reactive revocation. */
+  initialSessionId: string | null;
+  /** Forward these headers to the SSR response so the rotated cookie lands. */
+  headers: Headers;
+};
+
+/** A web-standard fetch handler plus a server-only SSR seeding helper. */
+export type LogtoSessionCookieHandler = {
+  (request: Request): Promise<Response>;
+  getInitialToken(request: Request): Promise<LogtoSessionCookieSeed>;
+};
+
+export type LogtoSessionCookieTransportOptions = {
+  /** Handler mount point (relative or absolute). Default `/api/logto-session`. */
+  endpoint?: string;
+  /** Injectable Fetch implementation. Defaults to `globalThis.fetch`. */
+  fetch?: typeof globalThis.fetch;
+  /** See `LogtoSessionCookieHandlerOptions.deviceBinding`. */
+  deviceBinding?: boolean;
+};
+
+type SessionError = {
+  kind: "terminal" | "transient";
+  code: string;
+  message: string;
+};
+
+type CookieRoute = "sign-in" | "callback" | "token" | "sign-out";
+
+const COOKIE_ROUTES = new Set<CookieRoute>([
+  "sign-in",
+  "callback",
+  "token",
+  "sign-out",
+]);
+
+const NO_STORE_HEADERS = { "Cache-Control": "no-store" } as const;
+
+function normalizeBasePath(basePath: string): string {
+  const value = basePath.trim();
+  if (!value.startsWith("/") || value.includes("?") || value.includes("#")) {
+    throw new Error(
+      `convex-logto: session cookie basePath must be an absolute path (got "${basePath}").`,
+    );
+  }
+  return value.length > 1 ? value.replace(/\/+$/, "") : value;
+}
+
+function normalizeEndpoint(endpoint: string): string {
+  const value = endpoint.trim().replace(/\/+$/, "");
+  if (!value) {
+    throw new Error("convex-logto: session cookie endpoint cannot be empty.");
+  }
+  if (value.startsWith("/")) return value;
+  const url = new URL(value);
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new Error(
+      "convex-logto: session cookie endpoint must use http or https.",
+    );
+  }
+  return url.toString().replace(/\/+$/, "");
+}
+
+function normalizeAllowedOrigins(origins: readonly string[]): Set<string> {
+  if (origins.length === 0) {
+    throw new Error(
+      "convex-logto: allowedOrigins must contain at least one exact browser origin.",
+    );
+  }
+  return new Set(
+    origins.map((origin) => {
+      const value = origin.trim();
+      const url = new URL(value);
+      if (
+        (url.protocol !== "https:" && url.protocol !== "http:") ||
+        url.username !== "" ||
+        url.password !== "" ||
+        url.pathname !== "/" ||
+        url.search !== "" ||
+        url.hash !== ""
+      ) {
+        throw new Error(
+          `convex-logto: allowedOrigins entries must be exact http(s) origins (got "${origin}").`,
+        );
+      }
+      return url.origin;
+    }),
+  );
+}
+
+function cookieHeader(sessionToken: string): string {
+  return (
+    `${LOGTO_SESSION_COOKIE_NAME}=${encodeURIComponent(sessionToken)}; ` +
+    "Path=/; HttpOnly; Secure; SameSite=Lax"
+  );
+}
+
+function clearCookieHeader(): string {
+  return (
+    `${LOGTO_SESSION_COOKIE_NAME}=; Path=/; HttpOnly; Secure; ` +
+    "SameSite=Lax; Max-Age=0"
+  );
+}
+
+function readCookie(request: Request): string | null {
+  const header = request.headers.get("cookie");
+  if (!header) return null;
+  for (const part of header.split(";")) {
+    const index = part.indexOf("=");
+    if (index < 0) continue;
+    const name = part.slice(0, index).trim();
+    if (name !== LOGTO_SESSION_COOKIE_NAME) continue;
+    try {
+      return decodeURIComponent(part.slice(index + 1).trim()) || null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function routeFor(request: Request, basePath: string): CookieRoute | null {
+  const pathname = new URL(request.url).pathname;
+  const prefix = basePath === "/" ? "/" : `${basePath}/`;
+  if (!pathname.startsWith(prefix)) return null;
+  const route = pathname.slice(prefix.length);
+  return COOKIE_ROUTES.has(route as CookieRoute)
+    ? (route as CookieRoute)
+    : null;
+}
+
+function corsHeaders(origin: string): Headers {
+  return new Headers({
+    "Access-Control-Allow-Credentials": "true",
+    "Access-Control-Allow-Origin": origin,
+    Vary: "Origin",
+  });
+}
+
+function responseWithCors(response: Response, origin: string | null): Response {
+  if (origin === null) return response;
+  for (const [name, value] of corsHeaders(origin)) {
+    response.headers.set(name, value);
+  }
+  return response;
+}
+
+function jsonResponse(
+  value: unknown,
+  init: ResponseInit = {},
+  origin: string | null = null,
+): Response {
+  const headers = new Headers(init.headers);
+  headers.set("Cache-Control", "no-store");
+  headers.set("Content-Type", "application/json");
+  return responseWithCors(
+    new Response(JSON.stringify(value), { ...init, headers }),
+    origin,
+  );
+}
+
+function errorData(error: unknown): SessionError | null {
+  const data =
+    error instanceof ConvexError
+      ? error.data
+      : typeof error === "object" && error !== null && "data" in error
+        ? (error as { data?: unknown }).data
+        : undefined;
+  if (typeof data !== "object" || data === null) return null;
+  const { kind, code, message } = data as Record<string, unknown>;
+  return (kind === "terminal" || kind === "transient") &&
+    typeof code === "string" &&
+    typeof message === "string"
+    ? { kind, code, message }
+    : null;
+}
+
+function actionErrorResponse(
+  error: unknown,
+  origin: string,
+  headers?: HeadersInit,
+): Response {
+  const data = errorData(error);
+  if (data) {
+    return jsonResponse(
+      { error: data },
+      {
+        status: data.kind === "terminal" ? 401 : 503,
+        headers,
+      },
+      origin,
+    );
+  }
+  console.error("convex-logto: session cookie action failed.", error);
+  return jsonResponse(
+    {
+      error: {
+        kind: "transient",
+        code: "session_transport_failed",
+        message: "The session service is temporarily unavailable.",
+      } satisfies SessionError,
+    },
+    { status: 500, headers },
+    origin,
+  );
+}
+
+async function readJsonObject(
+  request: Request,
+): Promise<Record<string, unknown>> {
+  const text = await request.text();
+  if (text === "") return {};
+  const parsed: unknown = JSON.parse(text);
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("request body must be a JSON object");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function requiredString(body: Record<string, unknown>, name: string): string {
+  const value = body[name];
+  if (typeof value !== "string" || value === "") {
+    throw new Error(`${name} must be a non-empty string`);
+  }
+  return value;
+}
+
+function optionalString(
+  body: Record<string, unknown>,
+  name: string,
+): string | undefined {
+  const value = body[name];
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || value === "") {
+    throw new Error(`${name} must be a non-empty string when provided`);
+  }
+  return value;
+}
+
+function validateRedirectUri(value: string, requestOrigin: string): string {
+  const url = new URL(value);
+  if (url.origin !== requestOrigin || url.protocol === "javascript:") {
+    throw new Error("redirectUri must use the calling browser origin");
+  }
+  return value;
+}
+
+function isSafari(userAgent: string): boolean {
+  return (
+    /Safari\//.test(userAgent) &&
+    !/(?:Chrome|Chromium|CriOS|Edg|EdgiOS|OPR|OPiOS|FxiOS|Firefox)\//.test(
+      userAgent,
+    )
+  );
+}
+
+/**
+ * Throw when Safari would combine cookie transport with software device
+ * binding. Exported so future non-React adapters can enforce the same rule.
+ */
+export function assertLogtoSessionCookieCompatibility(options: {
+  deviceBinding?: boolean;
+  userAgent?: string | null;
+}): void {
+  if (options.deviceBinding && isSafari(options.userAgent ?? "")) {
+    throw new Error(
+      "convex-logto: session cookie transport and device binding cannot be enabled together on Safari because ITP can evict the bound key while retaining the cookie. Disable one of them; silent fallback is not allowed.",
+    );
+  }
+}
+
+/**
+ * Build the same-site cookie transport's four-route standard-fetch handler.
+ * The returned function can be exported directly as a Next.js POST/OPTIONS
+ * handler or called from TanStack Start and Convex HTTP actions.
+ */
+export function createLogtoSessionCookieHandler(
+  options: LogtoSessionCookieHandlerOptions,
+): LogtoSessionCookieHandler {
+  const basePath = normalizeBasePath(
+    options.basePath ?? LOGTO_SESSION_COOKIE_BASE_PATH,
+  );
+  const allowedOrigins = normalizeAllowedOrigins(options.allowedOrigins);
+
+  const refreshFromCookie = async (request: Request) => {
+    const sessionToken = readCookie(request);
+    if (sessionToken === null) {
+      throw new ConvexError({
+        kind: "terminal" as const,
+        code: "session_cookie_missing",
+        message: "No session cookie is present. Sign in again.",
+      });
+    }
+    return await options.action(options.sessionApi.refresh, { sessionToken });
+  };
+
+  const handleRoute = async (
+    route: CookieRoute,
+    request: Request,
+    origin: string,
+  ): Promise<Response> => {
+    let body: Record<string, unknown>;
+    try {
+      body = await readJsonObject(request);
+    } catch {
+      return jsonResponse(
+        { error: "Malformed JSON request body" },
+        { status: 400 },
+        origin,
+      );
+    }
+
+    try {
+      switch (route) {
+        case "sign-in": {
+          const redirectUri = validateRedirectUri(
+            requiredString(body, "redirectUri"),
+            origin,
+          );
+          const returnTo = optionalString(body, "returnTo");
+          if (returnTo !== undefined && !isSafeReturnTo(returnTo)) {
+            return jsonResponse(
+              { error: "returnTo must be a same-origin path" },
+              { status: 400 },
+              origin,
+            );
+          }
+          const result = await options.action(options.sessionApi.signIn, {
+            redirectUri,
+            returnTo,
+          });
+          return jsonResponse(result, {}, origin);
+        }
+        case "callback": {
+          const result = await options.action(options.sessionApi.callback, {
+            code: requiredString(body, "code"),
+            state: requiredString(body, "state"),
+            redirectUri: validateRedirectUri(
+              requiredString(body, "redirectUri"),
+              origin,
+            ),
+          });
+          return jsonResponse(
+            {
+              idToken: result.idToken,
+              sessionId: result.sessionId,
+              returnTo: result.returnTo,
+            },
+            { headers: { "Set-Cookie": cookieHeader(result.sessionToken) } },
+            origin,
+          );
+        }
+        case "token": {
+          const result = await refreshFromCookie(request);
+          return jsonResponse(
+            { idToken: result.idToken, sessionId: result.sessionId },
+            { headers: { "Set-Cookie": cookieHeader(result.sessionToken) } },
+            origin,
+          );
+        }
+        case "sign-out": {
+          const headers = new Headers({
+            "Set-Cookie": clearCookieHeader(),
+          });
+          const sessionToken = readCookie(request);
+          if (sessionToken === null)
+            return jsonResponse({}, { headers }, origin);
+          try {
+            const result = await options.action(options.sessionApi.signOut, {
+              sessionToken,
+              postLogoutRedirectUri: optionalString(
+                body,
+                "postLogoutRedirectUri",
+              ),
+            });
+            return jsonResponse(result, { headers }, origin);
+          } catch (error) {
+            return actionErrorResponse(error, origin, headers);
+          }
+        }
+      }
+    } catch (error) {
+      const data = errorData(error);
+      const headers =
+        route === "token" && data?.kind === "terminal"
+          ? { "Set-Cookie": clearCookieHeader() }
+          : undefined;
+      return actionErrorResponse(error, origin, headers);
+    }
+  };
+
+  const handle = async (request: Request): Promise<Response> => {
+    const route = routeFor(request, basePath);
+    if (route === null) {
+      return new Response("Not found", {
+        status: 404,
+        headers: NO_STORE_HEADERS,
+      });
+    }
+
+    const rawOrigin = request.headers.get("origin");
+    const origin =
+      rawOrigin !== null && allowedOrigins.has(rawOrigin) ? rawOrigin : null;
+
+    if (request.method === "OPTIONS") {
+      if (origin === null) {
+        return new Response("Origin is not allowed", {
+          status: 403,
+          headers: NO_STORE_HEADERS,
+        });
+      }
+      const requestedMethod = request.headers.get(
+        "access-control-request-method",
+      );
+      const requestedHeaders = (
+        request.headers.get("access-control-request-headers") ?? ""
+      )
+        .toLowerCase()
+        .split(",")
+        .map((value) => value.trim());
+      if (
+        requestedMethod !== "POST" ||
+        !requestedHeaders.includes(LOGTO_SESSION_CSRF_HEADER)
+      ) {
+        return responseWithCors(
+          new Response("Invalid preflight", {
+            status: 403,
+            headers: NO_STORE_HEADERS,
+          }),
+          origin,
+        );
+      }
+      const headers = corsHeaders(origin);
+      headers.set(
+        "Access-Control-Allow-Headers",
+        `${LOGTO_SESSION_CSRF_HEADER}, content-type`,
+      );
+      headers.set("Access-Control-Allow-Methods", "POST");
+      headers.set("Cache-Control", "no-store");
+      return new Response(null, { status: 204, headers });
+    }
+
+    if (request.method !== "POST") {
+      return responseWithCors(
+        new Response("Method not allowed", {
+          status: 405,
+          headers: { ...NO_STORE_HEADERS, Allow: "POST, OPTIONS" },
+        }),
+        origin,
+      );
+    }
+    if (origin === null) {
+      return new Response("Origin is not allowed", {
+        status: 403,
+        headers: NO_STORE_HEADERS,
+      });
+    }
+    if (
+      request.headers.get(LOGTO_SESSION_CSRF_HEADER) !==
+      LOGTO_SESSION_CSRF_VALUE
+    ) {
+      return responseWithCors(
+        new Response("Missing or invalid CSRF header", {
+          status: 403,
+          headers: NO_STORE_HEADERS,
+        }),
+        origin,
+      );
+    }
+    assertLogtoSessionCookieCompatibility({
+      deviceBinding: options.deviceBinding,
+      userAgent: request.headers.get("user-agent"),
+    });
+    return await handleRoute(route, request, origin);
+  };
+
+  return Object.assign(handle, {
+    getInitialToken: async (
+      request: Request,
+    ): Promise<LogtoSessionCookieSeed> => {
+      assertLogtoSessionCookieCompatibility({
+        deviceBinding: options.deviceBinding,
+        userAgent: request.headers.get("user-agent"),
+      });
+      const headers = new Headers(NO_STORE_HEADERS);
+      if (readCookie(request) === null) {
+        return {
+          initialToken: null,
+          initialSessionId: null,
+          headers,
+        };
+      }
+      try {
+        const result = await refreshFromCookie(request);
+        headers.set("Set-Cookie", cookieHeader(result.sessionToken));
+        return {
+          initialToken: result.idToken,
+          initialSessionId: result.sessionId,
+          headers,
+        };
+      } catch (error) {
+        if (errorData(error)?.kind !== "terminal") throw error;
+        headers.set("Set-Cookie", clearCookieHeader());
+        return {
+          initialToken: null,
+          initialSessionId: null,
+          headers,
+        };
+      }
+    },
+  });
+}
+
+function browserUserAgent(): string | null {
+  return typeof navigator === "undefined" ? null : navigator.userAgent;
+}
+
+function endpointRoute(endpoint: string, route: CookieRoute): string {
+  return `${endpoint}/${route}`;
+}
+
+async function parseFetchResponse(response: Response): Promise<unknown> {
+  const body = (await response.json().catch(() => ({}))) as {
+    error?: unknown;
+  };
+  if (response.ok) return body;
+  if (typeof body.error === "object" && body.error !== null) {
+    const { kind, code, message } = body.error as Record<string, unknown>;
+    if (
+      (kind === "terminal" || kind === "transient") &&
+      typeof code === "string" &&
+      typeof message === "string"
+    ) {
+      throw new ConvexError({ kind, code, message });
+    }
+  }
+  throw new Error(
+    `convex-logto: session cookie handler responded ${response.status}.`,
+  );
+}
+
+/**
+ * Browser adapter for `SessionAuthEngine`. Session-token arguments are ignored:
+ * the browser can only present the HttpOnly cookie through Fetch credentials.
+ */
+export function createLogtoSessionCookieTransport(
+  sessionApi: LogtoSessionApi,
+  options: LogtoSessionCookieTransportOptions = {},
+): SessionTransport {
+  assertLogtoSessionCookieCompatibility({
+    deviceBinding: options.deviceBinding,
+    userAgent: browserUserAgent(),
+  });
+  const endpoint = normalizeEndpoint(
+    options.endpoint ?? LOGTO_SESSION_COOKIE_BASE_PATH,
+  );
+  const fetcher = options.fetch ?? globalThis.fetch;
+
+  const post = async (route: CookieRoute, body: unknown): Promise<unknown> => {
+    const response = await fetcher(endpointRoute(endpoint, route), {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json",
+        [LOGTO_SESSION_CSRF_HEADER]: LOGTO_SESSION_CSRF_VALUE,
+      },
+      body: JSON.stringify(body),
+    });
+    return await parseFetchResponse(response);
+  };
+
+  return {
+    action: async <Action extends SessionAction>(
+      action: Action,
+      args: Action["_args"],
+    ): Promise<Action["_returnType"]> => {
+      if (action === sessionApi.signIn) {
+        return (await post("sign-in", args)) as Action["_returnType"];
+      }
+      if (action === sessionApi.callback) {
+        const result = (await post("callback", args)) as {
+          idToken: string;
+          sessionId: string;
+          returnTo?: string;
+        };
+        return {
+          ...result,
+          sessionToken: COOKIE_SESSION_MARKER,
+        } as Action["_returnType"];
+      }
+      if (action === sessionApi.refresh) {
+        const result = (await post("token", {})) as {
+          idToken: string;
+          sessionId: string;
+        };
+        return {
+          ...result,
+          sessionToken: COOKIE_SESSION_MARKER,
+        } as Action["_returnType"];
+      }
+      if (action === sessionApi.signOut) {
+        return (await post("sign-out", {
+          postLogoutRedirectUri: (args as { postLogoutRedirectUri?: string })
+            .postLogoutRedirectUri,
+        })) as Action["_returnType"];
+      }
+      throw new Error(
+        "convex-logto: the cookie transport received an unknown session action.",
+      );
+    },
+  };
+}

--- a/packages/convex-logto/src/session-cookie.ts
+++ b/packages/convex-logto/src/session-cookie.ts
@@ -1,6 +1,7 @@
-import type { FunctionReference } from "convex/server";
+import { getFunctionName, type FunctionReference } from "convex/server";
 import { ConvexError } from "convex/values";
 import { isSafeReturnTo } from "./callback";
+import { SESSION_GC_AFTER_MS } from "./component/core.js";
 import type { SessionTransport, StoredSession } from "./session-client";
 import type { LogtoSessionApi } from "./session";
 
@@ -65,13 +66,18 @@ export type LogtoSessionCookieSeed = {
   initialToken: string | null;
   /** Stable session id for reactive revocation. */
   initialSessionId: string | null;
-  /** Forward these headers to the SSR response so the rotated cookie lands. */
+  /** Always forward these headers to the SSR response so the rotated cookie lands. */
   headers: Headers;
 };
 
 /** A web-standard fetch handler plus a server-only SSR seeding helper. */
 export type LogtoSessionCookieHandler = {
   (request: Request): Promise<Response>;
+  /**
+   * Best-effort SSR seed. Call at most once per incoming document request and
+   * always forward the returned headers. Concurrent requests that contend for
+   * refresh return an empty seed while leaving the cookie intact.
+   */
   getInitialToken(request: Request): Promise<LogtoSessionCookieSeed>;
 };
 
@@ -156,7 +162,7 @@ function normalizeAllowedOrigins(origins: readonly string[]): Set<string> {
 function cookieHeader(sessionToken: string): string {
   return (
     `${LOGTO_SESSION_COOKIE_NAME}=${encodeURIComponent(sessionToken)}; ` +
-    "Path=/; HttpOnly; Secure; SameSite=Lax"
+    `Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${SESSION_GC_AFTER_MS / 1000}`
   );
 }
 
@@ -240,6 +246,8 @@ function errorData(error: unknown): SessionError | null {
     : null;
 }
 
+class RequestValidationError extends Error {}
+
 function actionErrorResponse(
   error: unknown,
   origin: string,
@@ -285,7 +293,7 @@ async function readJsonObject(
 function requiredString(body: Record<string, unknown>, name: string): string {
   const value = body[name];
   if (typeof value !== "string" || value === "") {
-    throw new Error(`${name} must be a non-empty string`);
+    throw new RequestValidationError(`${name} must be a non-empty string`);
   }
   return value;
 }
@@ -297,15 +305,26 @@ function optionalString(
   const value = body[name];
   if (value === undefined) return undefined;
   if (typeof value !== "string" || value === "") {
-    throw new Error(`${name} must be a non-empty string when provided`);
+    throw new RequestValidationError(
+      `${name} must be a non-empty string when provided`,
+    );
   }
   return value;
 }
 
 function validateRedirectUri(value: string, requestOrigin: string): string {
-  const url = new URL(value);
-  if (url.origin !== requestOrigin || url.protocol === "javascript:") {
-    throw new Error("redirectUri must use the calling browser origin");
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new RequestValidationError(
+      "redirectUri must use the calling browser origin",
+    );
+  }
+  if (url.origin !== requestOrigin) {
+    throw new RequestValidationError(
+      "redirectUri must use the calling browser origin",
+    );
   }
   return value;
 }
@@ -427,16 +446,17 @@ export function createLogtoSessionCookieHandler(
           const headers = new Headers({
             "Set-Cookie": clearCookieHeader(),
           });
+          const postLogoutRedirectUri = optionalString(
+            body,
+            "postLogoutRedirectUri",
+          );
           const sessionToken = readCookie(request);
           if (sessionToken === null)
             return jsonResponse({}, { headers }, origin);
           try {
             const result = await options.action(options.sessionApi.signOut, {
               sessionToken,
-              postLogoutRedirectUri: optionalString(
-                body,
-                "postLogoutRedirectUri",
-              ),
+              postLogoutRedirectUri,
             });
             return jsonResponse(result, { headers }, origin);
           } catch (error) {
@@ -445,6 +465,9 @@ export function createLogtoSessionCookieHandler(
         }
       }
     } catch (error) {
+      if (error instanceof RequestValidationError) {
+        return jsonResponse({ error: error.message }, { status: 400 }, origin);
+      }
       const data = errorData(error);
       const headers =
         route === "token" && data?.kind === "terminal"
@@ -623,6 +646,12 @@ export function createLogtoSessionCookieTransport(
     options.endpoint ?? LOGTO_SESSION_COOKIE_BASE_PATH,
   );
   const fetcher = options.fetch ?? globalThis.fetch;
+  const actionNames = {
+    signIn: getFunctionName(sessionApi.signIn),
+    callback: getFunctionName(sessionApi.callback),
+    refresh: getFunctionName(sessionApi.refresh),
+    signOut: getFunctionName(sessionApi.signOut),
+  };
 
   const post = async (route: CookieRoute, body: unknown): Promise<unknown> => {
     const response = await fetcher(endpointRoute(endpoint, route), {
@@ -642,10 +671,11 @@ export function createLogtoSessionCookieTransport(
       action: Action,
       args: Action["_args"],
     ): Promise<Action["_returnType"]> => {
-      if (action === sessionApi.signIn) {
+      const actionName = getFunctionName(action);
+      if (actionName === actionNames.signIn) {
         return (await post("sign-in", args)) as Action["_returnType"];
       }
-      if (action === sessionApi.callback) {
+      if (actionName === actionNames.callback) {
         const result = (await post("callback", args)) as {
           idToken: string;
           sessionId: string;
@@ -656,7 +686,7 @@ export function createLogtoSessionCookieTransport(
           sessionToken: COOKIE_SESSION_MARKER,
         } as Action["_returnType"];
       }
-      if (action === sessionApi.refresh) {
+      if (actionName === actionNames.refresh) {
         const result = (await post("token", {})) as {
           idToken: string;
           sessionId: string;
@@ -666,7 +696,7 @@ export function createLogtoSessionCookieTransport(
           sessionToken: COOKIE_SESSION_MARKER,
         } as Action["_returnType"];
       }
-      if (action === sessionApi.signOut) {
+      if (actionName === actionNames.signOut) {
         return (await post("sign-out", {
           postLogoutRedirectUri: (args as { postLogoutRedirectUri?: string })
             .postLogoutRedirectUri,


### PR DESCRIPTION
Closes #28.

## Summary

- add a web-standard four-route session cookie handler (`sign-in`, `callback`, `token`, `sign-out`) with a fixed `__Host-` HttpOnly/Secure/SameSite=Lax cookie and rolling rotation
- enforce POST + fixed custom header + exact Origin allowlist, including credentialed CORS for same-site custom-domain mounts
- integrate an optional cookie transport into `ConvexLogtoSessionProvider`, keeping only a non-secret browser marker while preserving restore, cross-tab sign-out, Web Locks, and reactive revocation
- add `getInitialToken(request)` plus provider seed props for authenticated SSR/hydration
- throw loudly for Safari when cookie transport and device binding are combined
- document Next.js, TanStack Start, and Convex custom-domain mounts and add a minor changeset

## Design notes

- The handler is exported from the existing dual ESM/CJS root entry; no new package subpath was needed.
- Server integrations inject one generic Convex action callback, so the same handler composes with `ConvexHttpClient` and Convex HTTP action contexts without Node-only APIs.
- Callback/token JSON never includes the rotating session credential; the browser adapter substitutes a literal non-secret marker for the existing session engine.
- SSR seeding returns the rotated `Set-Cookie` header alongside `initialToken`/`initialSessionId`; callers must forward those headers.

## Validation

- `pnpm --filter convex-logto format`
- `pnpm --filter convex-logto test` — 155 passed
- `pnpm --filter convex-logto check-types`
- `pnpm --filter convex-logto lint`
- `pnpm --filter convex-logto build`
- `pnpm --filter convex-logto lint:package`
- `pnpm --filter docs build`

Changeset: `.changeset/lovely-brooms-lead.md` (minor).

Unrelated docs-build warnings discovered during validation are tracked separately in #36.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional same-site HttpOnly cookie transport for session mode.
  * Added secure sign-in, callback, refresh, and sign-out flows with CSRF and CORS protections.
  * Added SSR session hydration using initial token and session values.
  * Added integrations for Next.js, TanStack Start, and custom Convex HTTP actions.
  * Added compatibility checks for Safari device-binding limitations.

* **Bug Fixes**
  * Improved token rotation to preserve recently superseded sessions during refresh.

* **Documentation**
  * Expanded API, session-mode, and README guidance for configuration and security requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->