### PR TITLE
feat: add Expo native session mode

### DIFF
--- a/.changeset/fiery-canyons-fall.md
+++ b/.changeset/fiery-canyons-fall.md
@@ -1,0 +1,5 @@
+---
+"convex-logto": minor
+---
+
+Add React Native and Expo session mode with SecureStore persistence and system-browser OAuth.

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: API reference
-description: Every export from convex-logto, convex-logto/react, convex-logto/react-session, and convex-logto/native, with signatures.
+description: Every export from convex-logto and its web, native, and session-mode entries, with signatures.
 ---
 
 ## Exports
@@ -25,6 +25,8 @@ description: Every export from convex-logto, convex-logto/react, convex-logto/re
 | `useLogtoAuth()` | `convex-logto/react-session` | Same shape as the bridge hook; `signOut(opts?)` takes `{ postLogoutRedirectUri?, federated? }`. |
 | `ConvexLogtoProvider` | `convex-logto/native` | React Native / Expo provider (on `@logto/rn`). Same `config` / `configQuery` model; no callback route. |
 | `useLogtoAuth()` | `convex-logto/native` | Native `{ isAuthenticated, isLoading, user, signIn, signOut }`; `signOut()` takes no argument. |
+| `ConvexLogtoSessionProvider` | `convex-logto/native-session` | React Native / Expo session provider using SecureStore + the system browser. |
+| `useLogtoAuth()` | `convex-logto/native-session` | Native session `{ isAuthenticated, isLoading, user, signIn, signOut }`; no device-binding surface. |
 
 ## Backend
 
@@ -237,6 +239,44 @@ Same shape as the bridge hook: `{ isAuthenticated, isLoading, user, signIn, sign
   `federated: false`) ends the Logto SSO session and returns to
   `postLogoutRedirectUri` (default: your origin, which must be a registered
   Post sign-out redirect URI).
+
+## Native session mode (`convex-logto/native-session`)
+
+The React Native / Expo adapter for the same `SessionAuthEngine` and
+`logtoSessionApi(...)` actions as web session mode. It stores the rotating
+session token, OAuth state, and short-lived ID token in deployment-namespaced
+Expo SecureStore, and completes OAuth with `expo-web-browser` plus the app's
+deep-link redirect. There is no callback route, cookie transport, or software
+device-binding option.
+
+```tsx
+<ConvexLogtoSessionProvider
+  client={convex}
+  sessionApi={api.auth}
+  redirectUri="io.logto://callback"
+>
+  <App />
+</ConvexLogtoSessionProvider>
+```
+
+| Prop | Required | Purpose |
+| --- | --- | --- |
+| `client` | yes | Your `ConvexReactClient`. |
+| `sessionApi` | yes | The module re-exporting all five `logtoSessionApi(...)` functions. |
+| `redirectUri` | yes | Custom-scheme or universal-link callback registered as both a Redirect URI and Post sign-out redirect URI in Logto. |
+| `reactiveRevocation` | — | Subscribe to `sessionValid` and clear SecureStore immediately when revoked. Default `true`. |
+| `onAuthError` | — | Receives recoverable OAuth, SecureStore, and system-browser failures; errors are also logged. |
+
+`useLogtoAuth()` returns `{ isAuthenticated, isLoading, user, signIn,
+signOut }`. `signIn()` opens and completes the system-browser flow in place.
+`signOut({ postLogoutRedirectUri?, federated? })` clears SecureStore and revokes
+the server session, then ends Logto browser SSO unless `federated: false`.
+
+The ID token is persisted in SecureStore to make a fresh cold start a
+zero-round-trip authenticate. This is the native equivalent of choosing web
+`tokenStorage="local"`, but the bearer stays inside the OS encrypted keystore.
+See [Expo (React Native)](/docs/react-native#native-session-mode) for setup and
+the web/native differences.
 
 ## Native (`convex-logto/native`)
 

--- a/docs/content/docs/react-native.mdx
+++ b/docs/content/docs/react-native.mdx
@@ -1,11 +1,20 @@
 ---
 title: Expo (React Native)
-description: Wire Logto auth into a Convex Expo app with the convex-logto/native entry.
+description: Use Logto bridge mode or server-held session mode in a Convex Expo app.
 ---
 
-The same package works in React Native through the **`convex-logto/native`** entry,
-built on [`@logto/rn`](https://github.com/logto-io/react-native). The backend is
-**identical** to the web setup — only the frontend provider differs.
+There are two React Native entries:
+
+- **`convex-logto/native`** is bridge mode, built on
+  [`@logto/rn`](https://github.com/logto-io/react-native). The Logto SDK owns the
+  refresh token.
+- **`convex-logto/native-session`** is session mode. The Convex component owns
+  the Logto refresh token; Expo SecureStore holds only a rotating one-time
+  session token and a short-lived ID token.
+
+Both use the system browser and return through an app deep link, with no
+callback route. The bridge-mode walkthrough comes first; [native session
+mode](#native-session-mode) follows below.
 
 <Callout>
 `@logto/rn` signs in through the system browser and returns via your custom
@@ -160,6 +169,116 @@ Full runnable app: [`examples/expo`](https://github.com/Fanzzzd/convex-logto/tre
 
 Everything else — `logtoAuthConfig`, `logtoConfigQuery`, the webhook
 [user-sync](/docs/webhook-sync), and reading `ctx.auth.getUserIdentity()` — is shared.
+
+## Native session mode
+
+Use **`convex-logto/native-session`** when the Logto refresh token should remain
+inside the Convex session component. The server setup and five actions are the
+same as [web session mode](/docs/session-mode); only the storage and OAuth
+adapters differ on the device.
+
+### Install
+
+```bash
+pnpm add convex-logto
+npx expo install expo-secure-store expo-web-browser
+```
+
+This entry does not use `@logto/rn`, `expo-crypto`, or AsyncStorage.
+`expo-secure-store` and `expo-web-browser` are optional peers so bridge-mode and
+web-only apps do not install them.
+
+### Configure Logto and Convex
+
+Create a Logto **Traditional web** application, then register the app deep link
+in both lists:
+
+- **Redirect URIs** → `io.logto://callback`
+- **Post sign-out redirect URIs** → `io.logto://callback`
+
+Keep the `"scheme": "io.logto"` app configuration shown above. As with web
+session mode, set `LOGTO_ENDPOINT`, `LOGTO_APP_ID`, and
+`LOGTO_CLIENT_SECRET` on the Convex deployment, install the component, and
+export all five functions:
+
+```ts title="convex/convex.config.ts"
+import { defineApp } from "convex/server";
+import logto from "convex-logto/convex.config";
+
+const app = defineApp();
+app.use(logto);
+export default app;
+```
+
+```ts title="convex/auth.ts"
+import { logtoSessionApi } from "convex-logto";
+import { components } from "./_generated/api";
+
+export const { signIn, callback, refresh, signOut, sessionValid } =
+  logtoSessionApi(components.logto);
+```
+
+`convex/auth.config.ts` still uses `logtoAuthConfig()` so Convex validates the
+same ID token.
+
+### Mount the native session provider
+
+```tsx title="App.tsx"
+import { ConvexReactClient } from "convex/react";
+import { ConvexLogtoSessionProvider } from "convex-logto/native-session";
+import { api } from "./convex/_generated/api";
+
+const convex = new ConvexReactClient(process.env.EXPO_PUBLIC_CONVEX_URL!, {
+  unsavedChangesWarning: false,
+});
+
+export default function App() {
+  return (
+    <ConvexLogtoSessionProvider
+      client={convex}
+      sessionApi={api.auth}
+      redirectUri="io.logto://callback"
+    >
+      <Main />
+    </ConvexLogtoSessionProvider>
+  );
+}
+```
+
+`signIn()` asks the Convex action for an authorize URL, opens it with
+`WebBrowser.openAuthSessionAsync`, verifies that the returned `state` matches
+the single-use state stashed before the browser opened, and exchanges the code
+in place. There is no `/callback` screen or router integration.
+
+Native session mode keeps the rotating session token, OAuth state stash, and
+**short-lived ID token** in deployment-namespaced SecureStore. Persisting the ID
+token is a deliberate cold-start choice: while it remains fresh, the app can
+authenticate immediately without spending the one-time session token; unlike
+AsyncStorage, the bearer remains under the iOS Keychain / Android encrypted
+keystore. A stale ID token causes the normal server refresh and rolls the
+SecureStore session token before Convex receives the new ID token.
+
+Reactive revocation is on by default and uses the same `sessionValid`
+subscription as the web provider. `signOut()` clears SecureStore, revokes the
+server session, and opens Logto's end-session URL in the system browser unless
+`federated: false` is passed.
+
+### Differences from web session mode
+
+| | Web session | Native session |
+| --- | --- | --- |
+| Entry | `convex-logto/react-session` | `convex-logto/native-session` |
+| OAuth return | `/callback` route | system browser → deep link |
+| Session credential | localStorage, optional HttpOnly cookie | Expo SecureStore |
+| ID token default | sessionStorage | Expo SecureStore for fast cold starts |
+| Cross-context coordination | storage events + Web Locks | one installed app / SecureStore |
+| Cookie transport | optional, same-site only | unavailable |
+| Software device binding | optional on web | intentionally absent; SecureStore uses the OS keystore |
+
+Native session mode therefore has no `tokenStorage`, `cookieTransport`, or
+`deviceBinding` provider props. If SecureStore is unavailable or fails, auth
+fails loudly through `onAuthError`; it never falls back to AsyncStorage or an
+unbound plaintext credential.
 
 ## Expo SDK and `@logto/rn` versions
 

--- a/packages/convex-logto/README.md
+++ b/packages/convex-logto/README.md
@@ -222,6 +222,14 @@ fails loudly without IndexedDB, and cannot be combined with cookie transport;
 key eviction causes a clean re-authentication. See the session-mode guide for
 the exact threat model and the cross-browser DBSC re-evaluation trigger.
 
+For Expo, import `ConvexLogtoSessionProvider` from
+`convex-logto/native-session` and install `expo-secure-store` plus
+`expo-web-browser`. It reuses the same component and session actions, completes
+sign-in through the system browser/deep link (no callback route), keeps the
+rotating session token and short-lived ID token in the OS keystore, and retains
+reactive revocation. Native intentionally has no cookie-transport or software
+`deviceBinding` option.
+
 [session-mode-docs]: https://github.com/Fanzzzd/convex-logto/blob/main/docs/content/docs/session-mode.mdx
 [session-example]: https://github.com/Fanzzzd/convex-logto/tree/main/examples/vite-react-session
 
