### PR TITLE
feat: add OIDC back-channel logout

### DIFF
--- a/.changeset/clever-drinks-scream.md
+++ b/.changeset/clever-drinks-scream.md
@@ -1,0 +1,5 @@
+---
+"convex-logto": minor
+---
+
+Add verified OIDC back-channel logout for session mode.

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -12,6 +12,9 @@ description: Every export from convex-logto and its web, native, and session-mod
 | `logtoSync<DataModel>(handlers)` | `convex-logto` | Returns `{ sync }`, an internal mutation mapping user events to your tables. |
 | `registerLogtoWebhook(http, sync, opts?)` | `convex-logto` | Registers the verified webhook route. Reads `LOGTO_WEBHOOK_SIGNING_KEY`. |
 | `verifyLogtoSignature(key, body, sig)` | `convex-logto` | Low-level signature check, for custom routing. |
+| `registerLogtoBackchannelLogout(http, opts)` | `convex-logto` | Registers the verified OIDC back-channel logout route for session mode. |
+| `createLogtoBackchannelLogoutHandler(opts)` | `convex-logto` | Builds the same Convex HTTP action without registering a path. |
+| `verifyLogtoLogoutToken(token, opts?)` | `convex-logto` | Low-level Web Crypto/JWKS validation for an OIDC Logout Token. |
 | `logtoSessionApi(component, opts?)` | `convex-logto` | [Session mode](/docs/session-mode): builds the five public auth functions backed by the session component. |
 | `assertUserHasActiveSession(ctx, component)` | `convex-logto` | Session mode: throw unless the caller still has a live (unrevoked) session. |
 | `createLogtoSessionCookieHandler(opts)` | `convex-logto` | Four-route standard-fetch handler for the optional same-site HttpOnly cookie transport. |
@@ -74,6 +77,37 @@ registerLogtoWebhook(http, internal.logto.sync, { sessions: components.logto });
 
 Low-level signature check (HMAC-SHA256 via Web Crypto), for when you route the
 webhook yourself instead of using `registerLogtoWebhook`.
+
+### `registerLogtoBackchannelLogout(http, opts)`
+
+Registers `POST /logto/backchannel-logout` for [OIDC back-channel
+logout](/docs/backchannel-logout). Pass `sessions: components.logto`; the route
+reads `LOGTO_ENDPOINT` / `LOGTO_APP_ID` unless `endpoint` / `appId` overrides are
+provided. A custom `path` changes the registered URI.
+
+The handler verifies `RS256` / `PS256` Logout Tokens against Logto's cached
+JWKS, enforces issuer, audience, time, event, subject/session, `jti`, and
+no-`nonce` rules, then revokes by `sid` or falls back to all sessions for `sub`.
+Verified `jti` values are deduplicated for 24 hours. Success (including no
+matching session or a replay) is `200`; invalid requests are `400`, and bodies
+over 1 MB are `413`. Every response is `Cache-Control: no-store`.
+
+```ts title="convex/http.ts"
+registerLogtoBackchannelLogout(http, { sessions: components.logto });
+```
+
+### `createLogtoBackchannelLogoutHandler(opts)`
+
+Returns the same Convex HTTP action for custom router composition. It still
+enforces POST and form encoding. Options are `sessions`, optional `endpoint` /
+`appId`, and no `path` (the caller owns routing).
+
+### `verifyLogtoLogoutToken(token, opts?)`
+
+Low-level verifier used by the registered handler. Returns
+`{ issuer, subject?, sid?, jti }` after Web Crypto signature and OIDC claim
+validation; rejects invalid, encrypted, unsigned, or symmetrically signed
+tokens. It does not mutate or deduplicate sessions.
 
 ### `logtoSessionApi(component, opts?)`
 

--- a/docs/content/docs/backchannel-logout.mdx
+++ b/docs/content/docs/backchannel-logout.mdx
@@ -1,0 +1,91 @@
+---
+title: Back-channel logout
+description: Revoke session-mode sessions when Logto ends an IdP session, using a verified OIDC Logout Token.
+---
+
+OIDC back-channel logout lets Logto notify your Convex deployment when its
+identity-provider session ends. In [session mode](/docs/session-mode), the
+component deletes the matching session row and the existing `sessionValid`
+subscription pushes signed-out state to every live client. There is no client
+configuration or new frontend code.
+
+This is separate from [webhook sync](/docs/webhook-sync): webhooks handle
+account-level deletion and suspension, while back-channel logout handles an
+individual Logto sign-in session.
+
+## Register the Convex endpoint
+
+Install the session component as described in the [session-mode setup](/docs/session-mode),
+then add the route to the same `convex/http.ts` router as your other HTTP actions:
+
+```ts title="convex/http.ts"
+import { httpRouter } from "convex/server";
+import { registerLogtoBackchannelLogout } from "convex-logto";
+import { components } from "./_generated/api";
+
+const http = httpRouter();
+
+registerLogtoBackchannelLogout(http, {
+  sessions: components.logto,
+}); // POST /logto/backchannel-logout
+
+export default http;
+```
+
+The route reads `LOGTO_ENDPOINT` and `LOGTO_APP_ID`, the same deployment values
+as `logtoSessionApi`. You can override either in the options, or change the route
+with `path`.
+
+## Configure Logto
+
+In Logto Console, open **Applications**, select the **Traditional web** app used
+by session mode, and find its **Backchannel logout** section. Set **Backchannel
+logout URI** to:
+
+```text
+https://<your-deployment>.convex.site/logto/backchannel-logout
+```
+
+Use the deployment's `.convex.site` **HTTP Actions** URL, not its
+`.convex.cloud` client URL. Production, staging, and development deployments
+each need their own Logto app and URI.
+
+Enable **Is session required?** for precise session-level logout. Logto then
+includes the ID token's `sid`, and the component deletes only sessions created
+from that Logto session. If Logto sends a token with `sub` but no `sid`, the
+OIDC-defined fallback deletes every component session for that subject.
+
+Existing component sessions created before this feature gain their `sid` on
+their next ID-token refresh (or immediately after signing in again). A valid
+logout for an already-absent or not-yet-mapped `sid` still returns `200`, as the
+OIDC specification requires.
+
+## Validation and replay handling
+
+The endpoint accepts only a form-encoded POST containing exactly one
+`logout_token`. Before changing state it:
+
+- verifies an `RS256` or `PS256` signature with
+  `<LOGTO_ENDPOINT>/oidc/jwks` (cached for five minutes, with bounded refresh on
+  a new key id);
+- requires the configured issuer and app audience, fresh `iat`, unexpired
+  `exp`, and a non-empty `jti`;
+- requires the OIDC back-channel logout event and either `sid` or `sub`;
+- rejects `none`, symmetric signing algorithms, malformed JWTs, and any
+  `nonce` claim;
+- caps the request body at 1 MB.
+
+Verified `jti` values are claimed for 24 hours using the component's existing
+delivery-deduplication table. A retry is answered with the same `200` without
+re-running revocation; if the revocation mutation fails, the claim is released
+so Logto can retry the work.
+
+Responses include `Cache-Control: no-store`. Success is always `200`, including
+when no session matched, so the endpoint never reveals session existence.
+Invalid or failed logout requests return `400` with an OAuth-style JSON error;
+oversized bodies return `413`.
+
+For a custom router, `createLogtoBackchannelLogoutHandler(options)` returns the
+same Convex HTTP action without registering a path. The lower-level
+`verifyLogtoLogoutToken(token, options?)` verifier is also exported for advanced
+integrations.

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -14,6 +14,7 @@
     "session-mode",
     "auth-in-your-app",
     "webhook-sync",
