### PR TITLE
feat: add opt-in session device binding

### DIFF
--- a/.changeset/fluffy-cloths-tease.md
+++ b/.changeset/fluffy-cloths-tease.md
@@ -1,0 +1,5 @@
+---
+"convex-logto": minor
+---
+
+Add opt-in device binding for session tokens using non-extractable IndexedDB keys and proof-of-possession refresh signatures.

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -91,6 +91,11 @@ Options: `scopes` / `resources` (server-configured — the browser can't request
 its own), `reuseWindowMs` (default 10s), and `endpoint` / `appId` /
 `clientSecret` env overrides.
 
+The generated `callback` and `refresh` actions also accept optional
+device-binding fields used internally by `ConvexLogtoSessionProvider`
+(`devicePublicKey` and `deviceProof`). Existing callers and unbound sessions do
+not send them and retain the pre-binding behavior.
+
 ### `createLogtoSessionCookieHandler(opts)`
 
 Builds the [session mode cookie transport](/docs/session-mode#httponly-cookie-transport-optional)
@@ -100,8 +105,8 @@ as a standard `(Request) => Promise<Response>` handler. Options are:
 - `action(reference, args)` — calls the referenced public Convex action;
 - `allowedOrigins` — non-empty exact browser-origin allowlist;
 - `basePath` — default `/api/logto-session`;
-- `deviceBinding` — mirrors the device-binding flag so Safari can reject the
-  incompatible combination loudly.
+- `deviceBinding` — mirrors the device-binding flag so non-React mounts reject
+  the incompatible combination through the shared loud error.
 
 The four final path segments are `sign-in`, `callback`, `token`, and `sign-out`.
 Actual calls require POST, `x-convex-logto-csrf: 1`, and an allowed `Origin`;
@@ -117,6 +122,12 @@ document request and always forward `headers` to the SSR response so the rotated
 `ConvexLogtoSessionProvider`. Concurrent requests are best-effort: every failed
 seed returns empty without changing the cookie, while the browser `/token` route
 authoritatively clears a genuinely dead session.
+
+Cookie transport and device binding cannot be combined: HttpOnly makes the
+session token unavailable to the JavaScript-held signing key, and cookie
+transport already removes the off-device token-exfiltration path. The
+compatibility error applies on every browser; Safari ITP key eviction is an
+additional reason for the same exclusion.
 
 ### `assertUserHasActiveSession(ctx, component)`
 
@@ -200,13 +211,20 @@ in the bundle — it talks to the functions from `logtoSessionApi(...)`.
 | `afterSignIn` | — | Where to land after sign-in. Default `/`. `signIn({ returnTo })` overrides it. |
 | `navigate` | — | Your router's navigate (prefer replace-style) for soft post-sign-in navigation. Falls back to a hard `location.replace`. |
 | `tokenStorage` | — | Where the ID token persists: `"session"` (default, per-tab; reload without a round-trip), `"memory"` (strictest), `"local"`. |
-| `cookieTransport` | — | `{ endpoint?, fetch?, deviceBinding? }`; use the same-site handler instead of exposing the rotating session token to JavaScript. |
+| `deviceBinding` | — | Opt into ECDSA P-256 proof of possession backed by a non-extractable IndexedDB-held key. Default `false`; cannot be combined with `cookieTransport`. |
+| `cookieTransport` | — | `{ endpoint?, fetch?, deviceBinding? }`; use the same-site handler instead of exposing the rotating session token to JavaScript. Its reserved `deviceBinding` flag only activates the shared incompatibility assertion. |
 | `initialToken` / `initialSessionId` | — | Paired SSR seed returned by `handler.getInitialToken(request)`. |
 | `reactiveRevocation` | — | Subscribe to session liveness; drop auth live on revocation. Default `true`. |
-| `onAuthError` | — | Recoverable sign-in failures (stale/forged callback, Logto unreachable). Also logged to the console. |
+| `onAuthError` | — | Recoverable sign-in failures or opted-in device-key storage failures. Also logged to the console. |
 
 There is no callback component to add — the provider completes the exchange on
 `callbackPath` and replace-navigates into the app itself.
+
+With `deviceBinding`, the provider fails loudly if IndexedDB is unavailable,
+sends only the public key during callback, and signs each rotating session token
+before refresh. Key eviction makes the next refresh terminal and causes a clean
+re-authentication; unbound sessions remain the default and are unaffected. See
+the [session-mode threat model and DBSC re-evaluation note](/docs/session-mode#device-binding-optional).
 
 ### `useLogtoAuth()` (session)
 

--- a/docs/content/docs/session-mode.mdx
+++ b/docs/content/docs/session-mode.mdx
@@ -109,6 +109,55 @@ const { isAuthenticated, isLoading, user, signIn, signOut } = useLogtoAuth();
 // signOut() — revokes the grant, clears every tab, ends the Logto SSO session
 ```
 
+## Device binding (optional)
+
+Set `deviceBinding` to opt into proof of possession for the default session
+token transport:
+
+```tsx
+<ConvexLogtoSessionProvider
+  client={convex}
+  sessionApi={api.auth}
+  deviceBinding
+>
+  <App />
+</ConvexLogtoSessionProvider>
+```
+
+The browser generates an ECDSA P-256 keypair with Web Crypto and persists the
+`CryptoKeyPair` in deployment-namespaced IndexedDB. The private key is
+**non-extractable** and never reaches Convex; only its public JWK is captured
+when the callback creates the session. Every refresh signs the presented
+one-time session token, and the component verifies that signature before it
+claims or rotates the token. Because the token changes after every successful
+refresh, a captured proof cannot authorize the next generation (the existing
+10-second token-reuse grace still absorbs honest races).
+
+This protects against **off-device replay** after an attacker copies the
+JavaScript-visible session token: the token alone is no longer enough on
+another machine. It does not claim to defeat arbitrary code already executing
+on the same origin, which can ask the browser-held key to sign while that code
+is running.
+
+Binding is deliberately opt-in. If IndexedDB is unavailable, setup fails loudly
+instead of silently issuing an unbound session. If storage eviction removes the
+key while a bound session remains, the replacement key's next proof is rejected
+terminally and the client clears the session for a clean sign-in. That occasional
+re-authentication trade-off is why ordinary sessions remain unbound by default.
+
+Do not combine `deviceBinding` with `cookieTransport` on any browser. The cookie
+transport already prevents off-device replay by taking the token out of
+JavaScript, while device binding requires JavaScript to sign that exact token;
+supporting both would require weakening one of those guarantees. The shared
+compatibility assertion throws the same explicit configuration error regardless
+of which option you enable first. On Safari this also avoids the original ITP
+failure mode where IndexedDB can be evicted while the cookie survives.
+
+Re-evaluate this software fallback when
+[Device Bound Session Credentials (DBSC)](https://developer.chrome.com/docs/web-platform/device-bound-session-credentials)
+is available cross-browser. DBSC should become the preferred browser-managed
+mechanism once its interoperability and deployment support are broad enough.
+
 ## HttpOnly cookie transport (optional)
 
 The default one-time token is safe to rotate from `localStorage`, but an XSS bug
@@ -297,14 +346,14 @@ const seed = Route.useLoaderData();
 The server and hydration snapshots start authenticated, so Convex can accept the
 seeded ID token on the first paint without a browser `/token` round-trip.
 
-### Safari and device binding
+### Cookie transport versus device binding
 
-Cookie transport and software device binding are mutually exclusive on Safari:
-ITP can retain the cookie while evicting its IndexedDB-held key. Pass the same
-`deviceBinding: true` flag to the handler and `cookieTransport` configuration;
-Safari throws an explicit configuration error rather than silently dropping
-either protection. Device binding itself is tracked separately and is not
-implemented by the cookie adapter.
+Cookie transport and software device binding are alternative defenses against
+off-device session-token replay, not cumulative settings. Enabling both throws
+through `assertLogtoSessionCookieCompatibility`; the low-level handler and
+browser adapter retain a `deviceBinding` compatibility flag so non-React mounts
+fail through that same path. Safari's ITP key-eviction behavior is an additional
+reason for the exclusion, but the HttpOnly/signing conflict applies everywhere.
 
 ## Reactive revocation
 
@@ -351,11 +400,13 @@ is a 15-line version.
    forged or replayed callback is refused before any exchange.
 2. **Exchange** — the callback action redeems the code (client secret + PKCE),
    stores the refresh token in the component, and hands the browser the ID token
-   plus session token #1.
+   plus session token #1. With device binding enabled, it also stores the
+   browser's public key; the private key never leaves IndexedDB.
 3. **Refresh** — when the ID token nears expiry, the browser presents session
-   token #1; the component refreshes against Logto and answers with a fresh ID
-   token plus session token #2. Token #1's hash is kept briefly (10s) so
-   multi-tab races don't false-positive.
+   token #1 (and, for a bound session, its signature); the component verifies
+   proof before refreshing against Logto and answers with a fresh ID token plus
+   session token #2. Token #1's hash is kept briefly (10s) so multi-tab races
+   don't false-positive.
 4. **Theft detection** — if token #1 shows up *after* that window, someone has a
    copy. The component deletes the session and revokes the whole Logto grant;
    both the attacker and the victim are signed out, and the victim's next visit
@@ -379,10 +430,11 @@ destroy the grant.
 | `afterSignIn` | `"/"` | Where to land after sign-in; `signIn({ returnTo })` overrides. |
 | `navigate` | hard replace | Your router's navigate for soft post-sign-in navigation. |
 | `tokenStorage` | `"session"` | Where the ID token persists: `"session"` (per-tab, zero-round-trip reload), `"memory"` (strictest), `"local"`. |
-| `cookieTransport` | — | `{ endpoint?, fetch?, deviceBinding? }`: move the rotating session token into a persistent same-site HttpOnly cookie whose 190-day lifetime renews on every rotation. |
+| `deviceBinding` | `false` | Bind refreshes to a non-extractable IndexedDB-held ECDSA key. Cannot be combined with `cookieTransport`. |
+| `cookieTransport` | — | `{ endpoint?, fetch?, deviceBinding? }`: move the rotating session token into a persistent same-site HttpOnly cookie whose 190-day lifetime renews on every rotation. The reserved `deviceBinding` flag only activates the shared incompatibility assertion. |
 | `initialToken` / `initialSessionId` | — | Paired values from `handler.getInitialToken(request)` for authenticated SSR/hydration. |
 | `reactiveRevocation` | `true` | Subscribe to session liveness and drop auth live on revocation. |
-| `onAuthError` | — | Recoverable sign-in failures (stale/forged callback, Logto down). |
+| `onAuthError` | — | Recoverable sign-in failures and opted-in device-key storage failures. |
 
 `logtoSessionApi(component, opts?)` accepts `scopes`, `resources` (server-set —
 the browser can't request its own), `reuseWindowMs`, and env overrides.

--- a/packages/convex-logto/README.md
+++ b/packages/convex-logto/README.md
@@ -212,8 +212,15 @@ rotating credential into a persistent rolling `__Host-` HttpOnly cookie whose
 190-day lifetime matches server-side idle GC. It enforces fixed POST +
 custom-header + Origin CSRF checks and supports SSR seeding through
 `handler.getInitialToken(request)`. See the session-mode guide for Next.js,
-TanStack Start, and Convex custom-domain mounts, plus the Safari device-binding
+TanStack Start, and Convex custom-domain mounts, plus the cookie/device-binding
 exclusion.
+
+Alternatively, opt into `deviceBinding` on the provider to require an ECDSA
+proof from a non-extractable IndexedDB-held key on every refresh, making a
+copied session token useless off-device. It is intentionally off by default,
+fails loudly without IndexedDB, and cannot be combined with cookie transport;
+key eviction causes a clean re-authentication. See the session-mode guide for
+the exact threat model and the cross-browser DBSC re-evaluation trigger.
 
 [session-mode-docs]: https://github.com/Fanzzzd/convex-logto/blob/main/docs/content/docs/session-mode.mdx
 [session-example]: https://github.com/Fanzzzd/convex-logto/tree/main/examples/vite-react-session

--- a/packages/convex-logto/src/component/_generated/component.ts
+++ b/packages/convex-logto/src/component/_generated/component.ts
@@ -45,6 +45,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           appId: string;
           clientSecret: string;
           code: string;
+          devicePublicKey?: { crv: "P-256"; kty: "EC"; x: string; y: string };
           endpoint: string;
           redirectUri: string;
           state: string;
@@ -91,6 +92,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         {
           appId: string;
           clientSecret: string;
+          deviceProof?: string;
           endpoint: string;
           reuseWindowMs?: number;
           sessionToken: string;

--- a/packages/convex-logto/src/component/core.test.ts
+++ b/packages/convex-logto/src/component/core.test.ts
@@ -5,6 +5,7 @@ import { ConvexError } from "convex/values";
 import { describe, expect, it } from "vitest";
 import {
   DEFAULT_REUSE_WINDOW_MS,
+  assertDeviceProof,
   buildAuthorizeUrl,
   buildEndSessionUrl,
   classifyTokenEndpointFailure,
@@ -17,6 +18,7 @@ import {
   terminal,
   toBase64Url,
   transient,
+  verifyDeviceProof,
 } from "./core";
 
 // --- token helpers -----------------------------------------------------------
@@ -44,6 +46,76 @@ it("generatePkce produces an S256 challenge of the verifier", async () => {
     new TextEncoder().encode(verifier),
   );
   expect(challenge).toBe(toBase64Url(new Uint8Array(digest)));
+});
+
+async function deviceProofFixture(sessionToken: string) {
+  const pair = (await crypto.subtle.generateKey(
+    { name: "ECDSA", namedCurve: "P-256" },
+    false,
+    ["sign", "verify"],
+  )) as CryptoKeyPair;
+  const jwk = await crypto.subtle.exportKey("jwk", pair.publicKey);
+  if (jwk.kty !== "EC" || !jwk.x || !jwk.y) throw new Error("invalid JWK");
+  const publicKey = {
+    kty: "EC" as const,
+    crv: "P-256" as const,
+    x: jwk.x,
+    y: jwk.y,
+  };
+  const signature = await crypto.subtle.sign(
+    { name: "ECDSA", hash: "SHA-256" },
+    pair.privateKey,
+    new TextEncoder().encode(sessionToken),
+  );
+  return { publicKey, proof: toBase64Url(new Uint8Array(signature)) };
+}
+
+describe("device proof", () => {
+  it("signs and verifies the presented one-time session token", async () => {
+    const sessionToken = "session-token-1";
+    const { publicKey, proof } = await deviceProofFixture(sessionToken);
+    await expect(
+      verifyDeviceProof({ publicKey, sessionToken, proof }),
+    ).resolves.toBe(true);
+    await expect(
+      verifyDeviceProof({
+        publicKey,
+        sessionToken: "session-token-2",
+        proof,
+      }),
+    ).resolves.toBe(false);
+    await expect(
+      assertDeviceProof({ publicKey, sessionToken, proof }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects a proof from the wrong key terminally", async () => {
+    const sessionToken = "session-token-1";
+    const [{ publicKey }, { proof }] = await Promise.all([
+      deviceProofFixture(sessionToken),
+      deviceProofFixture(sessionToken),
+    ]);
+    await expect(
+      assertDeviceProof({ publicKey, sessionToken, proof }),
+    ).rejects.toMatchObject({
+      data: { kind: "terminal", code: "device_proof_invalid" },
+    });
+  });
+
+  it("rejects a missing proof for a bound session terminally", async () => {
+    const { publicKey } = await deviceProofFixture("session-token-1");
+    await expect(
+      assertDeviceProof({ publicKey, sessionToken: "session-token-1" }),
+    ).rejects.toMatchObject({
+      data: { kind: "terminal", code: "device_proof_required" },
+    });
+  });
+
+  it("leaves the existing unbound refresh path unchanged", async () => {
+    await expect(
+      assertDeviceProof({ sessionToken: "session-token-1" }),
+    ).resolves.toBeUndefined();
+  });
 });
 
 // --- URL builders ------------------------------------------------------------

--- a/packages/convex-logto/src/component/core.ts
+++ b/packages/convex-logto/src/component/core.ts
@@ -58,6 +58,92 @@ export async function hashToken(token: string): Promise<string> {
   return toHex(await crypto.subtle.digest("SHA-256", encoder.encode(token)));
 }
 
+export type DevicePublicKey = {
+  kty: "EC";
+  crv: "P-256";
+  x: string;
+  y: string;
+};
+
+function fromBase64Url(value: string): Uint8Array<ArrayBuffer> | null {
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) return null;
+  const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
+  try {
+    const binary = atob(base64.padEnd(Math.ceil(base64.length / 4) * 4, "="));
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index++) {
+      bytes[index] = binary.charCodeAt(index);
+    }
+    return bytes;
+  } catch {
+    return null;
+  }
+}
+
+/** Verify an ECDSA P-256 proof over the presented rotating session token. */
+export async function verifyDeviceProof(options: {
+  publicKey: DevicePublicKey;
+  sessionToken: string;
+  proof: string;
+}): Promise<boolean> {
+  const signature = fromBase64Url(options.proof);
+  // WebCrypto ECDSA signatures use fixed-width IEEE P1363 r || s encoding.
+  if (signature?.byteLength !== 64) return false;
+  try {
+    const key = await crypto.subtle.importKey(
+      "jwk",
+      {
+        ...options.publicKey,
+        ext: true,
+        key_ops: ["verify"],
+      },
+      { name: "ECDSA", namedCurve: "P-256" },
+      false,
+      ["verify"],
+    );
+    return await crypto.subtle.verify(
+      { name: "ECDSA", hash: "SHA-256" },
+      key,
+      signature,
+      encoder.encode(options.sessionToken),
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Enforce PoP only for sessions that opted in at exchange time. The signature
+ * covers the one-time session token itself, so it cannot be carried forward to
+ * the next rotation; token reuse retains only the existing bounded grace rule.
+ */
+export async function assertDeviceProof(options: {
+  publicKey?: DevicePublicKey;
+  sessionToken: string;
+  proof?: string;
+}): Promise<void> {
+  const publicKey = options.publicKey;
+  if (publicKey === undefined) return;
+  if (options.proof === undefined) {
+    throw terminal(
+      "device_proof_required",
+      "This session is device-bound, but its proof of possession is missing. Sign in again.",
+    );
+  }
+  if (
+    !(await verifyDeviceProof({
+      publicKey,
+      sessionToken: options.sessionToken,
+      proof: options.proof,
+    }))
+  ) {
+    throw terminal(
+      "device_proof_invalid",
+      "This session's device proof is invalid. The bound key may have been evicted; sign in again.",
+    );
+  }
+}
+
 /** PKCE S256: verifier (random) + challenge (SHA-256, base64url). */
 export async function generatePkce(): Promise<{
   verifier: string;

--- a/packages/convex-logto/src/component/lib.ts
+++ b/packages/convex-logto/src/component/lib.ts
@@ -2,6 +2,7 @@ import { ConvexError, v } from "convex/values";
 import {
   action,
   internalMutation,
+  internalQuery,
   mutation,
   query,
 } from "./_generated/server.js";
@@ -11,6 +12,7 @@ import {
   SESSION_GC_AFTER_MS,
   TRANSACTION_TTL_MS,
   WEBHOOK_DELIVERY_GC_AFTER_MS,
+  assertDeviceProof,
   buildAuthorizeUrl,
   buildEndSessionUrl,
   classifyTokenEndpointFailure,
@@ -22,6 +24,7 @@ import {
   rotateTokenHashes,
   terminal,
   transient,
+  type DevicePublicKey,
 } from "./core.js";
 
 // The confidential-client config every OIDC-touching call needs. The values are
@@ -33,6 +36,13 @@ const oidcArgs = {
   appId: v.string(),
   clientSecret: v.string(),
 };
+
+const devicePublicKeyValidator = v.object({
+  kty: v.literal("EC"),
+  crv: v.literal("P-256"),
+  x: v.string(),
+  y: v.string(),
+});
 
 type OidcConfig = { endpoint: string; appId: string; clientSecret: string };
 
@@ -171,6 +181,7 @@ export const exchange = action({
     code: v.string(),
     state: v.string(),
     redirectUri: v.string(),
+    devicePublicKey: v.optional(devicePublicKeyValidator),
   },
   returns: v.object({
     idToken: v.string(),
@@ -211,6 +222,7 @@ export const exchange = action({
         logtoRefreshToken: tokens.refresh_token,
         lastIdToken: tokens.id_token,
         lastIdTokenExp: claims.expiresAtMs,
+        devicePublicKey: args.devicePublicKey,
         now,
       },
     );
@@ -263,6 +275,7 @@ export const createSession = internalMutation({
     logtoRefreshToken: v.string(),
     lastIdToken: v.string(),
     lastIdTokenExp: v.number(),
+    devicePublicKey: v.optional(devicePublicKeyValidator),
     now: v.number(),
   },
   returns: v.string(),
@@ -282,6 +295,7 @@ export const refresh = action({
   args: {
     ...oidcArgs,
     sessionToken: v.string(),
+    deviceProof: v.optional(v.string()),
     reuseWindowMs: v.optional(v.number()),
   },
   returns: v.object({
@@ -294,6 +308,15 @@ export const refresh = action({
     args,
   ): Promise<{ idToken: string; sessionToken: string; sessionId: string }> => {
     const presentedHash = await hashToken(args.sessionToken);
+    const devicePublicKey: DevicePublicKey | null = await ctx.runQuery(
+      internal.lib.devicePublicKeyForToken,
+      { presentedHash },
+    );
+    await assertDeviceProof({
+      publicKey: devicePublicKey ?? undefined,
+      sessionToken: args.sessionToken,
+      proof: args.deviceProof,
+    });
     // The next token is generated in the action (mutations have deterministic
     // randomness); the mutation adopts it only where rotation happens.
     const candidate = generateToken();
@@ -362,6 +385,26 @@ export const refresh = action({
         };
       }
     }
+  },
+});
+
+export const devicePublicKeyForToken = internalQuery({
+  args: { presentedHash: v.string() },
+  returns: v.union(devicePublicKeyValidator, v.null()),
+  handler: async (ctx, args) => {
+    const byCurrent = await ctx.db
+      .query("sessions")
+      .withIndex("by_tokenHash", (q) => q.eq("tokenHash", args.presentedHash))
+      .unique();
+    const session =
+      byCurrent ??
+      (await ctx.db
+        .query("sessions")
+        .withIndex("by_prevTokenHash", (q) =>
+          q.eq("prevTokenHash", args.presentedHash),
+        )
+        .unique());
+    return session?.devicePublicKey ?? null;
   },
 });
 

--- a/packages/convex-logto/src/component/schema.ts
+++ b/packages/convex-logto/src/component/schema.ts
@@ -49,6 +49,15 @@ export default defineSchema({
     rotatedAt: v.optional(v.number()),
     /** Optimistic claim so concurrent refreshes can't double-hit Logto's token endpoint. */
     refreshingSince: v.optional(v.number()),
+    /** Optional ECDSA P-256 public key required to refresh a bound session. */
+    devicePublicKey: v.optional(
+      v.object({
+        kty: v.literal("EC"),
+        crv: v.literal("P-256"),
+        x: v.string(),
+        y: v.string(),
+      }),
+    ),
     /** The Logto refresh token (confidential client). Never leaves the component. */
     logtoRefreshToken: v.string(),
     /** Cached current ID token + expiry, served on the reuse-window path. */

--- a/packages/convex-logto/src/index.ts
+++ b/packages/convex-logto/src/index.ts
@@ -12,6 +12,7 @@ export {
   type LogtoSessionApi,
   type LogtoSessionApiOptions,
   type LogtoSessionComponent,
+  type LogtoSessionDevicePublicKey,
 } from "./session";
 export {
   LOGTO_SESSION_COOKIE_BASE_PATH,

--- a/packages/convex-logto/src/react-session.tsx
+++ b/packages/convex-logto/src/react-session.tsx
@@ -24,6 +24,7 @@ import {
   type SessionTransport,
   type TokenStorageKind,
 } from "./session-client";
+import { createSessionDeviceBinding } from "./session-device";
 import {
   createCookieSessionMarker,
   createLogtoSessionCookieTransport,
@@ -80,6 +81,11 @@ export type ConvexLogtoSessionProviderProps = {
    */
   tokenStorage?: TokenStorageKind;
   /**
+   * Bind refreshes to a non-extractable ECDSA key persisted in IndexedDB.
+   * Default `false`. Cannot be combined with `cookieTransport`.
+   */
+  deviceBinding?: boolean;
+  /**
    * Move the rotating session token into the same-site handler's HttpOnly
    * cookie. The browser keeps only a non-secret session marker in localStorage;
    * each rotation renews the persistent cookie's 190-day idle lifetime.
@@ -97,9 +103,9 @@ export type ConvexLogtoSessionProviderProps = {
   reactiveRevocation?: boolean;
   /**
    * Called when finishing a sign-in fails recoverably (a stale/replayed/forged
-   * callback, Logto unreachable). The user is returned to the app logged out
-   * either way; use this to toast/telemetry the failure. Errors are also logged
-   * to the console.
+   * callback, Logto unreachable) or opted-in device-key storage fails. The user
+   * is returned to the app logged out either way; use this to toast/telemetry
+   * the failure. Errors are also logged to the console.
    */
   onAuthError?: (error: Error) => void;
   children: ReactNode;
@@ -124,6 +130,7 @@ export function ConvexLogtoSessionProvider({
   afterSignIn = "/",
   navigate,
   tokenStorage = "session",
+  deviceBinding = false,
   cookieTransport,
   initialToken,
   initialSessionId,
@@ -168,7 +175,7 @@ export function ConvexLogtoSessionProvider({
       ? createLogtoSessionCookieTransport(sessionApi, {
           endpoint: cookieEndpoint,
           fetch: cookieFetch,
-          deviceBinding: cookieDeviceBinding,
+          deviceBinding: deviceBinding || cookieDeviceBinding,
         })
       : (client as SessionTransport);
     return new SessionAuthEngine({
@@ -183,6 +190,9 @@ export function ConvexLogtoSessionProvider({
       // route even though JavaScript cannot inspect the HttpOnly cookie.
       initialSession: usesCookieTransport
         ? createCookieSessionMarker(storage.readSession(), initialSessionId)
+        : undefined,
+      deviceBinding: deviceBinding
+        ? createSessionDeviceBinding(namespace)
         : undefined,
       navigate: (to) => {
         const soft = navigateRef.current;
@@ -201,6 +211,7 @@ export function ConvexLogtoSessionProvider({
     cookieEndpoint,
     cookieFetch,
     cookieDeviceBinding,
+    deviceBinding,
     initialToken,
     initialSessionId,
   ]);

--- a/packages/convex-logto/src/session-client.test.ts
+++ b/packages/convex-logto/src/session-client.test.ts
@@ -16,6 +16,7 @@ import {
   type TokenStorageKind,
 } from "./session-client";
 import type { LogtoSessionApi } from "./session";
+import type { SessionDeviceBinding } from "./session-device";
 import {
   COOKIE_SESSION_MARKER,
   createCookieSessionMarker,
@@ -80,6 +81,7 @@ function makeHarness(options?: {
   storedIdToken?: string;
   storedSession?: StoredSession;
   cookieBootstrap?: { initialSessionId?: string | null };
+  deviceBinding?: SessionDeviceBinding;
 }) {
   const handlers: Handlers = {
     signIn: vi.fn(),
@@ -113,6 +115,7 @@ function makeHarness(options?: {
     afterSignIn: options?.afterSignIn ?? "/",
     initialToken: options?.initialToken,
     initialSession,
+    deviceBinding: options?.deviceBinding,
     navigate,
     onAuthError,
     sleep: () => Promise.resolve(), // skip retry backoff in tests
@@ -140,6 +143,21 @@ const sessionResult = (n: number, sub = "user1") => ({
   sessionToken: `session-token-${n}`,
   sessionId: `session-id-${n}`,
 });
+
+const devicePublicKey = {
+  kty: "EC" as const,
+  crv: "P-256" as const,
+  x: "public-x",
+  y: "public-y",
+};
+
+function fakeDeviceBinding(proof = "device-proof") {
+  return {
+    prepare: vi.fn().mockResolvedValue(undefined),
+    getPublicKey: vi.fn().mockResolvedValue(devicePublicKey),
+    sign: vi.fn().mockResolvedValue(proof),
+  } satisfies SessionDeviceBinding;
+}
 
 beforeEach(() => {
   setURL("http://localhost:5173/");
@@ -222,6 +240,24 @@ describe("mount", () => {
     const { engine, handlers } = makeHarness();
     engine.start();
     expect((await settled(engine)).status).toBe("unauthenticated");
+    expect(handlers.refresh).not.toHaveBeenCalled();
+  });
+
+  it("reports device-key initialization failure instead of degrading to unbound", async () => {
+    const deviceBinding = fakeDeviceBinding();
+    deviceBinding.prepare.mockRejectedValue(
+      new Error("convex-logto: IndexedDB unavailable"),
+    );
+    const { engine, handlers, onAuthError } = makeHarness({ deviceBinding });
+
+    engine.start();
+    expect((await settled(engine)).status).toBe("unauthenticated");
+    expect(onAuthError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "convex-logto: IndexedDB unavailable",
+      }),
+    );
+    expect(handlers.callback).not.toHaveBeenCalled();
     expect(handlers.refresh).not.toHaveBeenCalled();
   });
 
@@ -324,6 +360,23 @@ describe("mount", () => {
     });
   });
 
+  it("bound refresh signs the presented token and sends the PoP once", async () => {
+    const deviceBinding = fakeDeviceBinding("proof-for-t1");
+    const { engine, storage, handlers } = makeHarness({ deviceBinding });
+    storage.writeSession({ token: "t1", sessionId: "s1" });
+    storage.writeIdToken(staleToken());
+    handlers.refresh.mockResolvedValue(sessionResult(2));
+
+    engine.start();
+    expect((await settled(engine)).status).toBe("authenticated");
+    expect(deviceBinding.prepare).toHaveBeenCalledTimes(1);
+    expect(deviceBinding.sign).toHaveBeenCalledWith("t1");
+    expect(handlers.refresh).toHaveBeenCalledWith({
+      sessionToken: "t1",
+      deviceProof: "proof-for-t1",
+    });
+  });
+
   it("terminal refresh on restore → storage cleared, unauthenticated", async () => {
     const { engine, storage, handlers } = makeHarness();
     storage.writeSession({ token: "t1", sessionId: "s1" });
@@ -380,6 +433,24 @@ describe("callback", () => {
     });
     await vi.waitFor(() => expect(navigate).toHaveBeenCalledWith("/dash"));
     expect(storage.takeTransaction()).toBeNull(); // stash consumed
+  });
+
+  it("bound callback captures the device public key in the new session", async () => {
+    const deviceBinding = fakeDeviceBinding();
+    const { engine, storage, handlers } = makeHarness({ deviceBinding });
+    setURL("http://localhost:5173/callback?code=c1&state=s1");
+    storage.stashTransaction({ state: "s1" });
+    handlers.callback.mockResolvedValue(sessionResult(1));
+
+    engine.start();
+    expect((await settled(engine)).status).toBe("authenticated");
+    expect(deviceBinding.getPublicKey).toHaveBeenCalledTimes(1);
+    expect(handlers.callback).toHaveBeenCalledWith({
+      code: "c1",
+      state: "s1",
+      redirectUri: "http://localhost:5173/callback",
+      devicePublicKey,
+    });
   });
 
   it("an unsafe server returnTo falls back to afterSignIn", async () => {

--- a/packages/convex-logto/src/session-client.test.ts
+++ b/packages/convex-logto/src/session-client.test.ts
@@ -16,7 +16,11 @@ import {
   type TokenStorageKind,
 } from "./session-client";
 import type { LogtoSessionApi } from "./session";
-import type { SessionDeviceBinding } from "./session-device";
+import {
+  SessionDeviceBindingError,
+  WebCryptoSessionDeviceBinding,
+  type SessionDeviceBinding,
+} from "./session-device";
 import {
   COOKIE_SESSION_MARKER,
   createCookieSessionMarker,
@@ -629,6 +633,22 @@ describe("signIn", () => {
     await expect(
       engine.signIn({ returnTo: "https://evil.com" }),
     ).rejects.toThrow(/same-origin path/);
+    expect(handlers.signIn).not.toHaveBeenCalled();
+  });
+
+  it("reports and rejects a device-key preparation failure", async () => {
+    const deviceBinding = new WebCryptoSessionDeviceBinding({
+      read: () => Promise.reject(new Error("IndexedDB unavailable")),
+      add: () => Promise.resolve(true),
+    });
+    const { engine, handlers, onAuthError } = makeHarness({ deviceBinding });
+
+    await expect(engine.signIn()).rejects.toBeInstanceOf(
+      SessionDeviceBindingError,
+    );
+    expect(onAuthError).toHaveBeenCalledWith(
+      expect.any(SessionDeviceBindingError),
+    );
     expect(handlers.signIn).not.toHaveBeenCalled();
   });
 });

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -527,7 +527,13 @@ export class SessionAuthEngine {
           `to prevent open redirects.`,
       );
     }
-    await this.options.deviceBinding?.prepare();
+    try {
+      await this.options.deviceBinding?.prepare();
+    } catch (error) {
+      const normalizedError = this.asError(error);
+      this.reportError(normalizedError);
+      throw normalizedError;
+    }
     const { url } = await this.options.transport.action(
       this.options.api.signIn,
       {

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -5,6 +5,10 @@
 import type { FunctionReference } from "convex/server";
 import { ConvexError } from "convex/values";
 import { classifySignInSearch, isSafeReturnTo } from "./callback";
+import {
+  SessionDeviceBindingError,
+  type SessionDeviceBinding,
+} from "./session-device";
 import type { LogtoSessionApi } from "./session";
 
 /** Where the short-lived ID token persists. The session token is always localStorage. */
@@ -204,6 +208,8 @@ export type SessionEngineOptions = {
   initialToken?: string;
   /** Session marker paired with `initialToken` (cookie transport uses a sentinel). */
   initialSession?: StoredSession;
+  /** Opt-in proof-of-possession key; absent keeps the legacy unbound flow. */
+  deviceBinding?: SessionDeviceBinding;
   /** Replace-style navigation; falls back to `location.replace`. */
   navigate?: (to: string) => void;
   onAuthError?: (error: Error) => void;
@@ -312,6 +318,13 @@ export class SessionAuthEngine {
   }
 
   private async startInner(): Promise<void> {
+    try {
+      await this.options.deviceBinding?.prepare();
+    } catch (error) {
+      this.reportError(this.asError(error));
+      this.setUnauthenticated();
+      return;
+    }
     const onCallback = window.location.pathname === this.options.callbackPath;
     const outcome = onCallback
       ? classifySignInSearch(window.location.search)
@@ -351,11 +364,13 @@ export class SessionAuthEngine {
       return;
     }
     try {
+      const devicePublicKey = await this.options.deviceBinding?.getPublicKey();
       const result = await this.retrying(() =>
         this.options.transport.action(this.options.api.callback, {
           code,
           state,
           redirectUri: `${window.location.origin}${this.options.callbackPath}`,
+          ...(devicePublicKey === undefined ? {} : { devicePublicKey }),
         }),
       );
       this.options.storage.writeSession({
@@ -464,10 +479,18 @@ export class SessionAuthEngine {
           this.setUnauthenticated();
         return null;
       }
+      let deviceProof: string | undefined;
+      try {
+        deviceProof = await this.options.deviceBinding?.sign(session.token);
+      } catch (error) {
+        this.reportError(this.asError(error));
+        return null;
+      }
       try {
         const result = await this.retrying(() =>
           this.options.transport.action(this.options.api.refresh, {
             sessionToken: session.token,
+            ...(deviceProof === undefined ? {} : { deviceProof }),
           }),
         );
         this.options.storage.writeSession({
@@ -504,6 +527,7 @@ export class SessionAuthEngine {
           `to prevent open redirects.`,
       );
     }
+    await this.options.deviceBinding?.prepare();
     const { url } = await this.options.transport.action(
       this.options.api.signIn,
       {
@@ -605,5 +629,13 @@ export class SessionAuthEngine {
     } catch {
       // A throwing error handler must not break the auth flow.
     }
+  }
+
+  private asError(error: unknown): Error {
+    if (error instanceof Error) return error;
+    return new SessionDeviceBindingError(
+      "convex-logto: device binding failed without an Error value.",
+      { cause: error },
+    );
   }
 }

--- a/packages/convex-logto/src/session-cookie.test.ts
+++ b/packages/convex-logto/src/session-cookie.test.ts
@@ -415,30 +415,36 @@ describe("browser transport", () => {
   });
 });
 
-describe("Safari device-binding exclusion", () => {
+describe("cookie transport and device-binding exclusion", () => {
   const safari =
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
     "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.5 Safari/605.1.15";
+  const chrome =
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) " +
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36";
 
-  it("throws loudly instead of degrading either protection", () => {
-    expect(() =>
+  it("throws the same loud error regardless of browser", () => {
+    const check = (userAgent: string) =>
       assertLogtoSessionCookieCompatibility({
         deviceBinding: true,
-        userAgent: safari,
-      }),
-    ).toThrow(/cannot be enabled together on Safari/);
+        userAgent,
+      });
+    expect(() => check(safari)).toThrow(/cannot be enabled together/);
+    expect(() => check(chrome)).toThrow(/cannot be enabled together/);
   });
 
-  it("also enforces the exclusion in the fetch handler", async () => {
-    const { handler, action } = makeHarness({ deviceBinding: true });
-    await expect(
-      handler(
-        request("token", {
-          cookie: cookie("session-token-1"),
-          userAgent: safari,
-        }),
-      ),
-    ).rejects.toThrow(/cannot be enabled together on Safari/);
-    expect(action).not.toHaveBeenCalled();
+  it("rejects enabling cookie transport after binding in the browser adapter", () => {
+    expect(() =>
+      createLogtoSessionCookieTransport(api, {
+        endpoint: BASE_PATH,
+        deviceBinding: true,
+      }),
+    ).toThrow(/cannot be enabled together/);
+  });
+
+  it("rejects enabling binding after cookie transport in the fetch handler", () => {
+    expect(() => makeHarness({ deviceBinding: true })).toThrow(
+      /cannot be enabled together/,
+    );
   });
 });

--- a/packages/convex-logto/src/session-cookie.ts
+++ b/packages/convex-logto/src/session-cookie.ts
@@ -55,8 +55,8 @@ export type LogtoSessionCookieHandlerOptions = {
   /** Mount point containing `sign-in`, `callback`, `token`, and `sign-out`. */
   basePath?: string;
   /**
-   * Mirror the session provider's future device-binding flag. Safari cannot
-   * safely combine its ITP storage behavior with this cookie transport.
+   * Mirror the session provider's device-binding flag so incompatible
+   * non-React configurations fail through the same assertion.
    */
   deviceBinding?: boolean;
 };
@@ -330,26 +330,20 @@ function validateRedirectUri(value: string, requestOrigin: string): string {
   return value;
 }
 
-function isSafari(userAgent: string): boolean {
-  return (
-    /Safari\//.test(userAgent) &&
-    !/(?:Chrome|Chromium|CriOS|Edg|EdgiOS|OPR|OPiOS|FxiOS|Firefox)\//.test(
-      userAgent,
-    )
-  );
-}
-
 /**
- * Throw when Safari would combine cookie transport with software device
- * binding. Exported so future non-React adapters can enforce the same rule.
+ * Throw when cookie transport would combine with software device binding.
+ * HttpOnly deliberately makes the token unavailable to the JavaScript key
+ * that must sign it, so the guarantees cannot be composed without weakening
+ * one. Exported so non-React adapters enforce the same rule.
  */
 export function assertLogtoSessionCookieCompatibility(options: {
   deviceBinding?: boolean;
+  /** Retained for source compatibility; the exclusion now applies everywhere. */
   userAgent?: string | null;
 }): void {
-  if (options.deviceBinding && isSafari(options.userAgent ?? "")) {
+  if (options.deviceBinding) {
     throw new Error(
-      "convex-logto: session cookie transport and device binding cannot be enabled together on Safari because ITP can evict the bound key while retaining the cookie. Disable one of them; silent fallback is not allowed.",
+      "convex-logto: session cookie transport and device binding cannot be enabled together. Cookie transport already keeps the session token out of JavaScript, while device binding requires JavaScript to sign that token. Disable one of them; silent fallback is not allowed. On Safari this also avoids ITP retaining the cookie after evicting its IndexedDB key.",
     );
   }
 }
@@ -362,6 +356,9 @@ export function assertLogtoSessionCookieCompatibility(options: {
 export function createLogtoSessionCookieHandler(
   options: LogtoSessionCookieHandlerOptions,
 ): LogtoSessionCookieHandler {
+  assertLogtoSessionCookieCompatibility({
+    deviceBinding: options.deviceBinding,
+  });
   const basePath = normalizeBasePath(
     options.basePath ?? LOGTO_SESSION_COOKIE_BASE_PATH,
   );
@@ -556,10 +553,6 @@ export function createLogtoSessionCookieHandler(
         origin,
       );
     }
-    assertLogtoSessionCookieCompatibility({
-      deviceBinding: options.deviceBinding,
-      userAgent: request.headers.get("user-agent"),
-    });
     return await handleRoute(route, request, origin);
   };
 
@@ -567,10 +560,6 @@ export function createLogtoSessionCookieHandler(
     getInitialToken: async (
       request: Request,
     ): Promise<LogtoSessionCookieSeed> => {
-      assertLogtoSessionCookieCompatibility({
-        deviceBinding: options.deviceBinding,
-        userAgent: request.headers.get("user-agent"),
-      });
       const headers = new Headers(NO_STORE_HEADERS);
       if (readCookie(request) === null) {
         return {

--- a/packages/convex-logto/src/session-device.test.ts
+++ b/packages/convex-logto/src/session-device.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment happy-dom
+
+import { describe, expect, it } from "vitest";
+import { verifyDeviceProof } from "./component/core";
+import {
+  WebCryptoSessionDeviceBinding,
+  createSessionDeviceBinding,
+  type SessionDeviceKeyRepository,
+} from "./session-device";
+
+function memoryRepository(): SessionDeviceKeyRepository & {
+  stored: CryptoKeyPair | undefined;
+} {
+  return {
+    stored: undefined,
+    async read() {
+      return this.stored;
+    },
+    async add(keyPair) {
+      if (this.stored !== undefined) return false;
+      this.stored = keyPair;
+      return true;
+    },
+  };
+}
+
+describe("WebCryptoSessionDeviceBinding", () => {
+  it("persists a non-extractable P-256 key and signs a verifiable token proof", async () => {
+    const repository = memoryRepository();
+    const binding = new WebCryptoSessionDeviceBinding(repository);
+    await binding.prepare();
+
+    expect(repository.stored?.privateKey.extractable).toBe(false);
+    expect(repository.stored?.privateKey.algorithm).toMatchObject({
+      name: "ECDSA",
+      namedCurve: "P-256",
+    });
+
+    const publicKey = await binding.getPublicKey();
+    const proof = await binding.sign("one-time-session-token");
+    await expect(
+      verifyDeviceProof({
+        publicKey,
+        sessionToken: "one-time-session-token",
+        proof,
+      }),
+    ).resolves.toBe(true);
+
+    // A fresh binding instance (another tab/reload) adopts the persisted key.
+    const reloaded = new WebCryptoSessionDeviceBinding(repository);
+    await expect(reloaded.getPublicKey()).resolves.toEqual(publicKey);
+  });
+
+  it("fails loudly when IndexedDB is unavailable at opt-in", () => {
+    expect(() => createSessionDeviceBinding("deployment", null)).toThrow(
+      /device binding requires working IndexedDB/,
+    );
+  });
+});

--- a/packages/convex-logto/src/session-device.test.ts
+++ b/packages/convex-logto/src/session-device.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from "vitest";
 import { verifyDeviceProof } from "./component/core";
 import {
+  SessionDeviceBindingError,
   WebCryptoSessionDeviceBinding,
   createSessionDeviceBinding,
   type SessionDeviceKeyRepository,
@@ -51,9 +52,12 @@ describe("WebCryptoSessionDeviceBinding", () => {
     await expect(reloaded.getPublicKey()).resolves.toEqual(publicKey);
   });
 
-  it("fails loudly when IndexedDB is unavailable at opt-in", () => {
-    expect(() => createSessionDeviceBinding("deployment", null)).toThrow(
-      /device binding requires working IndexedDB/,
+  it("defers an unavailable IndexedDB failure until preparation", async () => {
+    expect(window).toBeDefined();
+    const binding = createSessionDeviceBinding("deployment", null);
+
+    await expect(binding.prepare()).rejects.toBeInstanceOf(
+      SessionDeviceBindingError,
     );
   });
 });

--- a/packages/convex-logto/src/session-device.ts
+++ b/packages/convex-logto/src/session-device.ts
@@ -213,7 +213,6 @@ export function createSessionDeviceBinding(
     ? null
     : indexedDB,
 ): SessionDeviceBinding {
-  if (factory === null && typeof window !== "undefined") throw unavailable();
   return new WebCryptoSessionDeviceBinding(
     new IndexedDbDeviceKeyRepository(
       factory ??

--- a/packages/convex-logto/src/session-device.ts
+++ b/packages/convex-logto/src/session-device.ts
@@ -1,0 +1,228 @@
+import type { LogtoSessionDevicePublicKey } from "./session";
+
+const DEVICE_KEY_DATABASE_VERSION = 1;
+const DEVICE_KEY_STORE = "keys";
+const DEVICE_KEY_ID = "ecdsa-p256";
+
+/** Browser-side capability consumed by the framework-free session engine. */
+export type SessionDeviceBinding = {
+  /** Open persistent storage and create the non-extractable key if needed. */
+  prepare(): Promise<void>;
+  /** Public half captured by the component when the session is created. */
+  getPublicKey(): Promise<LogtoSessionDevicePublicKey>;
+  /** Sign the rotating session token without exposing the private key. */
+  sign(sessionToken: string): Promise<string>;
+};
+
+/** Minimal persistence seam: IndexedDB in production, in-memory in unit tests. */
+export type SessionDeviceKeyRepository = {
+  read(): Promise<unknown | undefined>;
+  /** Returns false when another tab won the first-write race. */
+  add(keyPair: CryptoKeyPair): Promise<boolean>;
+};
+
+export class SessionDeviceBindingError extends Error {}
+
+function unavailable(cause?: unknown): SessionDeviceBindingError {
+  return new SessionDeviceBindingError(
+    "convex-logto: device binding requires working IndexedDB to persist its " +
+      "non-extractable key. Disable deviceBinding or make IndexedDB available; " +
+      "silent fallback to an unbound session is not allowed.",
+    cause === undefined ? undefined : { cause },
+  );
+}
+
+function isCryptoKey(value: unknown, type: KeyType, usage: KeyUsage): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  const key = value as Partial<CryptoKey>;
+  const algorithm = key.algorithm as
+    | (KeyAlgorithm & { namedCurve?: unknown })
+    | undefined;
+  return (
+    key.type === type &&
+    algorithm?.name === "ECDSA" &&
+    algorithm.namedCurve === "P-256" &&
+    Array.isArray(key.usages) &&
+    key.usages.includes(usage)
+  );
+}
+
+function isDeviceKeyPair(value: unknown): value is CryptoKeyPair {
+  if (typeof value !== "object" || value === null) return false;
+  const pair = value as Partial<CryptoKeyPair>;
+  return (
+    isCryptoKey(pair.privateKey, "private", "sign") &&
+    pair.privateKey?.extractable === false &&
+    isCryptoKey(pair.publicKey, "public", "verify")
+  );
+}
+
+function toBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+async function generateDeviceKeyPair(): Promise<CryptoKeyPair> {
+  const pair = await crypto.subtle.generateKey(
+    { name: "ECDSA", namedCurve: "P-256" },
+    false,
+    ["sign", "verify"],
+  );
+  if (!isDeviceKeyPair(pair)) throw unavailable();
+  return pair;
+}
+
+/**
+ * ECDSA P-256 binding backed by a pluggable repository. The generated private
+ * key is non-extractable; IndexedDB persists the CryptoKey through structured
+ * cloning, never as exported key bytes.
+ */
+export class WebCryptoSessionDeviceBinding implements SessionDeviceBinding {
+  private keyPair: Promise<CryptoKeyPair> | null = null;
+
+  constructor(private repository: SessionDeviceKeyRepository) {}
+
+  prepare(): Promise<void> {
+    return this.loadKeyPair().then(() => undefined);
+  }
+
+  async getPublicKey(): Promise<LogtoSessionDevicePublicKey> {
+    const { publicKey } = await this.loadKeyPair();
+    const jwk = await crypto.subtle.exportKey("jwk", publicKey);
+    if (
+      jwk.kty !== "EC" ||
+      jwk.crv !== "P-256" ||
+      typeof jwk.x !== "string" ||
+      typeof jwk.y !== "string"
+    ) {
+      throw unavailable();
+    }
+    return { kty: "EC", crv: "P-256", x: jwk.x, y: jwk.y };
+  }
+
+  async sign(sessionToken: string): Promise<string> {
+    const { privateKey } = await this.loadKeyPair();
+    const signature = await crypto.subtle.sign(
+      { name: "ECDSA", hash: "SHA-256" },
+      privateKey,
+      new TextEncoder().encode(sessionToken),
+    );
+    return toBase64Url(new Uint8Array(signature));
+  }
+
+  private loadKeyPair(): Promise<CryptoKeyPair> {
+    this.keyPair ??= this.loadKeyPairInner().catch((error: unknown) => {
+      this.keyPair = null;
+      throw error instanceof SessionDeviceBindingError
+        ? error
+        : unavailable(error);
+    });
+    return this.keyPair;
+  }
+
+  private async loadKeyPairInner(): Promise<CryptoKeyPair> {
+    const existing = await this.repository.read();
+    if (existing !== undefined) {
+      if (!isDeviceKeyPair(existing)) throw unavailable();
+      return existing;
+    }
+
+    const candidate = await generateDeviceKeyPair();
+    if (await this.repository.add(candidate)) return candidate;
+
+    // Another tab populated the key after our initial read. Adopt its winner
+    // so every tab signs with the same device identity.
+    const winner = await this.repository.read();
+    if (!isDeviceKeyPair(winner)) throw unavailable();
+    return winner;
+  }
+}
+
+class IndexedDbDeviceKeyRepository implements SessionDeviceKeyRepository {
+  constructor(
+    private factory: IDBFactory,
+    private databaseName: string,
+  ) {}
+
+  async read(): Promise<unknown | undefined> {
+    const database = await this.open();
+    try {
+      return await new Promise((resolve, reject) => {
+        const request = database
+          .transaction(DEVICE_KEY_STORE, "readonly")
+          .objectStore(DEVICE_KEY_STORE)
+          .get(DEVICE_KEY_ID);
+        request.onsuccess = () => resolve(request.result as unknown);
+        request.onerror = () => reject(request.error ?? unavailable());
+      });
+    } finally {
+      database.close();
+    }
+  }
+
+  async add(keyPair: CryptoKeyPair): Promise<boolean> {
+    const database = await this.open();
+    try {
+      return await new Promise((resolve, reject) => {
+        const request = database
+          .transaction(DEVICE_KEY_STORE, "readwrite")
+          .objectStore(DEVICE_KEY_STORE)
+          .add(keyPair, DEVICE_KEY_ID);
+        request.onsuccess = () => resolve(true);
+        request.onerror = (event) => {
+          if (request.error?.name === "ConstraintError") {
+            event.preventDefault();
+            event.stopPropagation();
+            resolve(false);
+          } else {
+            reject(request.error ?? unavailable());
+          }
+        };
+      });
+    } finally {
+      database.close();
+    }
+  }
+
+  private open(): Promise<IDBDatabase> {
+    return new Promise((resolve, reject) => {
+      const request = this.factory.open(
+        this.databaseName,
+        DEVICE_KEY_DATABASE_VERSION,
+      );
+      request.onupgradeneeded = () => {
+        if (!request.result.objectStoreNames.contains(DEVICE_KEY_STORE)) {
+          request.result.createObjectStore(DEVICE_KEY_STORE);
+        }
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error ?? unavailable());
+      request.onblocked = () => reject(unavailable());
+    });
+  }
+}
+
+/** Create the deployment-namespaced IndexedDB-backed binding used by React. */
+export function createSessionDeviceBinding(
+  namespace: string,
+  factory: IDBFactory | null = typeof indexedDB === "undefined"
+    ? null
+    : indexedDB,
+): SessionDeviceBinding {
+  if (factory === null && typeof window !== "undefined") throw unavailable();
+  return new WebCryptoSessionDeviceBinding(
+    new IndexedDbDeviceKeyRepository(
+      factory ??
+        ({
+          open: () => {
+            throw unavailable();
+          },
+        } as unknown as IDBFactory),
+      `convex-logto:${namespace}:device-binding`,
+    ),
+  );
+}

--- a/packages/convex-logto/src/session.ts
+++ b/packages/convex-logto/src/session.ts
@@ -11,6 +11,21 @@ import { readEndpointAndAppId } from "./config";
 
 // --- component reference typing ---------------------------------------------
 
+/** Public half of the browser's non-extractable ECDSA P-256 binding key. */
+export type LogtoSessionDevicePublicKey = {
+  kty: "EC";
+  crv: "P-256";
+  x: string;
+  y: string;
+};
+
+const devicePublicKeyValidator = v.object({
+  kty: v.literal("EC"),
+  crv: v.literal("P-256"),
+  x: v.string(),
+  y: v.string(),
+});
+
 /**
  * The shape of `components.logto` in an app that installed the session
  * component (`app.use(logto)` in `convex/convex.config.ts`). Hand-written so
@@ -42,6 +57,7 @@ export type LogtoSessionComponent = {
         code: string;
         state: string;
         redirectUri: string;
+        devicePublicKey?: LogtoSessionDevicePublicKey;
       },
       {
         idToken: string;
@@ -58,6 +74,7 @@ export type LogtoSessionComponent = {
         appId: string;
         clientSecret: string;
         sessionToken: string;
+        deviceProof?: string;
         reuseWindowMs?: number;
       },
       { idToken: string; sessionToken: string; sessionId: string }
@@ -125,7 +142,12 @@ export type LogtoSessionApi = {
   callback: FunctionReference<
     "action",
     "public",
-    { code: string; state: string; redirectUri: string },
+    {
+      code: string;
+      state: string;
+      redirectUri: string;
+      devicePublicKey?: LogtoSessionDevicePublicKey;
+    },
     {
       idToken: string;
       sessionToken: string;
@@ -136,7 +158,7 @@ export type LogtoSessionApi = {
   refresh: FunctionReference<
     "action",
     "public",
-    { sessionToken: string },
+    { sessionToken: string; deviceProof?: string },
     { idToken: string; sessionToken: string; sessionId: string }
   >;
   signOut: FunctionReference<
@@ -218,7 +240,12 @@ export function logtoSessionApi(
   >;
   callback: RegisteredAction<
     "public",
-    { code: string; state: string; redirectUri: string },
+    {
+      code: string;
+      state: string;
+      redirectUri: string;
+      devicePublicKey?: LogtoSessionDevicePublicKey;
+    },
     Promise<{
       idToken: string;
       sessionToken: string;
@@ -228,7 +255,7 @@ export function logtoSessionApi(
   >;
   refresh: RegisteredAction<
     "public",
-    { sessionToken: string },
+    { sessionToken: string; deviceProof?: string },
     Promise<{ idToken: string; sessionToken: string; sessionId: string }>
   >;
   signOut: RegisteredAction<
@@ -259,7 +286,12 @@ export function logtoSessionApi(
       },
     }),
     callback: actionGeneric({
-      args: { code: v.string(), state: v.string(), redirectUri: v.string() },
+      args: {
+        code: v.string(),
+        state: v.string(),
+        redirectUri: v.string(),
+        devicePublicKey: v.optional(devicePublicKeyValidator),
+      },
       returns: v.object({
         idToken: v.string(),
         sessionToken: v.string(),
@@ -272,11 +304,15 @@ export function logtoSessionApi(
           code: args.code,
           state: args.state,
           redirectUri: args.redirectUri,
+          devicePublicKey: args.devicePublicKey,
         });
       },
     }),
     refresh: actionGeneric({
-      args: { sessionToken: v.string() },
+      args: {
+        sessionToken: v.string(),
+        deviceProof: v.optional(v.string()),
+      },
       returns: v.object({
         idToken: v.string(),
         sessionToken: v.string(),
@@ -286,6 +322,7 @@ export function logtoSessionApi(
         return await ctx.runAction(component.lib.refresh, {
           ...readSessionConfig(options),
           sessionToken: args.sessionToken,
+          deviceProof: args.deviceProof,
           reuseWindowMs: options.reuseWindowMs,
         });
       },


### PR DESCRIPTION
Closes #29.

## Summary

- Add opt-in deviceBinding to ConvexLogtoSessionProvider.
- Generate an ECDSA P-256 key with an unextractable private half and persist the CryptoKeyPair in deployment-namespaced IndexedDB.
- Capture only the public JWK at callback, sign the presented rotating session token, and verify proof before any component refresh claim or rotation.
- Keep all new schema fields and action arguments optional so existing unbound sessions and callers are unchanged.
- Document storage eviction, the exact replay boundary, the DBSC re-evaluation trigger, and the transport compatibility choice.

## Design decisions

- One device key is reused per Convex deployment namespace across reloads and tabs; an IndexedDB add race adopts the first winning key so concurrent tabs do not create divergent identities.
- Missing or invalid proof is terminal for a bound client, while the unbound path returns before WebCrypto work. A lost key therefore causes local cleanup and clean re-authentication without ever falling back to unbound refresh.
- The issue described cookie incompatibility specifically for Safari. With coordinator approval, this PR makes cookie transport and device binding mutually exclusive on every browser: HttpOnly makes the exact token unavailable to the JavaScript signing key, SSR cannot produce that signature, and cookie transport already addresses off-device replay. Both configuration directions use the same exported compatibility assertion; Safari ITP remains an additional reason.

## Validation

- pnpm --filter convex-logto test: 172 passed
- pnpm --filter convex-logto check-types: passed
- pnpm --filter convex-logto lint: passed
- pnpm --filter convex-logto format and format:check: passed
- pnpm --filter convex-logto build: passed
- pnpm --filter convex-logto lint:package: passed
- pnpm --filter docs build: passed
- Regenerated src/component/_generated/component.ts with Convex codegen.

Changeset: .changeset/fluffy-cloths-tease.md (minor).

No out-of-scope issues were discovered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional device binding for session authentication.
  * Session refreshes use secure device proofs to help prevent off-device token replay.
  * Device keys are securely stored and reused across browser tabs.
  * Added authentication error reporting for device-key storage or signing failures.
* **Bug Fixes**
  * Cookie transport now consistently rejects configurations that also enable device binding.
* **Documentation**
  * Expanded guidance on setup, limitations, transport compatibility, and reauthentication after key eviction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->