@@ -285,6 +293,8 @@ Convex validates an OIDC **ID token**. Logto's access tokens are typed `at+jwt`,
 | `useLogtoAuth()` | `convex-logto/react-session` | Same shape as the bridge hook; `signOut(opts?)` takes `{ postLogoutRedirectUri?, federated? }`. |
 | `ConvexLogtoProvider` | `convex-logto/native` | React Native / Expo provider (on `@logto/rn`). Same `configQuery` model; no callback route. |
 | `useLogtoAuth()` | `convex-logto/native` | Native `{ isAuthenticated, isLoading, user, signIn, signOut }`; `signIn()` defaults to the provider's `redirectUri`. |
+| `ConvexLogtoSessionProvider` | `convex-logto/native-session` | Expo session mode via SecureStore + system-browser deep links; same server component and actions. |
+| `useLogtoAuth()` | `convex-logto/native-session` | Native session auth/actions; `signOut(opts?)` supports federated browser sign-out. |
 
 ### Next.js note
 
@@ -292,7 +302,7 @@ Convex validates an OIDC **ID token**. Logto's access tokens are typed `at+jwt`,
 
 ### React Native / Expo
 
-For Expo, import from **`convex-logto/native`** (built on [`@logto/rn`](https://github.com/logto-io/react-native)) instead of `convex-logto/react`. The backend (`logtoAuthConfig` / `logtoConfigQuery`) is identical. There's no callback route on native — `signIn` opens the system browser and resolves on the deep-link return. See the [React Native guide](https://github.com/Fanzzzd/convex-logto/blob/main/docs/content/docs/react-native.mdx) and the runnable [`examples/expo`](https://github.com/Fanzzzd/convex-logto/tree/main/examples/expo) app.
+For Expo bridge mode, import from **`convex-logto/native`** (built on [`@logto/rn`](https://github.com/logto-io/react-native)) instead of `convex-logto/react`. For server-held session mode, use **`convex-logto/native-session`** with `expo-secure-store` and `expo-web-browser`. Neither native entry needs a callback route — `signIn` opens the system browser and resolves on the deep-link return. See the [React Native guide](https://github.com/Fanzzzd/convex-logto/blob/main/docs/content/docs/react-native.mdx) and the runnable bridge-mode [`examples/expo`](https://github.com/Fanzzzd/convex-logto/tree/main/examples/expo) app; a dedicated session-mode example is tracked in [#43](https://github.com/Fanzzzd/convex-logto/issues/43).
 
 ## License
 

--- a/packages/convex-logto/package.json
+++ b/packages/convex-logto/package.json
@@ -58,6 +58,10 @@
       "types": "./dist/native.d.ts",
       "import": "./dist/native.js"
     },
+    "./native-session": {
+      "types": "./dist/native-session.d.ts",
+      "import": "./dist/native-session.js"
+    },
     "./react-session": {
       "types": "./dist/react-session.d.ts",
       "import": "./dist/react-session.js"
@@ -90,6 +94,8 @@
     "@logto/react": ">=4.0.0",
     "@logto/rn": ">=1.1.0",
     "convex": ">=1.21.0",
+    "expo-secure-store": ">=14.0.0",
+    "expo-web-browser": ">=14.0.0",
     "react": ">=18.0.0"
   },
   "peerDependenciesMeta": {
@@ -97,6 +103,12 @@
       "optional": true
     },
     "@logto/rn": {
+      "optional": true
+    },
+    "expo-secure-store": {
+      "optional": true
+    },
+    "expo-web-browser": {
       "optional": true
     },
     "react": {
@@ -110,6 +122,8 @@
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.2.3",
     "convex": "^1.38.0",
+    "expo-secure-store": "^56.0.4",
+    "expo-web-browser": "^56.0.5",
     "happy-dom": "^20.10.6",
     "oxfmt": "^0.54.0",
     "oxlint": "^1.69.0",

--- a/packages/convex-logto/src/native-session-client.test.ts
+++ b/packages/convex-logto/src/native-session-client.test.ts
@@ -11,6 +11,7 @@ import {
   SessionSignOutError,
   type SessionSnapshot,
   type SessionTransport,
+  type StoredSession,
 } from "./session-client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -80,6 +81,8 @@ type Handlers = {
 function makeHarness(options?: {
   secureStore?: FakeSecureStore;
   webBrowser?: ReturnType<typeof fakeWebBrowser>;
+  initialToken?: string;
+  initialSession?: StoredSession;
 }) {
   const secureStore = options?.secureStore ?? fakeSecureStore();
   const webBrowser = options?.webBrowser ?? fakeWebBrowser();
@@ -117,6 +120,8 @@ function makeHarness(options?: {
     storage,
     callbackPath: "",
     afterSignIn: "",
+    initialToken: options?.initialToken,
+    initialSession: options?.initialSession,
     authFlow: createNativeSessionAuthFlow("io.logto://callback", webBrowser),
     navigate,
     onAuthError,
@@ -316,6 +321,8 @@ describe("native session adapters", () => {
 
     await expect(engine.signOut()).rejects.toMatchObject({
       name: "SessionSignOutError",
+      code: "local_cleanup_and_server_revocation_failed",
+      serverSessionStatus: "revocation_failed",
       message: expect.stringMatching(/did not complete/),
     });
 
@@ -325,7 +332,36 @@ describe("native session adapters", () => {
     expect(onAuthError).toHaveBeenCalledWith(expect.any(SessionSignOutError));
   });
 
-  it("returns normally when revocation succeeds despite durable cleanup failure", async () => {
+  it("returns normally when a failed durable cleanup succeeds on retry", async () => {
+    const secureStore = fakeSecureStore();
+    await seedSession(secureStore, freshToken());
+    let firstDelete = true;
+    secureStore.deleteItemAsync = vi.fn((key: string) => {
+      if (firstDelete) {
+        firstDelete = false;
+        return Promise.reject(new Error("keystore delete failed"));
+      }
+      secureStore.data.delete(key);
+      return Promise.resolve();
+    });
+    const { engine, handlers, onAuthError } = makeHarness({ secureStore });
+    engine.start();
+    await settled(engine);
+
+    await expect(engine.signOut({ federated: false })).resolves.toBeUndefined();
+
+    expect(handlers.signOut).toHaveBeenCalledTimes(1);
+    expect(secureStore.deleteItemAsync).toHaveBeenCalledTimes(6);
+    expect(secureStore.data.size).toBe(0);
+    expect(onAuthError).toHaveBeenCalledWith(
+      expect.any(NativeSessionStorageError),
+    );
+    expect(onAuthError).not.toHaveBeenCalledWith(
+      expect.any(SessionSignOutError),
+    );
+  });
+
+  it("rejects distinctly when revocation succeeds but durable cleanup fails twice", async () => {
     const secureStore = fakeSecureStore();
     await seedSession(secureStore, freshToken());
     secureStore.deleteItemAsync = vi
@@ -335,17 +371,17 @@ describe("native session adapters", () => {
     engine.start();
     await settled(engine);
 
-    await expect(engine.signOut({ federated: false })).resolves.toBeUndefined();
+    await expect(engine.signOut({ federated: false })).rejects.toMatchObject({
+      name: "SessionSignOutError",
+      code: "local_cleanup_failed",
+      serverSessionStatus: "revoked",
+      message: expect.stringMatching(/server session was revoked/),
+    });
 
     expect(handlers.signOut).toHaveBeenCalledTimes(1);
     expect(secureStore.deleteItemAsync).toHaveBeenCalledTimes(6);
     expect(secureStore.data.size).toBe(2);
-    expect(onAuthError).toHaveBeenCalledWith(
-      expect.any(NativeSessionStorageError),
-    );
-    expect(onAuthError).not.toHaveBeenCalledWith(
-      expect.any(SessionSignOutError),
-    );
+    expect(onAuthError).toHaveBeenCalledWith(expect.any(SessionSignOutError));
   });
 
   it("refuses a foreign return and a replay after its state is spent", async () => {
@@ -394,6 +430,27 @@ describe("native session adapters", () => {
     );
   });
 
+  it("clears an abandoned state before handling an authorize URL without state", async () => {
+    const { engine, storage, handlers, onAuthError } = makeHarness();
+    engine.start();
+    await settled(engine);
+    storage.stashTransaction({ state: "state-1" });
+    await storage.flush();
+    handlers.signIn.mockResolvedValue({
+      url: "https://auth.example.com/oidc/auth",
+    });
+
+    await engine.signIn();
+
+    expect(handlers.callback).not.toHaveBeenCalled();
+    expect(storage.takeTransaction()).toBeNull();
+    expect(onAuthError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringMatching(/doesn't match/),
+      }),
+    );
+  });
+
   it("spends the state without exchanging when the system browser is cancelled", async () => {
     const webBrowser = fakeWebBrowser({ type: "cancel" });
     const { engine, storage, handlers, onAuthError } = makeHarness({
@@ -416,6 +473,31 @@ describe("native session adapters", () => {
 
     engine.start();
     expect((await settled(engine)).status).toBe("unauthenticated");
+    expect(onAuthError).toHaveBeenCalledWith(
+      expect.any(NativeSessionStorageError),
+    );
+  });
+
+  it("drops the live auth snapshot when sign-out storage preparation fails", async () => {
+    const secureStore = fakeSecureStore();
+    secureStore.isAvailableAsync = vi.fn().mockResolvedValue(false);
+    const { engine, storage, handlers, onAuthError } = makeHarness({
+      secureStore,
+      initialToken: freshToken(),
+      initialSession: {
+        token: "session-token-old",
+        sessionId: "session-id-1",
+      },
+    });
+    expect(engine.getSnapshot().status).toBe("authenticated");
+
+    await expect(engine.signOut()).rejects.toBeInstanceOf(
+      NativeSessionStorageError,
+    );
+
+    expect(engine.getSnapshot().status).toBe("unauthenticated");
+    expect(storage.readSession()).toBeNull();
+    expect(handlers.signOut).not.toHaveBeenCalled();
     expect(onAuthError).toHaveBeenCalledWith(
       expect.any(NativeSessionStorageError),
     );

--- a/packages/convex-logto/src/native-session-client.test.ts
+++ b/packages/convex-logto/src/native-session-client.test.ts
@@ -1,0 +1,367 @@
+import type { LogtoSessionApi } from "./session";
+import {
+  createNativeSessionAuthFlow,
+  NativeSessionStorageArea,
+  NativeSessionStorageError,
+  type NativeSecureStore,
+  type NativeWebBrowser,
+} from "./native-session-client";
+import {
+  SessionAuthEngine,
+  type SessionSnapshot,
+  type SessionTransport,
+} from "./session-client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+function fakeIdToken(payload: Record<string, unknown>): string {
+  const encode = (value: unknown) =>
+    btoa(JSON.stringify(value))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  return `${encode({ alg: "RS256" })}.${encode(payload)}.signature`;
+}
+
+const freshToken = (sub = "native-user") =>
+  fakeIdToken({ sub, exp: Math.floor(Date.now() / 1000) + 3600 });
+const staleToken = () =>
+  fakeIdToken({ sub: "native-user", exp: Math.floor(Date.now() / 1000) + 10 });
+
+type FakeSecureStore = NativeSecureStore & { data: Map<string, string> };
+
+function fakeSecureStore(): FakeSecureStore {
+  const data = new Map<string, string>();
+  return {
+    data,
+    isAvailableAsync: vi.fn().mockResolvedValue(true),
+    getItemAsync: vi.fn((key: string) =>
+      Promise.resolve(data.get(key) ?? null),
+    ),
+    setItemAsync: vi.fn((key: string, value: string) => {
+      data.set(key, value);
+      return Promise.resolve();
+    }),
+    deleteItemAsync: vi.fn((key: string) => {
+      data.delete(key);
+      return Promise.resolve();
+    }),
+  };
+}
+
+function fakeWebBrowser(
+  result: { type: string; url?: string } = {
+    type: "success",
+    url: "io.logto://callback?code=code-1&state=state-1",
+  },
+): NativeWebBrowser & {
+  openAuthSessionAsync: ReturnType<typeof vi.fn>;
+} {
+  return {
+    openAuthSessionAsync: vi.fn().mockResolvedValue(result),
+  };
+}
+
+const api = {
+  signIn: { fn: "signIn" },
+  callback: { fn: "callback" },
+  refresh: { fn: "refresh" },
+  signOut: { fn: "signOut" },
+  sessionValid: { fn: "sessionValid" },
+} as unknown as LogtoSessionApi;
+
+type Handlers = {
+  signIn: ReturnType<typeof vi.fn>;
+  callback: ReturnType<typeof vi.fn>;
+  refresh: ReturnType<typeof vi.fn>;
+  signOut: ReturnType<typeof vi.fn>;
+};
+
+function makeHarness(options?: {
+  secureStore?: FakeSecureStore;
+  webBrowser?: ReturnType<typeof fakeWebBrowser>;
+}) {
+  const secureStore = options?.secureStore ?? fakeSecureStore();
+  const webBrowser = options?.webBrowser ?? fakeWebBrowser();
+  const storage = new NativeSessionStorageArea(
+    "https://native.convex.cloud",
+    secureStore,
+  );
+  const handlers: Handlers = {
+    signIn: vi.fn().mockResolvedValue({
+      url: "https://auth.example.com/oidc/auth?state=state-1",
+    }),
+    callback: vi.fn().mockResolvedValue({
+      idToken: freshToken(),
+      sessionToken: "session-token-1",
+      sessionId: "session-id-1",
+    }),
+    refresh: vi.fn().mockResolvedValue({
+      idToken: freshToken("refreshed-user"),
+      sessionToken: "session-token-2",
+      sessionId: "session-id-1",
+    }),
+    signOut: vi.fn().mockResolvedValue({
+      endSessionUrl: "https://auth.example.com/oidc/session/end",
+    }),
+  };
+  const transport = {
+    action: (reference: unknown, args: unknown) =>
+      handlers[(reference as { fn: keyof Handlers }).fn](args),
+  } as SessionTransport;
+  const onAuthError = vi.fn();
+  const navigate = vi.fn();
+  const engine = new SessionAuthEngine({
+    transport,
+    api,
+    storage,
+    callbackPath: "",
+    afterSignIn: "",
+    authFlow: createNativeSessionAuthFlow("io.logto://callback", webBrowser),
+    navigate,
+    onAuthError,
+    sleep: () => Promise.resolve(),
+  });
+  return {
+    engine,
+    storage,
+    secureStore,
+    webBrowser,
+    handlers,
+    onAuthError,
+    navigate,
+  };
+}
+
+function settled(engine: SessionAuthEngine): Promise<SessionSnapshot> {
+  return new Promise((resolve) => {
+    const check = () => {
+      const snapshot = engine.getSnapshot();
+      if (snapshot.status !== "restoring") {
+        unsubscribe();
+        resolve(snapshot);
+      }
+    };
+    const unsubscribe = engine.subscribe(check);
+    check();
+  });
+}
+
+async function seedSession(
+  secureStore: FakeSecureStore,
+  idToken: string,
+): Promise<void> {
+  const storage = new NativeSessionStorageArea(
+    "https://native.convex.cloud",
+    secureStore,
+  );
+  await storage.prepare();
+  storage.writeSession({
+    token: "session-token-old",
+    sessionId: "session-id-1",
+  });
+  storage.writeIdToken(idToken);
+  await storage.flush();
+}
+
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("native session adapters", () => {
+  it("completes system-browser sign-in and durably stores the session", async () => {
+    const { engine, storage, webBrowser, handlers, secureStore } =
+      makeHarness();
+    engine.start();
+    expect((await settled(engine)).status).toBe("unauthenticated");
+
+    await engine.signIn();
+
+    expect(handlers.signIn).toHaveBeenCalledWith({
+      redirectUri: "io.logto://callback",
+      returnTo: undefined,
+    });
+    expect(webBrowser.openAuthSessionAsync).toHaveBeenCalledWith(
+      "https://auth.example.com/oidc/auth?state=state-1",
+      "io.logto://callback",
+    );
+    expect(handlers.callback).toHaveBeenCalledWith({
+      code: "code-1",
+      state: "state-1",
+      redirectUri: "io.logto://callback",
+    });
+    expect(storage.readSession()).toEqual({
+      token: "session-token-1",
+      sessionId: "session-id-1",
+    });
+    expect(storage.readIdToken()).toBeTruthy();
+    expect(storage.takeTransaction()).toBeNull();
+    expect(engine.getSnapshot()).toMatchObject({
+      status: "authenticated",
+      sessionId: "session-id-1",
+      user: { sub: "native-user" },
+    });
+    expect(secureStore.data.size).toBe(2);
+  });
+
+  it("hydrates a cold start and rotates a stale session token", async () => {
+    const secureStore = fakeSecureStore();
+    await seedSession(secureStore, staleToken());
+    const { engine, storage, handlers } = makeHarness({ secureStore });
+
+    engine.start();
+    const snapshot = await settled(engine);
+
+    expect(handlers.refresh).toHaveBeenCalledWith({
+      sessionToken: "session-token-old",
+    });
+    expect(snapshot).toMatchObject({
+      status: "authenticated",
+      sessionId: "session-id-1",
+      user: { sub: "refreshed-user" },
+    });
+    expect(storage.readSession()?.token).toBe("session-token-2");
+
+    const coldStart = new NativeSessionStorageArea(
+      "https://native.convex.cloud",
+      secureStore,
+    );
+    await coldStart.prepare();
+    expect(coldStart.readSession()?.token).toBe("session-token-2");
+  });
+
+  it("clears SecureStore when reactive revocation fires", async () => {
+    const secureStore = fakeSecureStore();
+    await seedSession(secureStore, freshToken());
+    const { engine, storage } = makeHarness({ secureStore });
+    engine.start();
+    expect((await settled(engine)).status).toBe("authenticated");
+
+    engine.handleRevoked();
+    await storage.flush();
+
+    expect(engine.getSnapshot().status).toBe("unauthenticated");
+    expect(secureStore.data.size).toBe(0);
+  });
+
+  it("clears SecureStore before revoking and opens federated sign-out", async () => {
+    const secureStore = fakeSecureStore();
+    await seedSession(secureStore, freshToken());
+    const webBrowser = fakeWebBrowser({ type: "dismiss" });
+    const { engine, handlers } = makeHarness({ secureStore, webBrowser });
+    handlers.signOut.mockImplementation(() => {
+      expect(secureStore.data.size).toBe(0);
+      return Promise.resolve({
+        endSessionUrl: "https://auth.example.com/oidc/session/end",
+      });
+    });
+    engine.start();
+    await settled(engine);
+
+    await engine.signOut();
+
+    expect(handlers.signOut).toHaveBeenCalledWith({
+      sessionToken: "session-token-old",
+      postLogoutRedirectUri: "io.logto://callback",
+    });
+    expect(webBrowser.openAuthSessionAsync).toHaveBeenCalledWith(
+      "https://auth.example.com/oidc/session/end",
+      "io.logto://callback",
+    );
+    expect(engine.getSnapshot().status).toBe("unauthenticated");
+  });
+
+  it("refuses a foreign return and a replay after its state is spent", async () => {
+    const webBrowser = fakeWebBrowser({
+      type: "success",
+      url: "io.logto://callback?code=attacker-code&state=foreign-state",
+    });
+    const { engine, storage, handlers, onAuthError } = makeHarness({
+      webBrowser,
+    });
+    engine.start();
+    await settled(engine);
+
+    await engine.signIn();
+    expect(handlers.callback).not.toHaveBeenCalled();
+    expect(onAuthError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringMatching(/doesn't match/),
+      }),
+    );
+    expect(storage.takeTransaction()).toBeNull();
+
+    await engine.completeSignIn(
+      "io.logto://callback?code=late-code&state=state-1",
+      "io.logto://callback",
+    );
+    expect(handlers.callback).not.toHaveBeenCalled();
+    expect(onAuthError).toHaveBeenCalledTimes(2);
+  });
+
+  it("refuses a return when the authorization URL had no state", async () => {
+    const { engine, handlers, onAuthError } = makeHarness();
+    handlers.signIn.mockResolvedValue({
+      url: "https://auth.example.com/oidc/auth",
+    });
+    engine.start();
+    await settled(engine);
+
+    await engine.signIn();
+
+    expect(handlers.callback).not.toHaveBeenCalled();
+    expect(onAuthError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringMatching(/doesn't match/),
+      }),
+    );
+  });
+
+  it("spends the state without exchanging when the system browser is cancelled", async () => {
+    const webBrowser = fakeWebBrowser({ type: "cancel" });
+    const { engine, storage, handlers, onAuthError } = makeHarness({
+      webBrowser,
+    });
+    engine.start();
+    await settled(engine);
+
+    await engine.signIn();
+
+    expect(storage.takeTransaction()).toBeNull();
+    expect(handlers.callback).not.toHaveBeenCalled();
+    expect(onAuthError).not.toHaveBeenCalled();
+  });
+
+  it("fails loudly when SecureStore is unavailable", async () => {
+    const secureStore = fakeSecureStore();
+    secureStore.isAvailableAsync = vi.fn().mockResolvedValue(false);
+    const { engine, onAuthError } = makeHarness({ secureStore });
+
+    engine.start();
+    expect((await settled(engine)).status).toBe("unauthenticated");
+    expect(onAuthError).toHaveBeenCalledWith(
+      expect.any(NativeSessionStorageError),
+    );
+  });
+
+  it("reports a SecureStore write failure instead of opening the browser", async () => {
+    const secureStore = fakeSecureStore();
+    secureStore.setItemAsync = vi
+      .fn()
+      .mockRejectedValue(new Error("keystore write failed"));
+    const { engine, webBrowser, onAuthError } = makeHarness({ secureStore });
+    engine.start();
+    await settled(engine);
+
+    await expect(engine.signIn()).rejects.toBeInstanceOf(
+      NativeSessionStorageError,
+    );
+    expect(onAuthError).toHaveBeenCalledWith(
+      expect.any(NativeSessionStorageError),
+    );
+    expect(webBrowser.openAuthSessionAsync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/convex-logto/src/native-session-client.test.ts
+++ b/packages/convex-logto/src/native-session-client.test.ts
@@ -8,6 +8,7 @@ import {
 } from "./native-session-client";
 import {
   SessionAuthEngine,
+  SessionSignOutError,
   type SessionSnapshot,
   type SessionTransport,
 } from "./session-client";
@@ -207,6 +208,32 @@ describe("native session adapters", () => {
     expect(secureStore.data.size).toBe(2);
   });
 
+  it("shares one native sign-in flow across concurrent calls", async () => {
+    let finishBrowser!: (result: { type: string; url?: string }) => void;
+    const webBrowser = fakeWebBrowser();
+    webBrowser.openAuthSessionAsync.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishBrowser = resolve;
+        }),
+    );
+    const { engine, handlers } = makeHarness({ webBrowser });
+    engine.start();
+    await settled(engine);
+
+    const first = engine.signIn();
+    const second = engine.signIn();
+
+    expect(second).toBe(first);
+    await vi.waitFor(() => {
+      expect(webBrowser.openAuthSessionAsync).toHaveBeenCalledTimes(1);
+    });
+    expect(handlers.signIn).toHaveBeenCalledTimes(1);
+
+    finishBrowser({ type: "cancel" });
+    await Promise.all([first, second]);
+  });
+
   it("hydrates a cold start and rotates a stale session token", async () => {
     const secureStore = fakeSecureStore();
     await seedSession(secureStore, staleToken());
@@ -247,7 +274,7 @@ describe("native session adapters", () => {
     expect(secureStore.data.size).toBe(0);
   });
 
-  it("clears SecureStore before revoking and opens federated sign-out", async () => {
+  it("uses a custom post-logout URI for the action and browser return", async () => {
     const secureStore = fakeSecureStore();
     await seedSession(secureStore, freshToken());
     const webBrowser = fakeWebBrowser({ type: "dismiss" });
@@ -261,17 +288,64 @@ describe("native session adapters", () => {
     engine.start();
     await settled(engine);
 
-    await engine.signOut();
+    await engine.signOut({
+      postLogoutRedirectUri: "io.logto://signed-out",
+    });
 
     expect(handlers.signOut).toHaveBeenCalledWith({
       sessionToken: "session-token-old",
-      postLogoutRedirectUri: "io.logto://callback",
+      postLogoutRedirectUri: "io.logto://signed-out",
     });
     expect(webBrowser.openAuthSessionAsync).toHaveBeenCalledWith(
       "https://auth.example.com/oidc/session/end",
-      "io.logto://callback",
+      "io.logto://signed-out",
     );
     expect(engine.getSnapshot().status).toBe("unauthenticated");
+  });
+
+  it("rejects loudly when durable cleanup and server revocation both fail", async () => {
+    const secureStore = fakeSecureStore();
+    await seedSession(secureStore, freshToken());
+    secureStore.deleteItemAsync = vi
+      .fn()
+      .mockRejectedValue(new Error("keystore delete failed"));
+    const { engine, handlers, onAuthError } = makeHarness({ secureStore });
+    handlers.signOut.mockRejectedValue(new Error("network unavailable"));
+    engine.start();
+    await settled(engine);
+
+    await expect(engine.signOut()).rejects.toMatchObject({
+      name: "SessionSignOutError",
+      message: expect.stringMatching(/did not complete/),
+    });
+
+    expect(handlers.signOut).toHaveBeenCalledTimes(1);
+    expect(secureStore.deleteItemAsync).toHaveBeenCalledTimes(6);
+    expect(secureStore.data.size).toBe(2);
+    expect(onAuthError).toHaveBeenCalledWith(expect.any(SessionSignOutError));
+  });
+
+  it("returns normally when revocation succeeds despite durable cleanup failure", async () => {
+    const secureStore = fakeSecureStore();
+    await seedSession(secureStore, freshToken());
+    secureStore.deleteItemAsync = vi
+      .fn()
+      .mockRejectedValue(new Error("keystore delete failed"));
+    const { engine, handlers, onAuthError } = makeHarness({ secureStore });
+    engine.start();
+    await settled(engine);
+
+    await expect(engine.signOut({ federated: false })).resolves.toBeUndefined();
+
+    expect(handlers.signOut).toHaveBeenCalledTimes(1);
+    expect(secureStore.deleteItemAsync).toHaveBeenCalledTimes(6);
+    expect(secureStore.data.size).toBe(2);
+    expect(onAuthError).toHaveBeenCalledWith(
+      expect.any(NativeSessionStorageError),
+    );
+    expect(onAuthError).not.toHaveBeenCalledWith(
+      expect.any(SessionSignOutError),
+    );
   });
 
   it("refuses a foreign return and a replay after its state is spent", async () => {

--- a/packages/convex-logto/src/native-session-client.ts
+++ b/packages/convex-logto/src/native-session-client.ts
@@ -205,8 +205,8 @@ export function createNativeSessionAuthFlow(
       }
       return result.url;
     },
-    async openEndSession(url) {
-      await webBrowser.openAuthSessionAsync(url, redirectUri);
+    async openEndSession(url, returnUrl) {
+      await webBrowser.openAuthSessionAsync(url, returnUrl);
     },
   };
 }

--- a/packages/convex-logto/src/native-session-client.ts
+++ b/packages/convex-logto/src/native-session-client.ts
@@ -165,6 +165,10 @@ export class NativeSessionStorageArea implements SessionStorageAdapter {
 
   private write(name: StoredName, value: unknown): void {
     const raw = JSON.stringify(value);
+    // Deliberately keep the synchronous cache ahead if the durable write later
+    // fails. Rolling it back would make this live process reuse the superseded
+    // rotating token (and trigger reuse-kill after the grace window); only a
+    // cold start sees the older durable value, which cleanly re-authenticates.
     this.values.set(name, raw);
     this.enqueue(() => this.secureStore.setItemAsync(this.key(name), raw));
   }

--- a/packages/convex-logto/src/native-session-client.ts
+++ b/packages/convex-logto/src/native-session-client.ts
@@ -1,0 +1,212 @@
+import type {
+  SessionAuthFlow,
+  SessionStorageAdapter,
+  StoredSession,
+} from "./session-client";
+
+type StoredTransaction = { state: string };
+type StoredName = "session" | "idToken" | "txn";
+
+/** Structural subset of expo-secure-store used by native session mode. */
+export type NativeSecureStore = {
+  isAvailableAsync?(): Promise<boolean>;
+  getItemAsync(key: string): Promise<string | null>;
+  setItemAsync(key: string, value: string): Promise<void>;
+  deleteItemAsync(key: string): Promise<void>;
+};
+
+/** Structural subset of expo-web-browser used by native session mode. */
+export type NativeWebBrowser = {
+  openAuthSessionAsync(
+    url: string,
+    redirectUrl?: string | null,
+  ): Promise<{ type: string; url?: string }>;
+};
+
+export class NativeSessionStorageError extends Error {}
+
+function storageError(cause?: unknown): NativeSessionStorageError {
+  return new NativeSessionStorageError(
+    "convex-logto: native session mode requires working expo-secure-store; " +
+      "session credentials are never downgraded to unencrypted storage.",
+    cause === undefined ? undefined : { cause },
+  );
+}
+
+/**
+ * SecureStore keys accept only alphanumerics, `.`, `-`, and `_`. Encoding the
+ * deployment namespace as fixed-width UTF-16 hex keeps keys valid and avoids
+ * two Convex deployments sharing credentials on the same app install.
+ */
+function encodeNamespace(namespace: string): string {
+  let encoded = "";
+  for (let index = 0; index < namespace.length; index++) {
+    encoded += namespace.charCodeAt(index).toString(16).padStart(4, "0");
+  }
+  return encoded || "empty";
+}
+
+/**
+ * Async SecureStore adapter with a synchronous hydrated cache for the shared
+ * SessionAuthEngine. Every engine transition awaits `flush()`, so a rotated
+ * token is durable before it can be served or the browser flow can continue.
+ */
+export class NativeSessionStorageArea implements SessionStorageAdapter {
+  private values = new Map<StoredName, string>();
+  private preparation: Promise<void> | null = null;
+  private pendingWrites: Promise<void> = Promise.resolve();
+  private pendingWriteError: unknown;
+  private prefix: string;
+
+  constructor(
+    namespace: string,
+    private secureStore: NativeSecureStore,
+  ) {
+    this.prefix = `convex-logto.native.${encodeNamespace(namespace)}`;
+  }
+
+  get sessionEventKey(): string {
+    return this.key("session");
+  }
+
+  prepare(): Promise<void> {
+    this.preparation ??= this.load().catch((error: unknown) => {
+      this.preparation = null;
+      throw error instanceof NativeSessionStorageError
+        ? error
+        : storageError(error);
+    });
+    return this.preparation;
+  }
+
+  async flush(): Promise<void> {
+    await this.pendingWrites;
+    if (this.pendingWriteError !== undefined) {
+      const cause = this.pendingWriteError;
+      this.pendingWriteError = undefined;
+      throw storageError(cause);
+    }
+  }
+
+  readSession(): StoredSession | null {
+    const value = this.read<StoredSession>("session");
+    return value &&
+      typeof value.token === "string" &&
+      typeof value.sessionId === "string"
+      ? value
+      : null;
+  }
+
+  writeSession(session: StoredSession): void {
+    this.write("session", session);
+  }
+
+  readIdToken(): string | null {
+    const value = this.read<unknown>("idToken");
+    return typeof value === "string" ? value : null;
+  }
+
+  writeIdToken(idToken: string): void {
+    this.write("idToken", idToken);
+  }
+
+  stashTransaction(transaction: StoredTransaction): void {
+    this.write("txn", transaction);
+  }
+
+  takeTransaction(): StoredTransaction | null {
+    const value = this.read<StoredTransaction>("txn");
+    this.remove("txn");
+    return value && typeof value.state === "string" ? value : null;
+  }
+
+  clearAll(): void {
+    this.remove("session");
+    this.remove("idToken");
+    this.remove("txn");
+  }
+
+  clearIdToken(): void {
+    this.remove("idToken");
+  }
+
+  private key(name: StoredName): string {
+    return `${this.prefix}.${name}`;
+  }
+
+  private async load(): Promise<void> {
+    if (
+      this.secureStore.isAvailableAsync !== undefined &&
+      !(await this.secureStore.isAvailableAsync())
+    ) {
+      throw storageError();
+    }
+    const names = ["session", "idToken", "txn"] as const;
+    const stored = await Promise.all(
+      names.map((name) => this.secureStore.getItemAsync(this.key(name))),
+    );
+    for (let index = 0; index < names.length; index++) {
+      const raw = stored[index];
+      if (raw !== null && raw !== undefined) {
+        this.values.set(names[index]!, raw);
+      }
+    }
+  }
+
+  private read<T>(name: StoredName): T | null {
+    const raw = this.values.get(name);
+    if (raw === undefined) return null;
+    try {
+      return JSON.parse(raw) as T;
+    } catch {
+      return null;
+    }
+  }
+
+  private write(name: StoredName, value: unknown): void {
+    const raw = JSON.stringify(value);
+    this.values.set(name, raw);
+    this.enqueue(() => this.secureStore.setItemAsync(this.key(name), raw));
+  }
+
+  private remove(name: StoredName): void {
+    this.values.delete(name);
+    this.enqueue(() => this.secureStore.deleteItemAsync(this.key(name)));
+  }
+
+  private enqueue(operation: () => Promise<void>): void {
+    this.pendingWrites = this.pendingWrites
+      .then(operation)
+      .catch((error: unknown) => {
+        this.pendingWriteError ??= error;
+      });
+  }
+}
+
+/** Adapt Expo's system-browser result into the shared engine's auth-flow seam. */
+export function createNativeSessionAuthFlow(
+  redirectUri: string,
+  webBrowser: NativeWebBrowser,
+): SessionAuthFlow {
+  if (!redirectUri.trim()) {
+    throw new Error(
+      "convex-logto: native session mode requires a non-empty redirectUri.",
+    );
+  }
+  return {
+    redirectUri,
+    async openAuthorization(url) {
+      const result = await webBrowser.openAuthSessionAsync(url, redirectUri);
+      if (result.type !== "success") return null;
+      if (typeof result.url !== "string") {
+        throw new Error(
+          "convex-logto: expo-web-browser returned success without a redirect URL.",
+        );
+      }
+      return result.url;
+    },
+    async openEndSession(url) {
+      await webBrowser.openAuthSessionAsync(url, redirectUri);
+    },
+  };
+}

--- a/packages/convex-logto/src/native-session.tsx
+++ b/packages/convex-logto/src/native-session.tsx
@@ -175,7 +175,8 @@ export type LogtoSessionAuth = {
   signIn: () => Promise<void>;
   /**
    * Revoke the session, clear SecureStore, and end browser SSO by default.
-   * Rejects with `SessionSignOutError` if both durable cleanup and revocation fail.
+   * Rejects with `SessionSignOutError` when durable cleanup fails twice; its
+   * `serverSessionStatus` distinguishes a successful revocation from a dual failure.
    */
   signOut: (options?: {
     postLogoutRedirectUri?: string;
@@ -210,4 +211,5 @@ export function useLogtoAuth(): LogtoSessionAuth {
 }
 
 export type { LogtoSessionApi } from "./session";
+export type { SessionSignOutServerStatus } from "./session-client";
 export { SessionSignOutError } from "./session-client";

--- a/packages/convex-logto/src/native-session.tsx
+++ b/packages/convex-logto/src/native-session.tsx
@@ -1,0 +1,206 @@
+// The `convex-logto/native-session` entry: the web session state machine with
+// Expo SecureStore and system-browser adapters. It intentionally does not
+// import @logto/rn; the Convex component owns every OIDC token exchange.
+
+import * as SecureStore from "expo-secure-store";
+import * as WebBrowser from "expo-web-browser";
+import {
+  ConvexProviderWithAuth,
+  type ConvexReactClient,
+  useConvexAuth,
+  useQuery,
+} from "convex/react";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+} from "react";
+import {
+  createNativeSessionAuthFlow,
+  NativeSessionStorageArea,
+} from "./native-session-client";
+import { SessionAuthEngine, type SessionTransport } from "./session-client";
+import type { LogtoSessionApi } from "./session";
+
+const SessionContext = createContext<{
+  engine: SessionAuthEngine;
+  sessionApi: LogtoSessionApi;
+} | null>(null);
+
+function useSessionContext(caller: string) {
+  const context = useContext(SessionContext);
+  if (context === null) {
+    throw new Error(
+      `convex-logto: ${caller} must be used inside <ConvexLogtoSessionProvider>.`,
+    );
+  }
+  return context;
+}
+
+export type ConvexLogtoSessionProviderProps = {
+  /** Your `ConvexReactClient`. */
+  client: ConvexReactClient;
+  /** The module re-exporting `logtoSessionApi(...)`, e.g. `api.auth`. */
+  sessionApi: LogtoSessionApi;
+  /** Custom-scheme/universal-link callback registered in Logto. */
+  redirectUri: string;
+  /** Subscribe to `sessionValid` and drop auth immediately on revocation. Default true. */
+  reactiveRevocation?: boolean;
+  /** Recoverable OAuth, SecureStore, and system-browser failures. */
+  onAuthError?: (error: Error) => void;
+  children: ReactNode;
+};
+
+/**
+ * Session mode for React Native / Expo. The rotating session token, short-lived
+ * ID token, and single-use OAuth state are all encrypted by SecureStore. Sign-in
+ * and federated sign-out use expo-web-browser; there is no callback route.
+ *
+ * Device binding is intentionally absent: native credential persistence is
+ * already bound to the OS keystore, and this surface never exposes that option.
+ */
+export function ConvexLogtoSessionProvider({
+  client,
+  sessionApi,
+  redirectUri,
+  reactiveRevocation = true,
+  onAuthError,
+  children,
+}: ConvexLogtoSessionProviderProps) {
+  const onAuthErrorRef = useRef(onAuthError);
+  useEffect(() => {
+    onAuthErrorRef.current = onAuthError;
+  });
+
+  const engine = useMemo(() => {
+    const storage = new NativeSessionStorageArea(
+      clientNamespace(client),
+      SecureStore,
+    );
+    return new SessionAuthEngine({
+      transport: client as SessionTransport,
+      api: sessionApi,
+      storage,
+      callbackPath: "",
+      afterSignIn: "",
+      authFlow: createNativeSessionAuthFlow(redirectUri, WebBrowser),
+      // Native returns to the same mounted tree; callback completion has no
+      // route cleanup or post-sign-in navigation to perform.
+      navigate: () => {},
+      onAuthError: (error) => onAuthErrorRef.current?.(error),
+    });
+  }, [client, sessionApi, redirectUri]);
+
+  useEffect(() => {
+    engine.start();
+  }, [engine]);
+
+  const contextValue = useMemo(
+    () => ({ engine, sessionApi }),
+    [engine, sessionApi],
+  );
+
+  return (
+    <SessionContext.Provider value={contextValue}>
+      <ConvexProviderWithAuth client={client} useAuth={useAuthFromSession}>
+        {reactiveRevocation ? <RevocationWatcher /> : null}
+        {children}
+      </ConvexProviderWithAuth>
+    </SessionContext.Provider>
+  );
+}
+
+function clientNamespace(client: ConvexReactClient): string {
+  const url = (client as { url?: unknown }).url;
+  return typeof url === "string" ? url : "";
+}
+
+function useAuthFromSession() {
+  const { engine } = useSessionContext(
+    "ConvexLogtoSessionProvider's auth bridge",
+  );
+  const snapshot = useSyncExternalStore(
+    engine.subscribe,
+    engine.getSnapshot,
+    engine.getServerSnapshot,
+  );
+  const fetchAccessToken = useCallback(
+    ({ forceRefreshToken }: { forceRefreshToken: boolean }) =>
+      engine.fetchAccessToken(forceRefreshToken),
+    [engine],
+  );
+  return useMemo(
+    () => ({
+      isLoading: snapshot.status === "restoring",
+      isAuthenticated: snapshot.status === "authenticated",
+      fetchAccessToken,
+    }),
+    [snapshot, fetchAccessToken],
+  );
+}
+
+function RevocationWatcher() {
+  const { engine, sessionApi } = useSessionContext("RevocationWatcher");
+  const snapshot = useSyncExternalStore(
+    engine.subscribe,
+    engine.getSnapshot,
+    engine.getServerSnapshot,
+  );
+  const sessionId = snapshot.sessionId;
+  const hasSessionId = sessionId !== null && sessionId.length > 0;
+  const valid = useQuery(
+    sessionApi.sessionValid,
+    hasSessionId ? { sessionId } : "skip",
+  );
+  useEffect(() => {
+    if (hasSessionId && valid === false) engine.handleRevoked();
+  }, [engine, hasSessionId, valid]);
+  return null;
+}
+
+export type LogtoSessionAuth = {
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  /** Decoded ID token claims, for display only. */
+  user: Record<string, unknown> | undefined;
+  /** Open Logto in the system browser and complete the deep-link return in place. */
+  signIn: () => Promise<void>;
+  /** Revoke the session, clear SecureStore, and end browser SSO by default. */
+  signOut: (options?: {
+    postLogoutRedirectUri?: string;
+    federated?: boolean;
+  }) => Promise<void>;
+};
+
+export function useLogtoAuth(): LogtoSessionAuth {
+  const { engine } = useSessionContext("useLogtoAuth");
+  const { isAuthenticated, isLoading } = useConvexAuth();
+  const snapshot = useSyncExternalStore(
+    engine.subscribe,
+    engine.getSnapshot,
+    engine.getServerSnapshot,
+  );
+  const signIn = useCallback(() => engine.signIn(), [engine]);
+  const signOut = useCallback(
+    (options?: { postLogoutRedirectUri?: string; federated?: boolean }) =>
+      engine.signOut(options),
+    [engine],
+  );
+  return useMemo(
+    () => ({
+      isAuthenticated,
+      isLoading,
+      user: isAuthenticated ? snapshot.user : undefined,
+      signIn,
+      signOut,
+    }),
+    [isAuthenticated, isLoading, snapshot.user, signIn, signOut],
+  );
+}
+
+export type { LogtoSessionApi } from "./session";

--- a/packages/convex-logto/src/native-session.tsx
+++ b/packages/convex-logto/src/native-session.tsx
@@ -168,9 +168,15 @@ export type LogtoSessionAuth = {
   isLoading: boolean;
   /** Decoded ID token claims, for display only. */
   user: Record<string, unknown> | undefined;
-  /** Open Logto in the system browser and complete the deep-link return in place. */
+  /**
+   * Open Logto in the system browser and complete the deep-link return in
+   * place. Concurrent calls share the one in-progress native browser flow.
+   */
   signIn: () => Promise<void>;
-  /** Revoke the session, clear SecureStore, and end browser SSO by default. */
+  /**
+   * Revoke the session, clear SecureStore, and end browser SSO by default.
+   * Rejects with `SessionSignOutError` if both durable cleanup and revocation fail.
+   */
   signOut: (options?: {
     postLogoutRedirectUri?: string;
     federated?: boolean;
@@ -204,3 +210,4 @@ export function useLogtoAuth(): LogtoSessionAuth {
 }
 
 export type { LogtoSessionApi } from "./session";
+export { SessionSignOutError } from "./session-client";

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -35,6 +35,32 @@ export type SessionTransport = {
   ): Promise<Action["_returnType"]>;
 };
 
+/** Storage contract used by the shared web/native session state machine. */
+export type SessionStorageAdapter = {
+  /** Async stores hydrate their synchronous cache here before the engine reads it. */
+  prepare?(): Promise<void>;
+  /** Wait for queued durable writes; browser storage writes synchronously. */
+  flush?(): Promise<void>;
+  readonly sessionEventKey: string;
+  readSession(): StoredSession | null;
+  writeSession(session: StoredSession): void;
+  readIdToken(): string | null;
+  writeIdToken(idToken: string): void;
+  stashTransaction(transaction: StoredTransaction): void;
+  takeTransaction(): StoredTransaction | null;
+  clearAll(): void;
+  clearIdToken(): void;
+};
+
+/** Native system-browser seam. Absent means the existing browser redirect flow. */
+export type SessionAuthFlow = {
+  redirectUri: string;
+  /** Return the successful deep-link URL, or null when the user cancels. */
+  openAuthorization(url: string): Promise<string | null>;
+  /** Best-effort federated sign-out in the system browser. */
+  openEndSession(url: string): Promise<void>;
+};
+
 export function decodeJwtPayload(
   token: string,
 ): Record<string, unknown> | null {
@@ -201,7 +227,7 @@ export class SessionStorageArea {
 export type SessionEngineOptions = {
   transport: SessionTransport;
   api: LogtoSessionApi;
-  storage: SessionStorageArea;
+  storage: SessionStorageAdapter;
   callbackPath: string;
   afterSignIn: string;
   /** Fresh SSR-seeded ID token. */
@@ -212,6 +238,8 @@ export type SessionEngineOptions = {
   deviceBinding?: SessionDeviceBinding;
   /** Replace-style navigation; falls back to `location.replace`. */
   navigate?: (to: string) => void;
+  /** Native system-browser/deep-link flow; absent preserves the web flow. */
+  authFlow?: SessionAuthFlow;
   onAuthError?: (error: Error) => void;
   /** Injectable for tests. */
   now?: () => number;
@@ -243,6 +271,7 @@ export class SessionAuthEngine {
   private listeners = new Set<() => void>();
   private started = false;
   private inflightRefresh: Promise<string | null> | null = null;
+  private storagePreparation: Promise<void> | null = null;
   /** The last ID token handed to Convex — a forced fetch must never re-serve it. */
   private lastServed: string | null = null;
   private now: () => number;
@@ -312,17 +341,26 @@ export class SessionAuthEngine {
 
   /** Run the mount state machine. Idempotent (StrictMode double-effects). */
   start(): void {
-    if (this.started || typeof window === "undefined") return;
+    if (
+      this.started ||
+      (this.options.authFlow === undefined && typeof window === "undefined")
+    )
+      return;
     this.started = true;
     void this.startInner();
   }
 
   private async startInner(): Promise<void> {
     try {
+      await this.prepareStorage();
       await this.options.deviceBinding?.prepare();
     } catch (error) {
       this.reportError(this.asError(error));
       this.setUnauthenticated();
+      return;
+    }
+    if (this.options.authFlow !== undefined) {
+      await this.restore();
       return;
     }
     const onCallback = window.location.pathname === this.options.callbackPath;
@@ -330,7 +368,10 @@ export class SessionAuthEngine {
       ? classifySignInSearch(window.location.search)
       : ({ kind: "none" } as const);
     if (outcome.kind === "pending") {
-      await this.completeCallback();
+      await this.completeCallback(
+        new URLSearchParams(window.location.search),
+        `${window.location.origin}${this.options.callbackPath}`,
+      );
       return;
     }
     if (outcome.kind === "error") {
@@ -343,14 +384,17 @@ export class SessionAuthEngine {
     }
   }
 
-  private async completeCallback(): Promise<void> {
-    const params = new URLSearchParams(window.location.search);
+  private async completeCallback(
+    params: URLSearchParams,
+    redirectUri: string,
+  ): Promise<void> {
     const code = params.get("code") ?? "";
     const state = params.get("state") ?? "";
     // Login-CSRF binding: only the browser tab that started this sign-in holds
     // the matching stash. A foreign (attacker-initiated) or replayed callback
     // is refused without ever calling the exchange.
     const transaction = this.options.storage.takeTransaction();
+    await this.flushStorageReporting();
     if (!transaction || transaction.state !== state) {
       this.reportError(
         new Error(
@@ -369,7 +413,7 @@ export class SessionAuthEngine {
         this.options.transport.action(this.options.api.callback, {
           code,
           state,
-          redirectUri: `${window.location.origin}${this.options.callbackPath}`,
+          redirectUri,
           ...(devicePublicKey === undefined ? {} : { devicePublicKey }),
         }),
       );
@@ -378,6 +422,7 @@ export class SessionAuthEngine {
         sessionId: result.sessionId,
       });
       this.options.storage.writeIdToken(result.idToken);
+      await this.flushStorage();
       this.lastServed = null;
       this.setAuthenticated(result.idToken);
       const destination =
@@ -440,6 +485,13 @@ export class SessionAuthEngine {
 
   /** The `fetchAccessToken` half of `ConvexProviderWithAuth`'s `useAuth` contract. */
   async fetchAccessToken(forceRefreshToken: boolean): Promise<string | null> {
+    try {
+      await this.prepareStorage();
+    } catch (error) {
+      this.reportError(this.asError(error));
+      this.setUnauthenticated();
+      return null;
+    }
     const cached = this.options.storage.readIdToken();
     if (!forceRefreshToken && cached !== null && this.isFresh(cached)) {
       this.lastServed = cached;
@@ -498,6 +550,7 @@ export class SessionAuthEngine {
           sessionId: result.sessionId,
         });
         this.options.storage.writeIdToken(result.idToken);
+        await this.flushStorageReporting();
         return result.idToken;
       } catch (error) {
         if (sessionErrorKind(error) === "terminal") {
@@ -528,35 +581,119 @@ export class SessionAuthEngine {
       );
     }
     try {
+      await this.prepareStorage();
       await this.options.deviceBinding?.prepare();
     } catch (error) {
       const normalizedError = this.asError(error);
       this.reportError(normalizedError);
       throw normalizedError;
     }
+    const redirectUri =
+      this.options.authFlow?.redirectUri ??
+      `${window.location.origin}${this.options.callbackPath}`;
     const { url } = await this.options.transport.action(
       this.options.api.signIn,
       {
-        redirectUri: `${window.location.origin}${this.options.callbackPath}`,
+        redirectUri,
         returnTo,
       },
     );
     // Bind the transaction to this tab (see completeCallback).
     const state = new URL(url).searchParams.get("state");
     if (state !== null) this.options.storage.stashTransaction({ state });
-    window.location.assign(url);
+    await this.flushStorageReporting();
+    const authFlow = this.options.authFlow;
+    if (authFlow === undefined) {
+      window.location.assign(url);
+      return;
+    }
+
+    let callbackUrl: string | null;
+    try {
+      callbackUrl = await authFlow.openAuthorization(url);
+    } catch (error) {
+      this.options.storage.takeTransaction();
+      await this.flushStorageReporting();
+      const normalizedError = this.asError(error);
+      this.reportError(normalizedError);
+      throw normalizedError;
+    }
+    if (callbackUrl === null) {
+      // A cancelled browser session must not leave an OIDC state value that a
+      // later deep link could replay against.
+      this.options.storage.takeTransaction();
+      await this.flushStorageReporting();
+      return;
+    }
+    await this.completeSignIn(callbackUrl, redirectUri);
+  }
+
+  /** Complete a native system-browser return. Public for deep-link adapters/tests. */
+  async completeSignIn(
+    callbackUrl: string,
+    redirectUri: string,
+  ): Promise<void> {
+    let url: URL;
+    try {
+      url = new URL(callbackUrl);
+    } catch (error) {
+      this.options.storage.takeTransaction();
+      await this.flushStorageReporting();
+      this.reportError(
+        new Error("convex-logto: the native sign-in return URL is invalid.", {
+          cause: error,
+        }),
+      );
+      await this.restore();
+      this.navigateReplace(this.options.afterSignIn);
+      return;
+    }
+    const outcome = classifySignInSearch(url.search);
+    if (outcome.kind === "pending") {
+      await this.completeCallback(url.searchParams, redirectUri);
+      return;
+    }
+
+    // A returned browser session spends the state even when Logto returned an
+    // OAuth error or a malformed callback. This keeps the login-CSRF binding
+    // single-use on native, where there is no callback route to revisit.
+    this.options.storage.takeTransaction();
+    await this.flushStorageReporting();
+    this.reportError(
+      new Error(
+        outcome.kind === "error"
+          ? outcome.message
+          : "convex-logto: the native sign-in return did not include an authorization code and state.",
+      ),
+    );
+    await this.restore();
+    this.navigateReplace(this.options.afterSignIn);
   }
 
   async signOut(options?: {
     postLogoutRedirectUri?: string;
     federated?: boolean;
   }): Promise<void> {
+    try {
+      await this.prepareStorage();
+    } catch (error) {
+      const normalizedError = this.asError(error);
+      this.reportError(normalizedError);
+      throw normalizedError;
+    }
     const session = this.options.storage.readSession();
     // Clear before the network call: sign-out must not be blockable by a dead
     // Logto. The localStorage removal kicks other tabs via the storage event.
     this.options.storage.clearAll();
     this.lastServed = null;
     this.setUnauthenticated();
+    try {
+      await this.flushStorage();
+    } catch (error) {
+      // Still revoke the server session when durable local cleanup fails. A
+      // later cold start can only present a token the server has killed.
+      this.reportError(this.asError(error));
+    }
     if (session === null) return;
     let endSessionUrl: string | undefined;
     try {
@@ -565,7 +702,9 @@ export class SessionAuthEngine {
         {
           sessionToken: session.token,
           postLogoutRedirectUri:
-            options?.postLogoutRedirectUri ?? window.location.origin,
+            options?.postLogoutRedirectUri ??
+            this.options.authFlow?.redirectUri ??
+            window.location.origin,
         },
       ));
     } catch {
@@ -574,7 +713,15 @@ export class SessionAuthEngine {
     // Federated by default: also end Logto's SSO session so the next sign-in
     // isn't silent. The post sign-out redirect URI must be registered on the app.
     if (options?.federated !== false && endSessionUrl !== undefined) {
-      window.location.assign(endSessionUrl);
+      if (this.options.authFlow !== undefined) {
+        try {
+          await this.options.authFlow.openEndSession(endSessionUrl);
+        } catch (error) {
+          this.reportError(this.asError(error));
+        }
+      } else {
+        window.location.assign(endSessionUrl);
+      }
     }
   }
 
@@ -590,11 +737,40 @@ export class SessionAuthEngine {
   /** The reactive `sessionValid` subscription pushed `false`: the session was revoked. */
   handleRevoked(): void {
     this.options.storage.clearAll();
+    void this.flushStorage().catch((error: unknown) => {
+      this.reportError(this.asError(error));
+    });
     this.lastServed = null;
     this.setUnauthenticated();
   }
 
   // -- plumbing --
+
+  private prepareStorage(): Promise<void> {
+    if (this.storagePreparation === null) {
+      this.storagePreparation = (
+        this.options.storage.prepare?.() ?? Promise.resolve()
+      ).catch((error: unknown) => {
+        this.storagePreparation = null;
+        throw error;
+      });
+    }
+    return this.storagePreparation;
+  }
+
+  private flushStorage(): Promise<void> {
+    return this.options.storage.flush?.() ?? Promise.resolve();
+  }
+
+  private async flushStorageReporting(): Promise<void> {
+    try {
+      await this.flushStorage();
+    } catch (error) {
+      const normalizedError = this.asError(error);
+      this.reportError(normalizedError);
+      throw normalizedError;
+    }
+  }
 
   private isFresh(idToken: string): boolean {
     return idTokenExpMs(idToken) - ID_TOKEN_SKEW_MS > this.now();

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -58,8 +58,19 @@ export type SessionAuthFlow = {
   /** Return the successful deep-link URL, or null when the user cancels. */
   openAuthorization(url: string): Promise<string | null>;
   /** Best-effort federated sign-out in the system browser. */
-  openEndSession(url: string): Promise<void>;
+  openEndSession(url: string, returnUrl: string): Promise<void>;
 };
+
+/** Neither durable credential cleanup nor server-side revocation completed. */
+export class SessionSignOutError extends Error {
+  constructor(cause?: unknown) {
+    super(
+      "convex-logto: sign-out did not complete because SecureStore cleanup and server revocation both failed.",
+      cause === undefined ? undefined : { cause },
+    );
+    this.name = "SessionSignOutError";
+  }
+}
 
 export function decodeJwtPayload(
   token: string,
@@ -270,6 +281,7 @@ export class SessionAuthEngine {
   private serverSnapshot: SessionSnapshot;
   private listeners = new Set<() => void>();
   private started = false;
+  private inflightSignIn: Promise<void> | null = null;
   private inflightRefresh: Promise<string | null> | null = null;
   private storagePreparation: Promise<void> | null = null;
   /** The last ID token handed to Convex — a forced fetch must never re-serve it. */
@@ -571,7 +583,20 @@ export class SessionAuthEngine {
 
   // -- user actions --
 
-  async signIn(options?: { returnTo?: string }): Promise<void> {
+  signIn(options?: { returnTo?: string }): Promise<void> {
+    // Expo can only host one system-browser auth session at a time, and native
+    // storage intentionally has one OAuth transaction slot. Share the entire
+    // flow so a double-tap cannot overwrite its own login-CSRF state. The web
+    // redirect path remains independent and unchanged.
+    if (this.options.authFlow === undefined) return this.signInInner(options);
+    if (this.inflightSignIn !== null) return this.inflightSignIn;
+    this.inflightSignIn = this.signInInner(options).finally(() => {
+      this.inflightSignIn = null;
+    });
+    return this.inflightSignIn;
+  }
+
+  private async signInInner(options?: { returnTo?: string }): Promise<void> {
     const returnTo = options?.returnTo;
     if (returnTo !== undefined && !isSafeReturnTo(returnTo)) {
       throw new Error(
@@ -687,35 +712,74 @@ export class SessionAuthEngine {
     this.options.storage.clearAll();
     this.lastServed = null;
     this.setUnauthenticated();
+    let durableCleanupFailed = false;
     try {
       await this.flushStorage();
     } catch (error) {
       // Still revoke the server session when durable local cleanup fails. A
       // later cold start can only present a token the server has killed.
+      durableCleanupFailed = true;
       this.reportError(this.asError(error));
     }
-    if (session === null) return;
+    if (session === null) {
+      if (durableCleanupFailed) {
+        this.options.storage.clearAll();
+        try {
+          await this.flushStorage();
+        } catch (error) {
+          this.reportError(this.asError(error));
+        }
+      }
+      return;
+    }
+    const postLogoutRedirectUri =
+      options?.postLogoutRedirectUri ??
+      this.options.authFlow?.redirectUri ??
+      window.location.origin;
     let endSessionUrl: string | undefined;
+    let serverRevoked = false;
+    let serverRevocationError: unknown;
     try {
       ({ endSessionUrl } = await this.options.transport.action(
         this.options.api.signOut,
         {
           sessionToken: session.token,
-          postLogoutRedirectUri:
-            options?.postLogoutRedirectUri ??
-            this.options.authFlow?.redirectUri ??
-            window.location.origin,
+          postLogoutRedirectUri,
         },
       ));
-    } catch {
+      serverRevoked = true;
+    } catch (error) {
+      serverRevocationError = error;
       // Best effort: local sign-out already happened; the grant dies at its TTL.
+    }
+    if (durableCleanupFailed) {
+      // SecureStore failures can be transient (for example, a temporarily
+      // unavailable keystore). Retry once after the independent server kill.
+      this.options.storage.clearAll();
+      try {
+        await this.flushStorage();
+      } catch (error) {
+        const durableCleanupError = this.asError(error);
+        this.reportError(durableCleanupError);
+        if (!serverRevoked) {
+          const signOutError = new SessionSignOutError({
+            durableCleanupError,
+            serverRevocationError,
+          });
+          this.reportError(signOutError);
+          throw signOutError;
+        }
+      }
     }
     // Federated by default: also end Logto's SSO session so the next sign-in
     // isn't silent. The post sign-out redirect URI must be registered on the app.
     if (options?.federated !== false && endSessionUrl !== undefined) {
       if (this.options.authFlow !== undefined) {
         try {
-          await this.options.authFlow.openEndSession(endSessionUrl);
+          await this.options.authFlow.openEndSession(
+            endSessionUrl,
+            postLogoutRedirectUri,
+          );
         } catch (error) {
           this.reportError(this.asError(error));
         }

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -61,14 +61,34 @@ export type SessionAuthFlow = {
   openEndSession(url: string, returnUrl: string): Promise<void>;
 };
 
-/** Neither durable credential cleanup nor server-side revocation completed. */
+export type SessionSignOutServerStatus =
+  | "revoked"
+  | "revocation_failed"
+  | "not_present";
+
+/** Durable credential cleanup failed twice during an explicit sign-out. */
 export class SessionSignOutError extends Error {
-  constructor(cause?: unknown) {
+  readonly code:
+    | "local_cleanup_failed"
+    | "local_cleanup_and_server_revocation_failed";
+
+  constructor(
+    readonly serverSessionStatus: SessionSignOutServerStatus,
+    cause?: unknown,
+  ) {
+    const revocationAlsoFailed = serverSessionStatus === "revocation_failed";
     super(
-      "convex-logto: sign-out did not complete because SecureStore cleanup and server revocation both failed.",
+      revocationAlsoFailed
+        ? "convex-logto: sign-out did not complete because SecureStore cleanup and server revocation both failed."
+        : serverSessionStatus === "revoked"
+          ? "convex-logto: the server session was revoked, but local credentials could not be wiped from SecureStore."
+          : "convex-logto: local credentials could not be wiped from SecureStore.",
       cause === undefined ? undefined : { cause },
     );
     this.name = "SessionSignOutError";
+    this.code = revocationAlsoFailed
+      ? "local_cleanup_and_server_revocation_failed"
+      : "local_cleanup_failed";
   }
 }
 
@@ -624,6 +644,9 @@ export class SessionAuthEngine {
       },
     );
     // Bind the transaction to this tab (see completeCallback).
+    // Always spend an abandoned state before considering the new authorize
+    // URL: if Logto ever omits `state`, an old deep link must not match it.
+    this.options.storage.takeTransaction();
     const state = new URL(url).searchParams.get("state");
     if (state !== null) this.options.storage.stashTransaction({ state });
     await this.flushStorageReporting();
@@ -704,6 +727,16 @@ export class SessionAuthEngine {
     } catch (error) {
       const normalizedError = this.asError(error);
       this.reportError(normalizedError);
+      // A broken async store must not trap the live React tree in an
+      // authenticated snapshot. Queue deletion where the adapter still can,
+      // then preserve the storage failure signal for the caller.
+      this.lastServed = null;
+      this.setUnauthenticated();
+      try {
+        this.options.storage.clearAll();
+      } catch (clearError) {
+        this.reportError(this.asError(clearError));
+      }
       throw normalizedError;
     }
     const session = this.options.storage.readSession();
@@ -716,42 +749,37 @@ export class SessionAuthEngine {
     try {
       await this.flushStorage();
     } catch (error) {
-      // Still revoke the server session when durable local cleanup fails. A
-      // later cold start can only present a token the server has killed.
+      // Still attempt server revocation when durable local cleanup fails; a
+      // second cleanup failure becomes a loud error after that independent try.
       durableCleanupFailed = true;
       this.reportError(this.asError(error));
     }
-    if (session === null) {
-      if (durableCleanupFailed) {
-        this.options.storage.clearAll();
-        try {
-          await this.flushStorage();
-        } catch (error) {
-          this.reportError(this.asError(error));
-        }
-      }
-      return;
-    }
-    const postLogoutRedirectUri =
-      options?.postLogoutRedirectUri ??
-      this.options.authFlow?.redirectUri ??
-      window.location.origin;
+    let postLogoutRedirectUri: string | undefined;
     let endSessionUrl: string | undefined;
-    let serverRevoked = false;
+    let serverSessionStatus: SessionSignOutServerStatus =
+      session === null ? "not_present" : "revocation_failed";
     let serverRevocationError: unknown;
-    try {
-      ({ endSessionUrl } = await this.options.transport.action(
-        this.options.api.signOut,
-        {
-          sessionToken: session.token,
-          postLogoutRedirectUri,
-        },
-      ));
-      serverRevoked = true;
-    } catch (error) {
-      serverRevocationError = error;
-      // Best effort: local sign-out already happened; the grant dies at its TTL.
+    if (session !== null) {
+      postLogoutRedirectUri =
+        options?.postLogoutRedirectUri ??
+        this.options.authFlow?.redirectUri ??
+        window.location.origin;
+      try {
+        ({ endSessionUrl } = await this.options.transport.action(
+          this.options.api.signOut,
+          {
+            sessionToken: session.token,
+            postLogoutRedirectUri,
+          },
+        ));
+        serverSessionStatus = "revoked";
+      } catch (error) {
+        serverRevocationError = error;
+        // Best effort when local cleanup succeeded; a combined failure is
+        // converted into a loud SessionSignOutError below.
+      }
     }
+    let signOutError: SessionSignOutError | undefined;
     if (durableCleanupFailed) {
       // SecureStore failures can be transient (for example, a temporarily
       // unavailable keystore). Retry once after the independent server kill.
@@ -761,20 +789,22 @@ export class SessionAuthEngine {
       } catch (error) {
         const durableCleanupError = this.asError(error);
         this.reportError(durableCleanupError);
-        if (!serverRevoked) {
-          const signOutError = new SessionSignOutError({
-            durableCleanupError,
-            serverRevocationError,
-          });
-          this.reportError(signOutError);
-          throw signOutError;
-        }
+        signOutError = new SessionSignOutError(serverSessionStatus, {
+          durableCleanupError,
+          ...(serverRevocationError === undefined
+            ? {}
+            : { serverRevocationError }),
+        });
+        this.reportError(signOutError);
       }
     }
     // Federated by default: also end Logto's SSO session so the next sign-in
     // isn't silent. The post sign-out redirect URI must be registered on the app.
     if (options?.federated !== false && endSessionUrl !== undefined) {
-      if (this.options.authFlow !== undefined) {
+      if (
+        this.options.authFlow !== undefined &&
+        postLogoutRedirectUri !== undefined
+      ) {
         try {
           await this.options.authFlow.openEndSession(
             endSessionUrl,
@@ -787,6 +817,7 @@ export class SessionAuthEngine {
         window.location.assign(endSessionUrl);
       }
     }
+    if (signOutError !== undefined) throw signOutError;
   }
 
   // -- external events --

--- a/packages/convex-logto/tsup.config.ts
+++ b/packages/convex-logto/tsup.config.ts
@@ -7,6 +7,8 @@ const external = [
   /^react-dom(\/.*)?$/,
   /^@logto\/react(\/.*)?$/,
   /^@logto\/rn(\/.*)?$/,
+  /^expo-secure-store(\/.*)?$/,
+  /^expo-web-browser(\/.*)?$/,
   /^react-native(\/.*)?$/,
 ];
 
@@ -37,6 +39,13 @@ export default defineConfig([
   {
     ...shared,
     entry: { native: "src/native.tsx" },
+    format: ["esm"],
+  },
+  // Session mode on Expo uses ESM-only Expo modules and the same ESM-first
+  // React Native toolchain as the bridge-mode native entry.
+  {
+    ...shared,
+    entry: { "native-session": "src/native-session.tsx" },
     format: ["esm"],
   },
   // Session mode's React entry. No Logto SDK dependency; ESM-only like the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -336,6 +336,12 @@ importers:
       convex:
         specifier: ^1.38.0
         version: 1.41.0(react@19.2.7)
+      expo-secure-store:
+        specifier: ^56.0.4
+        version: 56.0.4(expo@56.0.12)
+      expo-web-browser:
+        specifier: ^56.0.5
+        version: 56.0.5(expo@56.0.12)(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))
       happy-dom:
         specifier: ^20.10.6
         version: 20.10.6
@@ -9872,7 +9878,7 @@ snapshots:
       react-refresh: 0.14.2
     optionalDependencies:
       '@babel/runtime': 7.29.7
-      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(typescript@5.8.3)
+      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.7(react@19.2.7))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -10451,7 +10457,7 @@ snapshots:
 
   expo-crypto@56.0.4(expo@56.0.12):
     dependencies:
-      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(typescript@5.8.3)
+      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.7(react@19.2.7))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(typescript@5.9.3)
 
   expo-file-system@56.0.8(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7)):
     dependencies:
@@ -10479,7 +10485,7 @@ snapshots:
 
   expo-keep-awake@56.0.3(expo@56.0.12)(react@19.2.7):
     dependencies:
-      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(typescript@5.8.3)
+      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.7(react@19.2.7))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(typescript@5.9.3)
       react: 19.2.7
 
   expo-modules-autolinking@56.0.16(typescript@5.8.3):
@@ -10528,7 +10534,7 @@ snapshots:
 
   expo-secure-store@56.0.4(expo@56.0.12):
     dependencies:
-      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.7(react@19.2.7))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(typescript@5.8.3)
+      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.7(react@19.2.7))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(typescript@5.9.3)
 
   expo-server@56.0.5: {}
 


### PR DESCRIPTION
Closes #30.

## Summary

- add the ESM-only `convex-logto/native-session` provider, backed by the existing `SessionAuthEngine`
- persist the rotating session token, OAuth state, and short-lived ID token in deployment-namespaced Expo SecureStore
- complete sign-in and federated sign-out through `expo-web-browser` deep links with no callback route
- preserve reactive `sessionValid` revocation and expose no native device-binding option
- document setup, security/storage semantics, and differences from web session mode

## Design decisions

- The shared engine gained optional storage `prepare`/`flush` hooks and a native auth-flow seam; absent adapters retain the current web `window`, storage-event, and Web Locks behavior.
- The ID token is also stored in SecureStore so a fresh cold start authenticates without spending the one-time session token, while keeping the short-lived bearer inside the OS encrypted keystore.
- SecureStore writes are queued behind a synchronous hydrated cache, and every credential rotation/state transition flushes before the engine proceeds; unavailable or failing SecureStore reports loudly through `onAuthError` with no plaintext fallback.
- Browser cancellation spends the stashed state, and returned states remain single-use so foreign and replayed deep links never reach the callback action.

## Validation

- `pnpm --filter convex-logto test` (182 tests)
- `pnpm --filter convex-logto check-types`
- `pnpm --filter convex-logto lint`
- `pnpm --filter convex-logto format`
- `pnpm --filter convex-logto build`
- `pnpm --filter convex-logto lint:package`
- `pnpm --filter docs build`

Changeset: `.changeset/fiery-canyons-fall.md` (minor).

Follow-ups: #43 tracks the out-of-scope Expo session example; #44 tracks pre-existing docs build warnings found during validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native Expo/React Native session authentication.
  * Added SecureStore persistence, system-browser OAuth, and deep-link callbacks.
  * Added session provider and authentication hook for sign-in, sign-out, refresh, authentication state, and user claims.
  * Added optional server-side session revocation monitoring.
  * Added a dedicated native-session package export with optional Expo integrations.
* **Documentation**
  * Added setup guides, API reference details, configuration instructions, and guidance comparing native session and bridge modes.
* **Tests**
  * Added comprehensive coverage for authentication flows, persistence, refresh, revocation, sign-out, cancellation, and storage errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->