+    "backchannel-logout",
     "multiple-environments",
     "---Reference---",
     "api-reference",

--- a/docs/content/docs/session-mode.mdx
+++ b/docs/content/docs/session-mode.mdx
@@ -385,6 +385,13 @@ user in Logto Console kills their sessions within seconds — register the
 registerLogtoWebhook(http, internal.logto.sync, { sessions: components.logto });
 ```
 
+To propagate an individual Logto session ending (including sign-out from
+another app), register the verified [OIDC back-channel logout
+endpoint](/docs/backchannel-logout). It stores the ID token's optional `sid` and
+deletes only the matching component session; a token carrying only `sub` uses
+the specification's sign-out-everywhere fallback. The same existing liveness
+subscription pushes the revocation, so no client changes are required.
+
 One consequence to plan for: a reactive query gated this way starts **throwing**
 the instant the session is revoked — a beat before the client flips to
 signed-out. Wrap such data in an error boundary (ordinary Convex practice for

--- a/packages/convex-logto/README.md
+++ b/packages/convex-logto/README.md
@@ -230,6 +230,10 @@ rotating session token and short-lived ID token in the OS keystore, and retains
 reactive revocation. Native intentionally has no cookie-transport or software
 `deviceBinding` option.
 
+Register `registerLogtoBackchannelLogout(http, { sessions: components.logto })`
+to verify Logto OIDC Logout Tokens and propagate IdP-side sign-out through the
+same reactive revocation path (one `sid` session, or every session for `sub`).
+
 [session-mode-docs]: https://github.com/Fanzzzd/convex-logto/blob/main/docs/content/docs/session-mode.mdx
 [session-example]: https://github.com/Fanzzzd/convex-logto/tree/main/examples/vite-react-session
 
@@ -282,6 +286,9 @@ Convex validates an OIDC **ID token**. Logto's access tokens are typed `at+jwt`,
 | `logtoConfigQuery()` | `convex-logto` | Public query serving `{ endpoint, appId }` to the frontend. |
 | `logtoSync<DataModel>(handlers)` | `convex-logto` | Returns `{ sync }`, an internal mutation mapping user events to your tables. |
 | `registerLogtoWebhook(http, sync, opts?)` | `convex-logto` | Registers the verified webhook route. Reads `LOGTO_WEBHOOK_SIGNING_KEY`; `sessions` option adds dedupe + session revocation. |
+| `registerLogtoBackchannelLogout(http, opts)` | `convex-logto` | Session mode: registers a verified OIDC back-channel logout route with `sid` / `sub` revocation. |
+| `createLogtoBackchannelLogoutHandler(opts)` | `convex-logto` | Builds the back-channel Convex HTTP action for custom route composition. |
+| `verifyLogtoLogoutToken(token, opts?)` | `convex-logto` | Low-level RS256/PS256 Logout Token verification against Logto's JWKS. |
 | `verifyLogtoSignature(key, body, sig)` | `convex-logto` | Low-level signature check, for custom routing. |
 | `logtoSessionApi(component, opts?)` | `convex-logto` | [Session mode](#session-mode): builds the five public auth functions backed by the session component. |
 | `assertUserHasActiveSession(ctx, component)` | `convex-logto` | Session mode: throw unless the caller still has a live (unrevoked) session. |

--- a/packages/convex-logto/src/backchannel-logout.test.ts
+++ b/packages/convex-logto/src/backchannel-logout.test.ts
@@ -1,0 +1,412 @@
+import { httpRouter } from "convex/server";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { registerLogtoBackchannelLogout } from "./backchannel-logout";
+import type { LogtoSessionComponent } from "./session";
+
+type SupportedAlgorithm = "RS256" | "PS256";
+type SigningFixture = {
+  privateKey: CryptoKey;
+  publicJwk: JsonWebKey & { kid: string };
+};
+
+const encoder = new TextEncoder();
+const appId = "app-1";
+let rs256: SigningFixture;
+let ps256: SigningFixture;
+let harnessNumber = 0;
+
+function base64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function encodedJson(value: unknown): string {
+  return base64Url(encoder.encode(JSON.stringify(value)));
+}
+
+async function signingFixture(
+  algorithm: SupportedAlgorithm,
+  kid: string,
+): Promise<SigningFixture> {
+  const webCryptoAlgorithm =
+    algorithm === "RS256"
+      ? {
+          name: "RSASSA-PKCS1-v1_5",
+          modulusLength: 2048,
+          publicExponent: new Uint8Array([1, 0, 1]),
+          hash: "SHA-256",
+        }
+      : {
+          name: "RSA-PSS",
+          modulusLength: 2048,
+          publicExponent: new Uint8Array([1, 0, 1]),
+          hash: "SHA-256",
+        };
+  const pair = (await crypto.subtle.generateKey(webCryptoAlgorithm, true, [
+    "sign",
+    "verify",
+  ])) as CryptoKeyPair;
+  const publicJwk = (await crypto.subtle.exportKey(
+    "jwk",
+    pair.publicKey,
+  )) as JsonWebKey & { kid: string };
+  publicJwk.kid = kid;
+  publicJwk.alg = algorithm;
+  publicJwk.use = "sig";
+  return { privateKey: pair.privateKey, publicJwk };
+}
+
+beforeAll(async () => {
+  [rs256, ps256] = await Promise.all([
+    signingFixture("RS256", "rsa-signing-key"),
+    signingFixture("PS256", "pss-signing-key"),
+  ]);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function validPayload(endpoint: string): Record<string, unknown> {
+  const now = Math.floor(Date.now() / 1000);
+  return {
+    iss: `${endpoint}/oidc`,
+    sub: "user-1",
+    aud: appId,
+    iat: now,
+    exp: now + 120,
+    jti: `logout-${harnessNumber}`,
+    sid: "logto-session-1",
+    events: {
+      "http://schemas.openid.net/event/backchannel-logout": {},
+    },
+  };
+}
+
+async function logoutToken(options: {
+  endpoint: string;
+  payload?: Record<string, unknown>;
+  algorithm?: SupportedAlgorithm;
+  headerAlgorithm?: string;
+  signingAlgorithm?: SupportedAlgorithm;
+}): Promise<string> {
+  const algorithm = options.algorithm ?? "RS256";
+  const signingAlgorithm = options.signingAlgorithm ?? algorithm;
+  const fixture = signingAlgorithm === "RS256" ? rs256 : ps256;
+  const header = encodedJson({
+    alg: options.headerAlgorithm ?? algorithm,
+    kid: algorithm === "RS256" ? rs256.publicJwk.kid : ps256.publicJwk.kid,
+    typ: "logout+jwt",
+  });
+  const payload = encodedJson(
+    options.payload ?? validPayload(options.endpoint),
+  );
+  const signature = await crypto.subtle.sign(
+    signingAlgorithm === "RS256"
+      ? { name: "RSASSA-PKCS1-v1_5" }
+      : { name: "RSA-PSS", saltLength: 32 },
+    fixture.privateKey,
+    encoder.encode(`${header}.${payload}`),
+  );
+  return `${header}.${payload}.${base64Url(new Uint8Array(signature))}`;
+}
+
+const refs = {
+  record: { fn: "record" },
+  forget: { fn: "forget" },
+  killSid: { fn: "killSid" },
+  killSubject: { fn: "killSubject" },
+};
+
+const sessions = {
+  lib: {
+    recordWebhookDelivery: refs.record,
+    forgetWebhookDelivery: refs.forget,
+    killSessionsBySid: refs.killSid,
+    killSubjectSessions: refs.killSubject,
+  },
+} as unknown as LogtoSessionComponent;
+
+type RouteHandler = (
+  ctx: { runMutation: (ref: unknown, args: unknown) => Promise<unknown> },
+  request: Request,
+) => Promise<Response>;
+
+function harness(options?: {
+  record?: boolean;
+  killSidError?: Error;
+  customPath?: string;
+}) {
+  harnessNumber += 1;
+  const endpoint = `https://auth-${harnessNumber}.example.com`;
+  const fetchMock = vi
+    .fn<typeof globalThis.fetch>()
+    .mockResolvedValue(
+      new Response(
+        JSON.stringify({ keys: [rs256.publicJwk, ps256.publicJwk] }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+  vi.stubGlobal("fetch", fetchMock);
+  const handlers: Record<string, ReturnType<typeof vi.fn>> = {
+    record: vi.fn().mockResolvedValue(options?.record ?? true),
+    forget: vi.fn().mockResolvedValue(null),
+    killSid: options?.killSidError
+      ? vi.fn().mockRejectedValue(options.killSidError)
+      : vi.fn().mockResolvedValue(1),
+    killSubject: vi.fn().mockResolvedValue(2),
+  };
+  const calls: Array<{ fn: string; args: unknown }> = [];
+  const runMutation = vi.fn((ref: unknown, args: unknown) => {
+    const fn = (ref as { fn: string }).fn;
+    calls.push({ fn, args });
+    return handlers[fn]!(args);
+  });
+  const http = httpRouter();
+  registerLogtoBackchannelLogout(http, {
+    sessions,
+    endpoint,
+    appId,
+    path: options?.customPath,
+  });
+  const path = options?.customPath ?? "/logto/backchannel-logout";
+  const match = http.lookup(path, "POST");
+  if (!match) throw new Error(`No POST route at ${path}`);
+  const handler = (match[0] as unknown as Record<string, RouteHandler>)[
+    "_handler"
+  ];
+  if (!handler) throw new Error("Back-channel route handler was not captured");
+  return { endpoint, fetchMock, handlers, calls, runMutation, handler };
+}
+
+function post(
+  body: BodyInit,
+  contentType = "application/x-www-form-urlencoded",
+) {
+  return new Request("https://convex.example/logto/backchannel-logout", {
+    method: "POST",
+    headers: { "Content-Type": contentType },
+    body,
+  });
+}
+
+function logoutRequest(token: string): Request {
+  return post(new URLSearchParams({ logout_token: token }));
+}
+
+async function expectInvalid(
+  tokenFactory: (endpoint: string) => string | Promise<string>,
+): Promise<void> {
+  const { endpoint, handler, runMutation } = harness();
+  const response = await handler(
+    { runMutation },
+    logoutRequest(await tokenFactory(endpoint)),
+  );
+  expect(response.status).toBe(400);
+  expect(response.headers.get("Cache-Control")).toBe("no-store");
+  await expect(response.json()).resolves.toMatchObject({
+    error: "invalid_request",
+  });
+  expect(runMutation).not.toHaveBeenCalled();
+}
+
+describe("Logto back-channel logout", () => {
+  it("kills only sessions with the valid token's sid", async () => {
+    const { endpoint, handler, handlers, calls, runMutation } = harness({
+      customPath: "/oidc/logout",
+    });
+    const token = await logoutToken({ endpoint });
+
+    const response = await handler({ runMutation }, logoutRequest(token));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(handlers.killSid).toHaveBeenCalledWith({
+      sid: "logto-session-1",
+    });
+    expect(handlers.killSubject).not.toHaveBeenCalled();
+    expect(calls.map((call) => call.fn)).toEqual(["record", "killSid"]);
+  });
+
+  it("kills every subject session when sid is absent", async () => {
+    const { endpoint, handler, handlers, runMutation } = harness();
+    const payload = validPayload(endpoint);
+    delete payload.sid;
+    const token = await logoutToken({ endpoint, payload });
+
+    const response = await handler({ runMutation }, logoutRequest(token));
+
+    expect(response.status).toBe(200);
+    expect(handlers.killSubject).toHaveBeenCalledWith({ subject: "user-1" });
+    expect(handlers.killSid).not.toHaveBeenCalled();
+  });
+
+  it("accepts PS256 logout tokens", async () => {
+    const { endpoint, handler, handlers, runMutation } = harness();
+    const token = await logoutToken({ endpoint, algorithm: "PS256" });
+
+    const response = await handler({ runMutation }, logoutRequest(token));
+
+    expect(response.status).toBe(200);
+    expect(handlers.killSid).toHaveBeenCalledTimes(1);
+  });
+
+  it("answers 200 and performs no revocation for a replayed jti", async () => {
+    const { endpoint, handler, handlers, calls, runMutation } = harness({
+      record: false,
+    });
+    const token = await logoutToken({ endpoint });
+
+    const response = await handler({ runMutation }, logoutRequest(token));
+
+    expect(response.status).toBe(200);
+    expect(handlers.killSid).not.toHaveBeenCalled();
+    expect(handlers.killSubject).not.toHaveBeenCalled();
+    expect(calls.map((call) => call.fn)).toEqual(["record"]);
+  });
+
+  it.each([
+    [
+      "wrong issuer",
+      async (endpoint: string) =>
+        logoutToken({
+          endpoint,
+          payload: { ...validPayload(endpoint), iss: "https://other/oidc" },
+        }),
+    ],
+    [
+      "wrong audience",
+      async (endpoint: string) =>
+        logoutToken({
+          endpoint,
+          payload: { ...validPayload(endpoint), aud: "other-app" },
+        }),
+    ],
+    [
+      "HS256 algorithm",
+      (endpoint: string) => logoutToken({ endpoint, headerAlgorithm: "HS256" }),
+    ],
+    [
+      "missing events",
+      async (endpoint: string) => {
+        const payload = validPayload(endpoint);
+        delete payload.events;
+        return logoutToken({ endpoint, payload });
+      },
+    ],
+    [
+      "present nonce",
+      async (endpoint: string) =>
+        logoutToken({
+          endpoint,
+          payload: { ...validPayload(endpoint), nonce: "forbidden" },
+        }),
+    ],
+    [
+      "stale iat",
+      async (endpoint: string) =>
+        logoutToken({
+          endpoint,
+          payload: {
+            ...validPayload(endpoint),
+            iat: Math.floor(Date.now() / 1000) - 301,
+          },
+        }),
+    ],
+    [
+      "expired token",
+      async (endpoint: string) =>
+        logoutToken({
+          endpoint,
+          payload: {
+            ...validPayload(endpoint),
+            exp: Math.floor(Date.now() / 1000) - 61,
+          },
+        }),
+    ],
+    [
+      "missing sub and sid",
+      async (endpoint: string) => {
+        const payload = validPayload(endpoint);
+        delete payload.sub;
+        delete payload.sid;
+        return logoutToken({ endpoint, payload });
+      },
+    ],
+    [
+      "missing jti",
+      async (endpoint: string) => {
+        const payload = validPayload(endpoint);
+        delete payload.jti;
+        return logoutToken({ endpoint, payload });
+      },
+    ],
+    ["garbage JWT", async () => "not-a-jwt"],
+  ])("rejects %s", async (_name, tokenFactory) => {
+    await expectInvalid(tokenFactory);
+  });
+
+  it("rejects an RSA-PSS signature presented as RS256", async () => {
+    await expectInvalid((endpoint) =>
+      logoutToken({
+        endpoint,
+        algorithm: "RS256",
+        signingAlgorithm: "PS256",
+      }),
+    );
+  });
+
+  it("rejects a non-form request", async () => {
+    const { handler, runMutation } = harness();
+    const response = await handler(
+      { runMutation },
+      post("{}", "application/json"),
+    );
+    expect(response.status).toBe(400);
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-POST request when the handler factory is mounted directly", async () => {
+    const { handler, runMutation } = harness();
+    const response = await handler(
+      { runMutation },
+      new Request("https://convex.example/logto/backchannel-logout"),
+    );
+    expect(response.status).toBe(400);
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it("rejects a body larger than 1 MB before verification", async () => {
+    const { handler, fetchMock, runMutation } = harness();
+    const response = await handler(
+      { runMutation },
+      post(new URLSearchParams({ logout_token: "x".repeat(1024 * 1024) })),
+    );
+    expect(response.status).toBe(413);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
+  it("releases the jti claim when session revocation fails", async () => {
+    const { endpoint, handler, handlers, calls, runMutation } = harness({
+      killSidError: new Error("mutation failed"),
+    });
+    const token = await logoutToken({ endpoint });
+
+    const response = await handler({ runMutation }, logoutRequest(token));
+
+    expect(response.status).toBe(400);
+    expect(handlers.forget).toHaveBeenCalledWith({
+      bodyHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+    });
+    expect(calls.map((call) => call.fn)).toEqual([
+      "record",
+      "killSid",
+      "forget",
+    ]);
+  });
+});

--- a/packages/convex-logto/src/backchannel-logout.ts
+++ b/packages/convex-logto/src/backchannel-logout.ts
@@ -1,0 +1,444 @@
+import {
+  type HttpRouter,
+  type PublicHttpAction,
+  httpActionGeneric,
+} from "convex/server";
+import { readEndpointAndAppId, type LogtoAuthConfigOptions } from "./config";
+import type { LogtoSessionComponent } from "./session";
+
+const encoder = /* @__PURE__ */ new TextEncoder();
+const decoder = /* @__PURE__ */ new TextDecoder("utf-8", { fatal: true });
+
+const BACKCHANNEL_LOGOUT_EVENT =
+  "http://schemas.openid.net/event/backchannel-logout";
+const MAX_BODY_BYTES = 1024 * 1024;
+const MAX_TOKEN_AGE_MS = 5 * 60 * 1000;
+const MAX_FUTURE_SKEW_MS = 60 * 1000;
+const JWKS_CACHE_MS = 5 * 60 * 1000;
+const JWKS_MISS_REFRESH_INTERVAL_MS = 60 * 1000;
+
+type SupportedAlgorithm = "RS256" | "PS256";
+type LogtoJwk = JsonWebKey & { kid?: string };
+
+export type LogtoLogoutTokenClaims = {
+  issuer: string;
+  subject?: string;
+  sid?: string;
+  jti: string;
+};
+
+export type VerifyLogtoLogoutTokenOptions = LogtoAuthConfigOptions;
+
+export type LogtoBackchannelLogoutHandlerOptions = LogtoAuthConfigOptions & {
+  /** The installed session component (`components.logto`). */
+  sessions: LogtoSessionComponent;
+};
+
+export type RegisterLogtoBackchannelLogoutOptions =
+  LogtoBackchannelLogoutHandlerOptions & {
+    /** HTTP route path. Default `/logto/backchannel-logout`. */
+    path?: string;
+  };
+
+class LogoutTokenValidationError extends Error {}
+
+type JwksCacheEntry = {
+  expiresAt: number;
+  fetchedAt: number;
+  promise: Promise<LogtoJwk[]>;
+};
+
+const jwksCache = new Map<string, JwksCacheEntry>();
+
+function invalid(message: string): never {
+  throw new LogoutTokenValidationError(message);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function decodeBase64Url(value: string): Uint8Array<ArrayBuffer> {
+  if (!value || !/^[A-Za-z0-9_-]+$/.test(value) || value.length % 4 === 1) {
+    return invalid("Malformed JWT encoding.");
+  }
+  try {
+    const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
+    const binary = atob(base64.padEnd(Math.ceil(base64.length / 4) * 4, "="));
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index++) {
+      bytes[index] = binary.charCodeAt(index);
+    }
+    return bytes;
+  } catch {
+    return invalid("Malformed JWT encoding.");
+  }
+}
+
+function decodeJsonSegment(value: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(
+      decoder.decode(decodeBase64Url(value)),
+    ) as unknown;
+    if (!isRecord(parsed)) return invalid("Malformed JWT JSON.");
+    return parsed;
+  } catch (error) {
+    if (error instanceof LogoutTokenValidationError) throw error;
+    return invalid("Malformed JWT JSON.");
+  }
+}
+
+function supportedAlgorithm(value: unknown): SupportedAlgorithm {
+  if (value !== "RS256" && value !== "PS256") {
+    return invalid("Unsupported logout token signing algorithm.");
+  }
+  return value;
+}
+
+async function fetchJwks(url: string): Promise<LogtoJwk[]> {
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      headers: { Accept: "application/json" },
+    });
+  } catch {
+    return invalid("Could not fetch the Logto JWKS.");
+  }
+  if (!response.ok) return invalid("Could not fetch the Logto JWKS.");
+  const body = (await response.json().catch(() => null)) as unknown;
+  if (!isRecord(body) || !Array.isArray(body.keys)) {
+    return invalid("Logto returned a malformed JWKS.");
+  }
+  return body.keys.filter(isRecord) as LogtoJwk[];
+}
+
+async function loadJwks(
+  url: string,
+  now: number,
+  force = false,
+): Promise<{ keys: LogtoJwk[]; fromCache: boolean; fetchedAt: number }> {
+  const cached = jwksCache.get(url);
+  if (!force && cached && cached.expiresAt > now) {
+    return {
+      keys: await cached.promise,
+      fromCache: true,
+      fetchedAt: cached.fetchedAt,
+    };
+  }
+  const promise = fetchJwks(url);
+  const entry = {
+    expiresAt: now + JWKS_CACHE_MS,
+    fetchedAt: now,
+    promise,
+  };
+  jwksCache.set(url, entry);
+  try {
+    return { keys: await promise, fromCache: false, fetchedAt: now };
+  } catch (error) {
+    if (jwksCache.get(url) === entry) jwksCache.delete(url);
+    throw error;
+  }
+}
+
+function matchingKeys(
+  keys: LogtoJwk[],
+  algorithm: SupportedAlgorithm,
+  kid: string | undefined,
+): LogtoJwk[] {
+  return keys.filter(
+    (key) =>
+      key.kty === "RSA" &&
+      typeof key.n === "string" &&
+      typeof key.e === "string" &&
+      (kid === undefined || key.kid === kid) &&
+      (key.alg === undefined || key.alg === algorithm) &&
+      (key.use === undefined || key.use === "sig") &&
+      (key.key_ops === undefined || key.key_ops.includes("verify")),
+  );
+}
+
+async function verifySignature(options: {
+  compactHeader: string;
+  compactPayload: string;
+  signature: Uint8Array<ArrayBuffer>;
+  algorithm: SupportedAlgorithm;
+  kid?: string;
+  jwksUrl: string;
+  now: number;
+}): Promise<boolean> {
+  let loaded = await loadJwks(options.jwksUrl, options.now);
+  let candidates = matchingKeys(loaded.keys, options.algorithm, options.kid);
+  // A new `kid` is the safe key-rotation signal. Bound forced refreshes so an
+  // attacker cannot turn arbitrary kid values into an unbounded JWKS fetcher.
+  if (
+    candidates.length === 0 &&
+    loaded.fromCache &&
+    options.now - loaded.fetchedAt >= JWKS_MISS_REFRESH_INTERVAL_MS
+  ) {
+    loaded = await loadJwks(options.jwksUrl, options.now, true);
+    candidates = matchingKeys(loaded.keys, options.algorithm, options.kid);
+  }
+  const signed = encoder.encode(
+    `${options.compactHeader}.${options.compactPayload}`,
+  );
+  for (const jwk of candidates) {
+    try {
+      const webCryptoAlgorithm =
+        options.algorithm === "RS256"
+          ? { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" }
+          : { name: "RSA-PSS", hash: "SHA-256" };
+      const key = await crypto.subtle.importKey(
+        "jwk",
+        jwk,
+        webCryptoAlgorithm,
+        false,
+        ["verify"],
+      );
+      const verified = await crypto.subtle.verify(
+        options.algorithm === "RS256"
+          ? { name: "RSASSA-PKCS1-v1_5" }
+          : { name: "RSA-PSS", saltLength: 32 },
+        key,
+        options.signature,
+        signed,
+      );
+      if (verified) return true;
+    } catch {
+      // A malformed/incompatible JWK is not a reason to skip the other keys.
+    }
+  }
+  return false;
+}
+
+function audienceMatches(value: unknown, appId: string): boolean {
+  return (
+    value === appId ||
+    (Array.isArray(value) &&
+      value.length > 0 &&
+      value.every((audience) => typeof audience === "string") &&
+      value.includes(appId))
+  );
+}
+
+/**
+ * Verify a compact, signed OIDC Logout Token against Logto's RSA JWKS and the
+ * Back-Channel Logout validation rules. Encrypted logout tokens are not
+ * supported; compact JWE input is rejected as malformed.
+ */
+export async function verifyLogtoLogoutToken(
+  logoutToken: string,
+  options: VerifyLogtoLogoutTokenOptions = {},
+): Promise<LogtoLogoutTokenClaims> {
+  const { endpoint, appId } = readEndpointAndAppId(options);
+  const parts = logoutToken.split(".");
+  if (parts.length !== 3) return invalid("Malformed logout token.");
+  const [compactHeader, compactPayload, compactSignature] = parts as [
+    string,
+    string,
+    string,
+  ];
+  const header = decodeJsonSegment(compactHeader);
+  const payload = decodeJsonSegment(compactPayload);
+  const algorithm = supportedAlgorithm(header.alg);
+  const kid = header.kid;
+  if (kid !== undefined && (typeof kid !== "string" || kid.length === 0)) {
+    return invalid("Invalid logout token kid.");
+  }
+  const signature = decodeBase64Url(compactSignature);
+  if (
+    !(await verifySignature({
+      compactHeader,
+      compactPayload,
+      signature,
+      algorithm,
+      ...(typeof kid === "string" ? { kid } : {}),
+      jwksUrl: `${endpoint}/oidc/jwks`,
+      now: Date.now(),
+    }))
+  ) {
+    return invalid("Invalid logout token signature.");
+  }
+
+  const issuer = `${endpoint}/oidc`;
+  if (payload.iss !== issuer || !audienceMatches(payload.aud, appId)) {
+    return invalid("Logout token issuer or audience mismatch.");
+  }
+  const now = Date.now();
+  const iat = payload.iat;
+  const exp = payload.exp;
+  if (
+    typeof iat !== "number" ||
+    !Number.isFinite(iat) ||
+    typeof exp !== "number" ||
+    !Number.isFinite(exp)
+  ) {
+    return invalid("Logout token is missing iat or exp.");
+  }
+  const issuedAt = iat * 1000;
+  const expiresAt = exp * 1000;
+  if (
+    now - issuedAt > MAX_TOKEN_AGE_MS ||
+    issuedAt - now > MAX_FUTURE_SKEW_MS ||
+    expiresAt < now - MAX_FUTURE_SKEW_MS ||
+    expiresAt < issuedAt
+  ) {
+    return invalid("Logout token is stale or expired.");
+  }
+  const events = payload.events;
+  const event = isRecord(events) ? events[BACKCHANNEL_LOGOUT_EVENT] : undefined;
+  if (!isRecord(event)) return invalid("Logout token event is missing.");
+  if (Object.prototype.hasOwnProperty.call(payload, "nonce")) {
+    return invalid("Logout tokens must not contain nonce.");
+  }
+  const subject = payload.sub;
+  const sid = payload.sid;
+  if (
+    (subject !== undefined &&
+      (typeof subject !== "string" || subject.length === 0)) ||
+    (sid !== undefined && (typeof sid !== "string" || sid.length === 0)) ||
+    (subject === undefined && sid === undefined)
+  ) {
+    return invalid("Logout token must identify a subject or session.");
+  }
+  const jti = payload.jti;
+  if (typeof jti !== "string" || jti.length === 0) {
+    return invalid("Logout token is missing jti.");
+  }
+  return {
+    issuer,
+    ...(typeof subject === "string" ? { subject } : {}),
+    ...(typeof sid === "string" ? { sid } : {}),
+    jti,
+  };
+}
+
+const noStoreHeaders = {
+  "Cache-Control": "no-store",
+  "Content-Type": "application/json",
+} as const;
+
+function successResponse(): Response {
+  return new Response(null, {
+    status: 200,
+    headers: { "Cache-Control": "no-store" },
+  });
+}
+
+function errorResponse(description: string, status = 400): Response {
+  return new Response(
+    JSON.stringify({
+      error: "invalid_request",
+      error_description: description,
+    }),
+    { status, headers: noStoreHeaders },
+  );
+}
+
+async function deliveryKey(claims: LogtoLogoutTokenClaims): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    encoder.encode(`backchannel-logout\0${claims.issuer}\0${claims.jti}`),
+  );
+  let hex = "";
+  for (const byte of new Uint8Array(digest)) {
+    hex += byte.toString(16).padStart(2, "0");
+  }
+  return hex;
+}
+
+/** Build the Convex HTTP action for a Logto OIDC back-channel logout URI. */
+export function createLogtoBackchannelLogoutHandler(
+  options: LogtoBackchannelLogoutHandlerOptions,
+): PublicHttpAction {
+  return httpActionGeneric(async (ctx, request) => {
+    if (request.method !== "POST") {
+      return errorResponse("Back-channel logout requires POST.");
+    }
+    const contentLength = Number(request.headers.get("Content-Length"));
+    if (Number.isFinite(contentLength) && contentLength > MAX_BODY_BYTES) {
+      return errorResponse("Payload too large.", 413);
+    }
+    const contentType = request.headers
+      .get("Content-Type")
+      ?.split(";", 1)[0]
+      ?.trim()
+      .toLowerCase();
+    if (contentType !== "application/x-www-form-urlencoded") {
+      return errorResponse(
+        "Expected an application/x-www-form-urlencoded logout request.",
+      );
+    }
+    let rawBody: ArrayBuffer;
+    try {
+      rawBody = await request.arrayBuffer();
+    } catch {
+      return errorResponse("Could not read the logout request.");
+    }
+    if (rawBody.byteLength > MAX_BODY_BYTES) {
+      return errorResponse("Payload too large.", 413);
+    }
+    let form: URLSearchParams;
+    try {
+      form = new URLSearchParams(decoder.decode(rawBody));
+    } catch {
+      return errorResponse("Malformed form body.");
+    }
+    const logoutTokens = form.getAll("logout_token");
+    if (logoutTokens.length !== 1 || !logoutTokens[0]) {
+      return errorResponse("Exactly one logout_token is required.");
+    }
+
+    let claims: LogtoLogoutTokenClaims;
+    try {
+      claims = await verifyLogtoLogoutToken(logoutTokens[0], options);
+    } catch {
+      return errorResponse("The logout_token is invalid.");
+    }
+
+    const bodyHash = await deliveryKey(claims);
+    let claimed = false;
+    try {
+      claimed = await ctx.runMutation(
+        options.sessions.lib.recordWebhookDelivery,
+        { bodyHash, now: Date.now() },
+      );
+      // A valid replay is already fully handled. Always return the same 200 as
+      // a first delivery so neither jti nor session existence leaks.
+      if (!claimed) return successResponse();
+      if (claims.sid !== undefined) {
+        await ctx.runMutation(options.sessions.lib.killSessionsBySid, {
+          sid: claims.sid,
+        });
+      } else {
+        await ctx.runMutation(options.sessions.lib.killSubjectSessions, {
+          subject: claims.subject!,
+        });
+      }
+      return successResponse();
+    } catch {
+      if (claimed) {
+        await ctx
+          .runMutation(options.sessions.lib.forgetWebhookDelivery, { bodyHash })
+          .catch(() => {});
+      }
+      return errorResponse("The logout request could not be completed.");
+    }
+  });
+}
+
+/**
+ * Register `POST /logto/backchannel-logout` (or `options.path`) on a Convex
+ * HTTP router. Configure the resulting `.convex.site` URL as the Logto app's
+ * back-channel logout URI.
+ */
+export function registerLogtoBackchannelLogout(
+  http: HttpRouter,
+  options: RegisterLogtoBackchannelLogoutOptions,
+): void {
+  const { path = "/logto/backchannel-logout", ...handlerOptions } = options;
+  http.route({
+    path,
+    method: "POST",
+    handler: createLogtoBackchannelLogoutHandler(handlerOptions),
+  });
+}

--- a/packages/convex-logto/src/component/_generated/component.ts
+++ b/packages/convex-logto/src/component/_generated/component.ts
@@ -72,6 +72,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         boolean,
         Name
       >;
+      killSessionsBySid: FunctionReference<
+        "mutation",
+        "internal",
+        { sid: string },
+        number,
+        Name
+      >;
       killSubjectSessions: FunctionReference<
         "mutation",
         "internal",

--- a/packages/convex-logto/src/component/core.test.ts
+++ b/packages/convex-logto/src/component/core.test.ts
@@ -194,6 +194,21 @@ it("decodeIdToken extracts sub and exp (ms)", () => {
   });
 });
 
+it("decodeIdToken captures an optional Logto sid", () => {
+  const token = fakeIdToken({
+    iss: "https://auth.example.com/oidc",
+    aud: "app1",
+    sub: "user1",
+    sid: "logto-session-1",
+    exp: 1_700_000_000,
+  });
+  expect(decodeIdToken(token, expected)).toEqual({
+    subject: "user1",
+    sid: "logto-session-1",
+    expiresAtMs: 1_700_000_000_000,
+  });
+});
+
 it.each([
   ["malformed", "not-a-jwt"],
   [

--- a/packages/convex-logto/src/component/core.ts
+++ b/packages/convex-logto/src/component/core.ts
@@ -211,7 +211,7 @@ export function buildEndSessionUrl(options: {
 export function decodeIdToken(
   idToken: string,
   expected: { endpoint: string; appId: string },
-): { subject: string; expiresAtMs: number } {
+): { subject: string; sid?: string; expiresAtMs: number } {
   const parts = idToken.split(".");
   if (parts.length !== 3) {
     throw terminal("invalid_id_token", "Logto returned a malformed ID token.");
@@ -223,7 +223,7 @@ export function decodeIdToken(
   } catch {
     throw terminal("invalid_id_token", "Logto returned a malformed ID token.");
   }
-  const { iss, aud, sub, exp } = payload;
+  const { iss, aud, sub, sid, exp } = payload;
   if (iss !== `${expected.endpoint}/oidc` || aud !== expected.appId) {
     throw terminal(
       "id_token_mismatch",
@@ -234,7 +234,11 @@ export function decodeIdToken(
   if (typeof sub !== "string" || typeof exp !== "number") {
     throw terminal("invalid_id_token", "ID token is missing sub/exp claims.");
   }
-  return { subject: sub, expiresAtMs: exp * 1000 };
+  return {
+    subject: sub,
+    ...(typeof sid === "string" && sid.length > 0 ? { sid } : {}),
+    expiresAtMs: exp * 1000,
+  };
 }
 
 /**

--- a/packages/convex-logto/src/component/lib.test.ts
+++ b/packages/convex-logto/src/component/lib.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+import { killSessionsBySid } from "./lib";
+
+type Session = { _id: string; sid?: string };
+
+describe("killSessionsBySid", () => {
+  it("uses the sid index and deletes only matching sessions", async () => {
+    const sessions: Session[] = [
+      { _id: "session-1", sid: "sid-a" },
+      { _id: "session-2", sid: "sid-a" },
+      { _id: "session-3", sid: "sid-b" },
+      { _id: "legacy-session" },
+    ];
+    let indexedSid: string | undefined;
+    const deleted: string[] = [];
+    const db = {
+      query: vi.fn(() => ({
+        withIndex: vi.fn(
+          (
+            index: string,
+            configure: (query: {
+              eq(field: string, value: string): unknown;
+            }) => unknown,
+          ) => {
+            expect(index).toBe("by_sid");
+            configure({
+              eq(field, value) {
+                expect(field).toBe("sid");
+                indexedSid = value;
+                return this;
+              },
+            });
+            return {
+              collect: () =>
+                Promise.resolve(
+                  sessions.filter((session) => session.sid === indexedSid),
+                ),
+            };
+          },
+        ),
+      })),
+      delete: vi.fn((id: string) => {
+        deleted.push(id);
+        return Promise.resolve();
+      }),
+    };
+    type Handler = (
+      ctx: { db: typeof db },
+      args: { sid: string },
+    ) => Promise<number>;
+    const handler = (killSessionsBySid as unknown as Record<string, Handler>)[
+      "_handler"
+    ]!;
+
+    await expect(handler({ db }, { sid: "sid-a" })).resolves.toBe(2);
+    expect(deleted).toEqual(["session-1", "session-2"]);
+  });
+});

--- a/packages/convex-logto/src/component/lib.ts
+++ b/packages/convex-logto/src/component/lib.ts
@@ -218,6 +218,7 @@ export const exchange = action({
       internal.lib.createSession,
       {
         subject: claims.subject,
+        sid: claims.sid,
         tokenHash: await hashToken(sessionToken),
         logtoRefreshToken: tokens.refresh_token,
         lastIdToken: tokens.id_token,
@@ -271,6 +272,7 @@ export const consumeTransaction = internalMutation({
 export const createSession = internalMutation({
   args: {
     subject: v.string(),
+    sid: v.optional(v.string()),
     tokenHash: v.string(),
     logtoRefreshToken: v.string(),
     lastIdToken: v.string(),
@@ -376,6 +378,7 @@ export const refresh = action({
           newRefreshToken: tokens.refresh_token,
           idToken: tokens.id_token,
           idTokenExp: claims.expiresAtMs,
+          sid: claims.sid,
           now: Date.now(),
         });
         return {
@@ -510,6 +513,7 @@ export const completeRefresh = internalMutation({
     newRefreshToken: v.optional(v.string()),
     idToken: v.string(),
     idTokenExp: v.number(),
+    sid: v.optional(v.string()),
     now: v.number(),
   },
   returns: v.null(),
@@ -526,6 +530,7 @@ export const completeRefresh = internalMutation({
       refreshingSince: undefined,
       lastIdToken: args.idToken,
       lastIdTokenExp: args.idTokenExp,
+      ...(args.sid === undefined ? {} : { sid: args.sid }),
       lastRefreshedAt: args.now,
       ...(args.newRefreshToken
         ? { logtoRefreshToken: args.newRefreshToken }
@@ -651,12 +656,27 @@ export const killSubjectSessions = mutation({
   },
 });
 
+/** Kill only component sessions mapped to one Logto OP session (`sid`). */
+export const killSessionsBySid = mutation({
+  args: { sid: v.string() },
+  returns: v.number(),
+  handler: async (ctx, args) => {
+    const sessions = await ctx.db
+      .query("sessions")
+      .withIndex("by_sid", (q) => q.eq("sid", args.sid))
+      .collect();
+    for (const session of sessions) {
+      await ctx.db.delete(session._id);
+    }
+    return sessions.length;
+  },
+});
+
 // --- webhook delivery dedupe -------------------------------------------------
 
 /**
- * Claim a webhook delivery by its raw-body hash. Returns `true` the first time
- * a body is seen — the caller processes it; `false` on a repeat (a Logto retry
- * whose original 200 was lost) — the caller answers 200 without reprocessing.
+ * Claim a verified Logto delivery by a SHA-256 key (webhook body or issuer+jti).
+ * Returns `true` the first time; `false` on a retry whose original 200 was lost.
  */
 export const recordWebhookDelivery = mutation({
   args: { bodyHash: v.string(), now: v.number() },

--- a/packages/convex-logto/src/component/schema.ts
+++ b/packages/convex-logto/src/component/schema.ts
@@ -28,9 +28,9 @@ export default defineSchema({
   // One row per browser sign-in. Owns exactly one Logto grant and one rotating
   // chain of session tokens; killed as a unit (reuse handling, sign-out,
   // webhook-driven revocation).
-  // SHA-256 hashes of processed webhook delivery bodies — exactly-once handling
-  // for Logto's retries (a delivery whose 200 got lost in transit is re-sent
-  // with the identical signed body). Swept by the GC cron after 24h.
+  // SHA-256 delivery claims — raw webhook bodies and back-channel logout jtis.
+  // Exactly-once handling absorbs a Logto retry whose 200 got lost. Swept by
+  // the GC cron after 24h.
   webhookDeliveries: defineTable({
     bodyHash: v.string(),
     seenAt: v.number(),
@@ -41,6 +41,8 @@ export default defineSchema({
   sessions: defineTable({
     /** Logto user id (the ID token's `sub`). */
     subject: v.string(),
+    /** Logto OP session id (the ID token's optional `sid`). */
+    sid: v.optional(v.string()),
     /** SHA-256 (hex) of the current session token — never the token itself. */
     tokenHash: v.string(),
     /** Hash of the immediately-previous token, accepted inside the reuse window. */
@@ -69,5 +71,6 @@ export default defineSchema({
     .index("by_tokenHash", ["tokenHash"])
     .index("by_prevTokenHash", ["prevTokenHash"])
     .index("by_subject", ["subject"])
+    .index("by_sid", ["sid"])
     .index("by_lastRefreshedAt", ["lastRefreshedAt"]),
 });

--- a/packages/convex-logto/src/index.ts
+++ b/packages/convex-logto/src/index.ts
@@ -1,4 +1,13 @@
 export {
+  createLogtoBackchannelLogoutHandler,
+  registerLogtoBackchannelLogout,
+  verifyLogtoLogoutToken,
+  type LogtoBackchannelLogoutHandlerOptions,
+  type LogtoLogoutTokenClaims,
+  type RegisterLogtoBackchannelLogoutOptions,
+  type VerifyLogtoLogoutTokenOptions,
+} from "./backchannel-logout";
+export {
   logtoAuthConfig,
   logtoConfigQuery,
   type LogtoAuthConfigOptions,

--- a/packages/convex-logto/src/session.ts
+++ b/packages/convex-logto/src/session.ts
@@ -110,6 +110,12 @@ export type LogtoSessionComponent = {
       { subject: string },
       number
     >;
+    killSessionsBySid: FunctionReference<
+      "mutation",
+      "internal",
+      { sid: string },
+      number
+    >;
     recordWebhookDelivery: FunctionReference<
       "mutation",
       "internal",


### PR DESCRIPTION
## Summary

- add a registerable Convex HTTP action for verified Logto OIDC back-channel logout
- persist optional ID-token sid values and revoke either the indexed sid session set or every session for sub
- document Logto Console setup, validation behavior, replay handling, and reactive propagation

## Design decisions

- Reuse the existing delivery-claim table with a SHA-256 key over issuer and jti, retaining the existing 24-hour GC window.
- Cache JWKS responses for five minutes and permit bounded unknown-kid refreshes after one minute, avoiding an attacker-controlled JWKS fetch loop.
- Capture sid during exchange and refresh so pre-existing sessions migrate when their next ID token arrives; preserve a known sid if a later token omits it.
- Keep the client unchanged because the existing sessionValid subscription already propagates component deletion.

## Validation coverage

- RS256 and PS256 signature success with mocked Logto JWKS
- wrong issuer, audience, algorithm, signature, missing event, nonce, stale iat, expired token, missing subject/session, missing jti, and garbage JWT rejection
- sid-only targeted revocation, sub fallback revocation, replay dedupe, mutation-failure claim release, POST/content-type validation, and oversized-body rejection

## Verification

- pnpm --filter convex-logto test: 209 passed
- pnpm --filter convex-logto check-types: passed
- pnpm --filter convex-logto lint: passed
- pnpm --filter convex-logto format: passed
- pnpm --filter convex-logto build: passed
- pnpm --filter convex-logto lint:package: passed
- pnpm --filter docs build: passed; pre-existing warnings remain tracked in #36

Changeset: .changeset/clever-drinks-scream.md

Out-of-scope issue filed: #47 tracks Convex component codegen failing when another local backend owns port 3212.

Closes #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added verified OIDC back-channel logout support for session mode.
  * Sessions can be revoked by session ID or user subject, with replay protection and RS256/PS256 token support.
  * Added configurable logout endpoint registration and token verification APIs.
  * Matching client sessions now update automatically without frontend changes.

* **Documentation**
  * Added setup, configuration, API reference, and troubleshooting guidance for back-channel logout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->