### PR TITLE
feat: add sign out everywhere for session mode

### DIFF
--- a/.changeset/frank-ties-travel.md
+++ b/.changeset/frank-ties-travel.md
@@ -1,0 +1,5 @@
+---
+"convex-logto": minor
+---
+
+Add subject-scoped sign out everywhere to web and native session mode.

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -15,7 +15,7 @@ description: Every export from convex-logto and its web, native, and session-mod
 | `registerLogtoBackchannelLogout(http, opts)` | `convex-logto` | Registers the verified OIDC back-channel logout route for session mode. |
 | `createLogtoBackchannelLogoutHandler(opts)` | `convex-logto` | Builds the same Convex HTTP action without registering a path. |
 | `verifyLogtoLogoutToken(token, opts?)` | `convex-logto` | Low-level Web Crypto/JWKS validation for an OIDC Logout Token. |
-| `logtoSessionApi(component, opts?)` | `convex-logto` | [Session mode](/docs/session-mode): builds the five public auth functions backed by the session component. |
+| `logtoSessionApi(component, opts?)` | `convex-logto` | [Session mode](/docs/session-mode): builds the six public auth functions backed by the session component. |
 | `assertUserHasActiveSession(ctx, component)` | `convex-logto` | Session mode: throw unless the caller still has a live (unrevoked) session. |
 | `createLogtoSessionCookieHandler(opts)` | `convex-logto` | Four-route standard-fetch handler for the optional same-site HttpOnly cookie transport. |
 | `createLogtoSessionCookieTransport(api, opts?)` | `convex-logto` | Framework-free browser adapter used by the session provider's `cookieTransport` prop. |
@@ -25,11 +25,11 @@ description: Every export from convex-logto and its web, native, and session-mod
 | `useLogtoAuth()` | `convex-logto/react` | `{ isAuthenticated, isLoading, user, signIn, signOut }`. |
 | default | `convex-logto/convex.config` | The session component, for `app.use(logto)` in `convex/convex.config.ts`. |
 | `ConvexLogtoSessionProvider` | `convex-logto/react-session` | Session mode's provider — no Logto SDK; talks to your `logtoSessionApi` functions. |
-| `useLogtoAuth()` | `convex-logto/react-session` | Same shape as the bridge hook; `signOut(opts?)` takes `{ postLogoutRedirectUri?, federated? }`. |
+| `useLogtoAuth()` | `convex-logto/react-session` | Session auth plus `signOutEverywhere({ postLogoutRedirectUri? })`. |
 | `ConvexLogtoProvider` | `convex-logto/native` | React Native / Expo provider (on `@logto/rn`). Same `config` / `configQuery` model; no callback route. |
 | `useLogtoAuth()` | `convex-logto/native` | Native `{ isAuthenticated, isLoading, user, signIn, signOut }`; `signOut()` takes no argument. |
 | `ConvexLogtoSessionProvider` | `convex-logto/native-session` | React Native / Expo session provider using SecureStore + the system browser. |
-| `useLogtoAuth()` | `convex-logto/native-session` | Native session `{ isAuthenticated, isLoading, user, signIn, signOut }`; no device-binding surface. |
+| `useLogtoAuth()` | `convex-logto/native-session` | Native session `{ isAuthenticated, isLoading, user, signIn, signOut, signOutEverywhere }`; no device-binding surface. |
 
 ## Backend
 
@@ -112,20 +112,32 @@ tokens. It does not mutate or deduplicate sessions.
 ### `logtoSessionApi(component, opts?)`
 
 [Session mode](/docs/session-mode)'s server surface: pass `components.logto`
-(after `app.use(logto)`), re-export the five functions it returns. Reads
+(after `app.use(logto)`), re-export the six functions it returns. Reads
 `LOGTO_ENDPOINT`, `LOGTO_APP_ID`, and `LOGTO_CLIENT_SECRET`.
 
 ```ts title="convex/auth.ts"
 import { logtoSessionApi } from "convex-logto";
 import { components } from "./_generated/api";
 
-export const { signIn, callback, refresh, signOut, sessionValid } =
-  logtoSessionApi(components.logto);
+export const {
+  signIn,
+  callback,
+  refresh,
+  signOut,
+  signOutEverywhere,
+  sessionValid,
+} = logtoSessionApi(components.logto);
 ```
 
 Options: `scopes` / `resources` (server-configured — the browser can't request
 its own), `reuseWindowMs` (default 10s), and `endpoint` / `appId` /
 `clientSecret` env overrides.
+
+`signOutEverywhere({ sessionToken, postLogoutRedirectUri? })` hashes the token,
+derives its subject inside the component, atomically deletes every session for
+that subject, and returns `{ count, endSessionUrl }`. The subject is never a
+public argument. It intentionally does not issue one RFC 7009 request per
+deleted row; their now-unreachable grants expire at Logto's TTL.
 
 The generated `callback` and `refresh` actions also accept optional
 device-binding fields used internally by `ConvexLogtoSessionProvider`
@@ -146,7 +158,9 @@ as a standard `(Request) => Promise<Response>` handler. Options are:
 
 The four final path segments are `sign-in`, `callback`, `token`, and `sign-out`.
 Actual calls require POST, `x-convex-logto-csrf: 1`, and an allowed `Origin`;
-approved preflights receive credentialed CORS headers. The cookie is fixed to
+approved preflights receive credentialed CORS headers. `signOutEverywhere` uses
+an internal selector on the existing `sign-out` route, so enabling it does not
+add a fifth route. The cookie is fixed to
 `__Host-convex-logto-session=<encoded-token>; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=16416000`
 and rolls on every successful token rotation. Each roll renews the 190-day
 maximum age, matching the component's idle-session garbage collection window.
@@ -242,7 +256,7 @@ in the bundle — it talks to the functions from `logtoSessionApi(...)`.
 | Prop | Required | Purpose |
 | --- | --- | --- |
 | `client` | yes | Your `ConvexReactClient`. |
-| `sessionApi` | yes | The module re-exporting `logtoSessionApi(...)`'s functions, e.g. `api.auth` (exact names: `signIn` / `callback` / `refresh` / `signOut` / `sessionValid`). |
+| `sessionApi` | yes | The module re-exporting `logtoSessionApi(...)`'s functions, e.g. `api.auth` (exact names: `signIn` / `callback` / `refresh` / `signOut` / `signOutEverywhere` / `sessionValid`). |
 | `callbackPath` | — | Route that finishes the redirect. Default `/callback`; exact match against the registered Redirect URI's path. |
 | `afterSignIn` | — | Where to land after sign-in. Default `/`. `signIn({ returnTo })` overrides it. |
 | `navigate` | — | Your router's navigate (prefer replace-style) for soft post-sign-in navigation. Falls back to a hard `location.replace`. |
@@ -264,7 +278,8 @@ the [session-mode threat model and DBSC re-evaluation note](/docs/session-mode#d
 
 ### `useLogtoAuth()` (session)
 
-Same shape as the bridge hook: `{ isAuthenticated, isLoading, user, signIn, signOut }`.
+Returns `{ isAuthenticated, isLoading, user, signIn, signOut,
+signOutEverywhere }`.
 
 - `signIn({ returnTo? })` — one round-trip to mint the sign-in URL, then a
   full-page redirect. `returnTo` must be a same-origin path.
@@ -273,6 +288,10 @@ Same shape as the bridge hook: `{ isAuthenticated, isLoading, user, signIn, sign
   `federated: false`) ends the Logto SSO session and returns to
   `postLogoutRedirectUri` (default: your origin, which must be a registered
   Post sign-out redirect URI).
+- `signOutEverywhere({ postLogoutRedirectUri? })` — derives the caller subject
+  from its session token, atomically kills all of that subject's sessions, and
+  always completes federated sign-out for this device. Older app modules that
+  have not re-exported the action fail with an explicit deployment fix.
 
 ## Native session mode (`convex-logto/native-session`)
 
@@ -296,15 +315,18 @@ device-binding option.
 | Prop | Required | Purpose |
 | --- | --- | --- |
 | `client` | yes | Your `ConvexReactClient`. |
-| `sessionApi` | yes | The module re-exporting all five `logtoSessionApi(...)` functions. |
+| `sessionApi` | yes | The module re-exporting all six `logtoSessionApi(...)` functions. |
 | `redirectUri` | yes | Custom-scheme or universal-link callback registered as both a Redirect URI and Post sign-out redirect URI in Logto. |
 | `reactiveRevocation` | — | Subscribe to `sessionValid` and clear SecureStore immediately when revoked. Default `true`. |
 | `onAuthError` | — | Receives recoverable OAuth, SecureStore, and system-browser failures; errors are also logged. |
 
 `useLogtoAuth()` returns `{ isAuthenticated, isLoading, user, signIn,
-signOut }`. `signIn()` opens and completes the system-browser flow in place.
+signOut, signOutEverywhere }`. `signIn()` opens and completes the system-browser flow in place.
 `signOut({ postLogoutRedirectUri?, federated? })` clears SecureStore and revokes
 the server session, then ends Logto browser SSO unless `federated: false`.
+`signOutEverywhere({ postLogoutRedirectUri? })` clears SecureStore, kills every
+component session for the caller subject, and ends this device's Logto browser
+SSO session.
 
 The ID token is persisted in SecureStore to make a fresh cold start a
 zero-round-trip authenticate. This is the native equivalent of choosing web

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -136,8 +136,11 @@ its own), `reuseWindowMs` (default 10s), and `endpoint` / `appId` /
 `signOutEverywhere({ sessionToken, postLogoutRedirectUri? })` hashes the token,
 derives its subject inside the component, atomically deletes every session for
 that subject, and returns `{ count, endSessionUrl }`. The subject is never a
-public argument. It intentionally does not issue one RFC 7009 request per
-deleted row; their now-unreachable grants expire at Logto's TTL.
+public argument. The immediately previous token is accepted only inside
+`reuseWindowMs`; presenting it later deletes only that stale session and raises
+the normal terminal reuse error. The action intentionally does not issue one
+RFC 7009 request per deleted row; their now-unreachable grants expire at
+Logto's TTL.
 
 The generated `callback` and `refresh` actions also accept optional
 device-binding fields used internally by `ConvexLogtoSessionProvider`

--- a/docs/content/docs/react-native.mdx
+++ b/docs/content/docs/react-native.mdx
@@ -173,9 +173,9 @@ Everything else — `logtoAuthConfig`, `logtoConfigQuery`, the webhook
 ## Native session mode
 
 Use **`convex-logto/native-session`** when the Logto refresh token should remain
-inside the Convex session component. The server setup and five actions are the
-same as [web session mode](/docs/session-mode); only the storage and OAuth
-adapters differ on the device.
+inside the Convex session component. The server setup and six public functions
+are the same as [web session mode](/docs/session-mode); only the storage and
+OAuth adapters differ on the device.
 
 ### Install
 

--- a/docs/content/docs/react-native.mdx
+++ b/docs/content/docs/react-native.mdx
@@ -199,7 +199,7 @@ in both lists:
 Keep the `"scheme": "io.logto"` app configuration shown above. As with web
 session mode, set `LOGTO_ENDPOINT`, `LOGTO_APP_ID`, and
 `LOGTO_CLIENT_SECRET` on the Convex deployment, install the component, and
-export all five functions:
+export all six functions:
 
 ```ts title="convex/convex.config.ts"
 import { defineApp } from "convex/server";
@@ -214,8 +214,14 @@ export default app;
 import { logtoSessionApi } from "convex-logto";
 import { components } from "./_generated/api";
 
-export const { signIn, callback, refresh, signOut, sessionValid } =
-  logtoSessionApi(components.logto);
+export const {
+  signIn,
+  callback,
+  refresh,
+  signOut,
+  signOutEverywhere,
+  sessionValid,
+} = logtoSessionApi(components.logto);
 ```
 
 `convex/auth.config.ts` still uses `logtoAuthConfig()` so Convex validates the
@@ -262,6 +268,9 @@ Reactive revocation is on by default and uses the same `sessionValid`
 subscription as the web provider. `signOut()` clears SecureStore, revokes the
 server session, and opens Logto's end-session URL in the system browser unless
 `federated: false` is passed.
+`signOutEverywhere({ postLogoutRedirectUri? })` instead deletes every component
+session for the caller subject, lets the same subscription sign out other live
+devices, and always ends this device's Logto browser session.
 
 ### Differences from web session mode
 

--- a/docs/content/docs/session-mode.mdx
+++ b/docs/content/docs/session-mode.mdx
@@ -135,22 +135,26 @@ await signOutEverywhere({
 ```
 
 The component derives the subject **only** from the caller's presented live
-session token (the current or immediately previous rotation generation) and
-deletes all matching rows in one mutation. There is no client-supplied subject
-and no read-then-delete race. Local credentials are cleared first, using the
-same unblockable and durable-cleanup behavior as `signOut()`; other live
-devices receive `sessionValid: false` through the existing reactive
-subscription and drop authentication without new client plumbing.
+session token (the current generation, or the immediately previous generation
+within the configured reuse window) and deletes all matching rows in one
+mutation. A previous token outside that window is treated as theft: only its
+own session is deleted and the operation rejects, leaving the subject's other
+sessions intact. There is no client-supplied subject and no read-then-delete
+race. Local credentials are cleared first, using the same unblockable and
+durable-cleanup behavior as `signOut()`; other live devices receive
+`sessionValid: false` through the existing reactive subscription and drop
+authentication without new client plumbing.
 If the subject-wide server action fails, the promise rejects so the app can
 report that the everywhere operation was incomplete, even though this device
 has already cleared its local credentials.
 
-The caller's end-session URL carries its last ID token as `id_token_hint`, so
-that device's Logto browser SSO session is ended too. This is still an
-**RP-level boundary**: one device cannot erase the Logto OP cookies stored in
-other devices' browsers. A device that retains a live Logto cookie can start a
-new sign-in and may be authenticated by Logto without another credential
-prompt.
+The caller also follows Logto's end-session URL, ending that device's browser
+SSO session. The URL deliberately carries no ID token; Logto's client ID and
+registered post-logout redirect are sufficient, as they are for ordinary
+`signOut()`. This is still an **RP-level boundary**: one device cannot erase the
+Logto OP cookies stored in other devices' browsers. A device that retains a
+live Logto cookie can start a new sign-in and may be authenticated by Logto
+without another credential prompt.
 
 Deleting a component row also deletes its server-held Logto refresh token, so
 the corresponding grant becomes unreachable by the app. The operation does

--- a/docs/content/docs/session-mode.mdx
+++ b/docs/content/docs/session-mode.mdx
@@ -75,11 +75,17 @@ issued to the Traditional Web app.
 import { logtoSessionApi } from "convex-logto";
 import { components } from "./_generated/api";
 
-export const { signIn, callback, refresh, signOut, sessionValid } =
-  logtoSessionApi(components.logto);
+export const {
+  signIn,
+  callback,
+  refresh,
+  signOut,
+  signOutEverywhere,
+  sessionValid,
+} = logtoSessionApi(components.logto);
 ```
 
-Re-export all five with these exact names — the provider looks them up on the
+Re-export all six with these exact names — the provider looks them up on the
 module you pass it.
 
 ### 5. Mount the provider
@@ -98,16 +104,67 @@ const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL);
 
 That's the whole frontend. No `@logto/react`, no callback component — the
 provider finishes the exchange on `/callback` and replace-navigates back into
-the app by itself. `useLogtoAuth()` from `convex-logto/react-session` has the
-same shape as the bridge hook:
+the app by itself. `useLogtoAuth()` from `convex-logto/react-session` extends
+the bridge hook with `signOutEverywhere`:
 
 ```tsx
 import { useLogtoAuth } from "convex-logto/react-session";
 
-const { isAuthenticated, isLoading, user, signIn, signOut } = useLogtoAuth();
+const {
+  isAuthenticated,
+  isLoading,
+  user,
+  signIn,
+  signOut,
+  signOutEverywhere,
+} = useLogtoAuth();
 // signIn({ returnTo: "/dashboard" }) — same-origin path, lands there after sign-in
 // signOut() — revokes the grant, clears every tab, ends the Logto SSO session
 ```
+
+## Sign out everywhere
+
+`signOutEverywhere()` deletes every component session belonging to the current
+user, then completes an ordinary federated sign-out for the calling browser or
+native device:
+
+```tsx
+await signOutEverywhere({
+  postLogoutRedirectUri: window.location.origin,
+});
+```
+
+The component derives the subject **only** from the caller's presented live
+session token (the current or immediately previous rotation generation) and
+deletes all matching rows in one mutation. There is no client-supplied subject
+and no read-then-delete race. Local credentials are cleared first, using the
+same unblockable and durable-cleanup behavior as `signOut()`; other live
+devices receive `sessionValid: false` through the existing reactive
+subscription and drop authentication without new client plumbing.
+If the subject-wide server action fails, the promise rejects so the app can
+report that the everywhere operation was incomplete, even though this device
+has already cleared its local credentials.
+
+The caller's end-session URL carries its last ID token as `id_token_hint`, so
+that device's Logto browser SSO session is ended too. This is still an
+**RP-level boundary**: one device cannot erase the Logto OP cookies stored in
+other devices' browsers. A device that retains a live Logto cookie can start a
+new sign-in and may be authenticated by Logto without another credential
+prompt.
+
+Deleting a component row also deletes its server-held Logto refresh token, so
+the corresponding grant becomes unreachable by the app. The operation does
+not make one RFC 7009 request per deleted session: that loop would add a Logto
+round trip and partial-failure state for every device with negligible security
+gain. Unreachable grants expire at their configured Logto TTL; normal
+single-session `signOut()` continues to revoke its one grant eagerly.
+
+If an older `convex/auth.ts` has not re-exported `signOutEverywhere`, the
+provider rejects with an explicit upgrade message instead of exposing a
+cryptic missing-function response. Re-export the six-function set shown above
+and deploy the Convex functions.
+Listing or labeling individual devices is separate follow-up work tracked in
+[#49](https://github.com/Fanzzzd/convex-logto/issues/49).
 
 ## Device binding (optional)
 

--- a/packages/convex-logto/README.md
+++ b/packages/convex-logto/README.md
@@ -182,8 +182,14 @@ export default app;
 import { logtoSessionApi } from "convex-logto";
 import { components } from "./_generated/api";
 
-export const { signIn, callback, refresh, signOut, sessionValid } =
-  logtoSessionApi(components.logto);
+export const {
+  signIn,
+  callback,
+  refresh,
+  signOut,
+  signOutEverywhere,
+  sessionValid,
+} = logtoSessionApi(components.logto);
 ```
 
 ```tsx
@@ -200,10 +206,18 @@ root.render(
 
 Config lives on the deployment (`LOGTO_ENDPOINT`, `LOGTO_APP_ID`,
 `LOGTO_CLIENT_SECRET`); `useLogtoAuth()` from `convex-logto/react-session` has
-the same shape as the bridge hook. Full guide — threat model, token dance,
-server-side revocation with `assertUserHasActiveSession` — in the
+the bridge actions plus `signOutEverywhere()`. Full guide — threat model, token
+dance, server-side revocation with `assertUserHasActiveSession` — in the
 [Session mode docs][session-mode-docs] and the runnable
 [`vite-react-session`][session-example] example.
+
+`signOutEverywhere()` atomically derives the caller subject from its rotating
+session token, deletes every matching component session, and then ends the
+calling device's Logto SSO session. Other devices drop through reactive
+revocation; their separate Logto browser cookies cannot be erased by the RP and
+can be used to start a new sign-in. Deleted refresh tokens become unreachable
+and their grants expire at Logto's TTL rather than triggering an N-request RFC
+7009 loop.
 
 Apps with a same-site server endpoint can additionally mount
 `createLogtoSessionCookieHandler()` and pass
@@ -290,18 +304,18 @@ Convex validates an OIDC **ID token**. Logto's access tokens are typed `at+jwt`,
 | `createLogtoBackchannelLogoutHandler(opts)` | `convex-logto` | Builds the back-channel Convex HTTP action for custom route composition. |
 | `verifyLogtoLogoutToken(token, opts?)` | `convex-logto` | Low-level RS256/PS256 Logout Token verification against Logto's JWKS. |
 | `verifyLogtoSignature(key, body, sig)` | `convex-logto` | Low-level signature check, for custom routing. |
-| `logtoSessionApi(component, opts?)` | `convex-logto` | [Session mode](#session-mode): builds the five public auth functions backed by the session component. |
+| `logtoSessionApi(component, opts?)` | `convex-logto` | [Session mode](#session-mode): builds the six public auth functions backed by the session component. |
 | `assertUserHasActiveSession(ctx, component)` | `convex-logto` | Session mode: throw unless the caller still has a live (unrevoked) session. |
 | `createLogtoSessionCookieHandler(opts)` | `convex-logto` | Four-route standard-fetch handler for the optional same-site HttpOnly cookie transport. |
 | `ConvexLogtoProvider` | `convex-logto/react` | Logto + Convex + auto sign-in callback in one provider. Static `config` or backend `configQuery`. |
 | `useLogtoAuth()` | `convex-logto/react` | `{ isAuthenticated, isLoading, user, signIn, signOut }`. |
 | default | `convex-logto/convex.config` | The session component, for `app.use(logto)`. |
 | `ConvexLogtoSessionProvider` | `convex-logto/react-session` | Session mode's provider — no Logto SDK; talks to your `logtoSessionApi` functions. |
-| `useLogtoAuth()` | `convex-logto/react-session` | Same shape as the bridge hook; `signOut(opts?)` takes `{ postLogoutRedirectUri?, federated? }`. |
+| `useLogtoAuth()` | `convex-logto/react-session` | Session auth actions, including `signOutEverywhere({ postLogoutRedirectUri? })`. |
 | `ConvexLogtoProvider` | `convex-logto/native` | React Native / Expo provider (on `@logto/rn`). Same `configQuery` model; no callback route. |
 | `useLogtoAuth()` | `convex-logto/native` | Native `{ isAuthenticated, isLoading, user, signIn, signOut }`; `signIn()` defaults to the provider's `redirectUri`. |
 | `ConvexLogtoSessionProvider` | `convex-logto/native-session` | Expo session mode via SecureStore + system-browser deep links; same server component and actions. |
-| `useLogtoAuth()` | `convex-logto/native-session` | Native session auth/actions; `signOut(opts?)` supports federated browser sign-out. |
+| `useLogtoAuth()` | `convex-logto/native-session` | Native session auth/actions, including federated `signOutEverywhere(opts?)`. |
 
 ### Next.js note
 

--- a/packages/convex-logto/src/component/_generated/component.ts
+++ b/packages/convex-logto/src/component/_generated/component.ts
@@ -89,8 +89,9 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
       killSubjectSessionsByToken: FunctionReference<
         "mutation",
         "internal",
-        { presentedHash: string },
-        { count: number; idTokenHint: string; subject: string },
+        { now: number; presentedHash: string; reuseWindowMs: number },
+        | { count: number; outcome: "signed-out"; subject: string }
+        | { outcome: "reuse" },
         Name
       >;
       recordWebhookDelivery: FunctionReference<

--- a/packages/convex-logto/src/component/_generated/component.ts
+++ b/packages/convex-logto/src/component/_generated/component.ts
@@ -86,6 +86,13 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         number,
         Name
       >;
+      killSubjectSessionsByToken: FunctionReference<
+        "mutation",
+        "internal",
+        { presentedHash: string },
+        { count: number; idTokenHint: string; subject: string },
+        Name
+      >;
       recordWebhookDelivery: FunctionReference<
         "mutation",
         "internal",

--- a/packages/convex-logto/src/component/core.test.ts
+++ b/packages/convex-logto/src/component/core.test.ts
@@ -148,7 +148,7 @@ it("buildAuthorizeUrl carries PKCE, state, prompt=consent, and base scopes", () 
   expect(p.getAll("resource")).toEqual(["https://api.example.com"]);
 });
 
-it("buildEndSessionUrl includes optional redirect and ID-token hint", () => {
+it("buildEndSessionUrl includes the post-logout redirect only when given", () => {
   const bare = new URL(
     buildEndSessionUrl({ endpoint: "https://auth.example.com", appId: "app1" }),
   );
@@ -161,13 +161,11 @@ it("buildEndSessionUrl includes optional redirect and ID-token hint", () => {
       endpoint: "https://auth.example.com",
       appId: "app1",
       postLogoutRedirectUri: "https://app.example.com",
-      idTokenHint: "last-id-token",
     }),
   );
   expect(withUri.searchParams.get("post_logout_redirect_uri")).toBe(
     "https://app.example.com",
   );
-  expect(withUri.searchParams.get("id_token_hint")).toBe("last-id-token");
 });
 
 // --- ID token decoding -------------------------------------------------------

--- a/packages/convex-logto/src/component/core.test.ts
+++ b/packages/convex-logto/src/component/core.test.ts
@@ -148,7 +148,7 @@ it("buildAuthorizeUrl carries PKCE, state, prompt=consent, and base scopes", () 
   expect(p.getAll("resource")).toEqual(["https://api.example.com"]);
 });
 
-it("buildEndSessionUrl includes the post-logout redirect only when given", () => {
+it("buildEndSessionUrl includes optional redirect and ID-token hint", () => {
   const bare = new URL(
     buildEndSessionUrl({ endpoint: "https://auth.example.com", appId: "app1" }),
   );
@@ -161,11 +161,13 @@ it("buildEndSessionUrl includes the post-logout redirect only when given", () =>
       endpoint: "https://auth.example.com",
       appId: "app1",
       postLogoutRedirectUri: "https://app.example.com",
+      idTokenHint: "last-id-token",
     }),
   );
   expect(withUri.searchParams.get("post_logout_redirect_uri")).toBe(
     "https://app.example.com",
   );
+  expect(withUri.searchParams.get("id_token_hint")).toBe("last-id-token");
 });
 
 // --- ID token decoding -------------------------------------------------------

--- a/packages/convex-logto/src/component/core.ts
+++ b/packages/convex-logto/src/component/core.ts
@@ -192,14 +192,10 @@ export function buildEndSessionUrl(options: {
   endpoint: string;
   appId: string;
   postLogoutRedirectUri?: string;
-  idTokenHint?: string;
 }): string {
   const params = new URLSearchParams({ client_id: options.appId });
   if (options.postLogoutRedirectUri) {
     params.set("post_logout_redirect_uri", options.postLogoutRedirectUri);
-  }
-  if (options.idTokenHint) {
-    params.set("id_token_hint", options.idTokenHint);
   }
   return `${options.endpoint}/oidc/session/end?${params}`;
 }
@@ -296,13 +292,28 @@ export function decideRefresh(options: {
   }
 
   // Not current — the caller matched it via prevTokenHash.
-  const inWindow =
-    session.rotatedAt !== undefined && now - session.rotatedAt < reuseWindowMs;
+  const inWindow = isPreviousTokenWithinReuseWindow({
+    rotatedAt: session.rotatedAt,
+    now,
+    reuseWindowMs,
+  });
   if (!inWindow) return { outcome: "reuse" };
   if (claimed) return { outcome: "in-flight" };
   if (session.lastIdTokenExp - idTokenSkewMs > now)
     return { outcome: "cached" };
   return { outcome: "refresh-previous" };
+}
+
+/** Apply the same exclusive previous-generation grace window everywhere. */
+export function isPreviousTokenWithinReuseWindow(options: {
+  rotatedAt?: number;
+  now: number;
+  reuseWindowMs: number;
+}): boolean {
+  return (
+    options.rotatedAt !== undefined &&
+    options.now - options.rotatedAt < options.reuseWindowMs
+  );
 }
 
 /** Rotate while keeping the superseded current generation as the grace token. */
@@ -340,6 +351,14 @@ export function transient(
   message: string,
 ): ConvexError<SessionErrorData> {
   return new ConvexError({ kind: "transient" as const, code, message });
+}
+
+/** The shared terminal signal for a previous token presented after its grace window. */
+export function sessionReuseDetectedError(): ConvexError<SessionErrorData> {
+  return terminal(
+    "session_reuse_detected",
+    "This session token was already rotated away — the session has been revoked. Sign in again.",
+  );
 }
 
 /** Classify a Logto token-endpoint failure: 4xx auth failures are terminal, the rest transient. */

--- a/packages/convex-logto/src/component/core.ts
+++ b/packages/convex-logto/src/component/core.ts
@@ -192,10 +192,14 @@ export function buildEndSessionUrl(options: {
   endpoint: string;
   appId: string;
   postLogoutRedirectUri?: string;
+  idTokenHint?: string;
 }): string {
   const params = new URLSearchParams({ client_id: options.appId });
   if (options.postLogoutRedirectUri) {
     params.set("post_logout_redirect_uri", options.postLogoutRedirectUri);
+  }
+  if (options.idTokenHint) {
+    params.set("id_token_hint", options.idTokenHint);
   }
   return `${options.endpoint}/oidc/session/end?${params}`;
 }

--- a/packages/convex-logto/src/component/lib.test.ts
+++ b/packages/convex-logto/src/component/lib.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { killSessionsBySid } from "./lib";
+import { killSessionsBySid, killSubjectSessionsByToken } from "./lib";
 
 type Session = { _id: string; sid?: string };
 
@@ -54,5 +54,118 @@ describe("killSessionsBySid", () => {
 
     await expect(handler({ db }, { sid: "sid-a" })).resolves.toBe(2);
     expect(deleted).toEqual(["session-1", "session-2"]);
+  });
+});
+
+type SubjectSession = {
+  _id: string;
+  subject: string;
+  tokenHash: string;
+  prevTokenHash?: string;
+  lastIdToken: string;
+};
+
+function subjectSessionHarness(initial: SubjectSession[]) {
+  const sessions = [...initial];
+  const deleted: string[] = [];
+  const db = {
+    query: vi.fn(() => ({
+      withIndex: (
+        index: string,
+        configure: (query: {
+          eq(field: string, value: string): unknown;
+        }) => unknown,
+      ) => {
+        let field = "";
+        let value = "";
+        configure({
+          eq(nextField, nextValue) {
+            field = nextField;
+            value = nextValue;
+            return this;
+          },
+        });
+        const matching = () =>
+          sessions.filter(
+            (session) =>
+              (session as unknown as Record<string, unknown>)[field] === value,
+          );
+        return {
+          unique: () => Promise.resolve(matching()[0] ?? null),
+          collect: () => Promise.resolve(matching()),
+          index,
+        };
+      },
+    })),
+    delete: vi.fn((id: string) => {
+      deleted.push(id);
+      const index = sessions.findIndex((session) => session._id === id);
+      if (index >= 0) sessions.splice(index, 1);
+      return Promise.resolve();
+    }),
+  };
+  type Handler = (
+    ctx: { db: typeof db },
+    args: { presentedHash: string },
+  ) => Promise<{ count: number; subject: string; idTokenHint: string }>;
+  const handler = (
+    killSubjectSessionsByToken as unknown as Record<string, Handler>
+  )["_handler"]!;
+  return { db, deleted, sessions, handler };
+}
+
+describe("killSubjectSessionsByToken", () => {
+  const fixture = (): SubjectSession[] => [
+    {
+      _id: "subject-a-caller",
+      subject: "subject-a",
+      tokenHash: "caller-current",
+      prevTokenHash: "caller-previous",
+      lastIdToken: "caller-id-token",
+    },
+    {
+      _id: "subject-a-other",
+      subject: "subject-a",
+      tokenHash: "other-current",
+      lastIdToken: "other-id-token",
+    },
+    {
+      _id: "subject-b",
+      subject: "subject-b",
+      tokenHash: "subject-b-current",
+      lastIdToken: "subject-b-id-token",
+    },
+  ];
+
+  it("derives the subject from the current token and deletes all of only that subject", async () => {
+    const { db, deleted, sessions, handler } = subjectSessionHarness(fixture());
+
+    await expect(
+      handler({ db }, { presentedHash: "caller-current" }),
+    ).resolves.toEqual({
+      count: 2,
+      subject: "subject-a",
+      idTokenHint: "caller-id-token",
+    });
+    expect(deleted).toEqual(["subject-a-caller", "subject-a-other"]);
+    expect(sessions.map((session) => session._id)).toEqual(["subject-b"]);
+  });
+
+  it("accepts the immediately previous token hash", async () => {
+    const { db, handler } = subjectSessionHarness(fixture());
+
+    await expect(
+      handler({ db }, { presentedHash: "caller-previous" }),
+    ).resolves.toMatchObject({ count: 2, subject: "subject-a" });
+  });
+
+  it("rejects an unknown token terminally", async () => {
+    const { db, handler } = subjectSessionHarness(fixture());
+
+    await expect(
+      handler({ db }, { presentedHash: "unknown" }),
+    ).rejects.toMatchObject({
+      data: { kind: "terminal", code: "session_not_found" },
+    });
   });
 });

--- a/packages/convex-logto/src/component/lib.test.ts
+++ b/packages/convex-logto/src/component/lib.test.ts
@@ -62,6 +62,7 @@ type SubjectSession = {
   subject: string;
   tokenHash: string;
   prevTokenHash?: string;
+  rotatedAt?: number;
   lastIdToken: string;
 };
 
@@ -106,8 +107,11 @@ function subjectSessionHarness(initial: SubjectSession[]) {
   };
   type Handler = (
     ctx: { db: typeof db },
-    args: { presentedHash: string },
-  ) => Promise<{ count: number; subject: string; idTokenHint: string }>;
+    args: { presentedHash: string; now: number; reuseWindowMs: number },
+  ) => Promise<
+    | { outcome: "signed-out"; count: number; subject: string }
+    | { outcome: "reuse" }
+  >;
   const handler = (
     killSubjectSessionsByToken as unknown as Record<string, Handler>
   )["_handler"]!;
@@ -115,12 +119,15 @@ function subjectSessionHarness(initial: SubjectSession[]) {
 }
 
 describe("killSubjectSessionsByToken", () => {
-  const fixture = (): SubjectSession[] => [
+  const now = 1_000_000;
+  const reuseWindowMs = 10_000;
+  const fixture = (rotatedAt = now - 1_000): SubjectSession[] => [
     {
       _id: "subject-a-caller",
       subject: "subject-a",
       tokenHash: "caller-current",
       prevTokenHash: "caller-previous",
+      rotatedAt,
       lastIdToken: "caller-id-token",
     },
     {
@@ -138,32 +145,54 @@ describe("killSubjectSessionsByToken", () => {
   ];
 
   it("derives the subject from the current token and deletes all of only that subject", async () => {
-    const { db, deleted, sessions, handler } = subjectSessionHarness(fixture());
+    const { db, deleted, sessions, handler } = subjectSessionHarness(
+      fixture(now - reuseWindowMs - 1),
+    );
 
     await expect(
-      handler({ db }, { presentedHash: "caller-current" }),
+      handler({ db }, { presentedHash: "caller-current", now, reuseWindowMs }),
     ).resolves.toEqual({
+      outcome: "signed-out",
       count: 2,
       subject: "subject-a",
-      idTokenHint: "caller-id-token",
     });
     expect(deleted).toEqual(["subject-a-caller", "subject-a-other"]);
     expect(sessions.map((session) => session._id)).toEqual(["subject-b"]);
   });
 
-  it("accepts the immediately previous token hash", async () => {
-    const { db, handler } = subjectSessionHarness(fixture());
+  it("accepts the immediately previous token hash inside the reuse window", async () => {
+    const { db, deleted, handler } = subjectSessionHarness(fixture());
 
     await expect(
-      handler({ db }, { presentedHash: "caller-previous" }),
-    ).resolves.toMatchObject({ count: 2, subject: "subject-a" });
+      handler({ db }, { presentedHash: "caller-previous", now, reuseWindowMs }),
+    ).resolves.toEqual({
+      outcome: "signed-out",
+      count: 2,
+      subject: "subject-a",
+    });
+    expect(deleted).toEqual(["subject-a-caller", "subject-a-other"]);
+  });
+
+  it("contains previous-token reuse outside the window to only that session", async () => {
+    const { db, deleted, sessions, handler } = subjectSessionHarness(
+      fixture(now - reuseWindowMs),
+    );
+
+    await expect(
+      handler({ db }, { presentedHash: "caller-previous", now, reuseWindowMs }),
+    ).resolves.toEqual({ outcome: "reuse" });
+    expect(deleted).toEqual(["subject-a-caller"]);
+    expect(sessions.map((session) => session._id)).toEqual([
+      "subject-a-other",
+      "subject-b",
+    ]);
   });
 
   it("rejects an unknown token terminally", async () => {
     const { db, handler } = subjectSessionHarness(fixture());
 
     await expect(
-      handler({ db }, { presentedHash: "unknown" }),
+      handler({ db }, { presentedHash: "unknown", now, reuseWindowMs }),
     ).rejects.toMatchObject({
       data: { kind: "terminal", code: "session_not_found" },
     });

--- a/packages/convex-logto/src/component/lib.ts
+++ b/packages/convex-logto/src/component/lib.ts
@@ -636,6 +636,57 @@ export const hasActiveSessionForSubject = query({
   },
 });
 
+/**
+ * Authenticate with a live session token, derive its subject server-side, and
+ * delete every session for that subject atomically. The immediately-previous
+ * token hash is accepted so a caller racing a normal rotation keeps the same
+ * grace behavior as refresh. Never accept a client-supplied subject here.
+ */
+export const killSubjectSessionsByToken = mutation({
+  args: { presentedHash: v.string() },
+  returns: v.object({
+    count: v.number(),
+    subject: v.string(),
+    idTokenHint: v.string(),
+  }),
+  handler: async (ctx, args) => {
+    const byCurrent = await ctx.db
+      .query("sessions")
+      .withIndex("by_tokenHash", (q) => q.eq("tokenHash", args.presentedHash))
+      .unique();
+    const caller =
+      byCurrent ??
+      (await ctx.db
+        .query("sessions")
+        .withIndex("by_prevTokenHash", (q) =>
+          q.eq("prevTokenHash", args.presentedHash),
+        )
+        .unique());
+    if (!caller) {
+      throw terminal(
+        "session_not_found",
+        "No session for this token — it was signed out or revoked. Sign in again.",
+      );
+    }
+
+    const sessions = await ctx.db
+      .query("sessions")
+      .withIndex("by_subject", (q) => q.eq("subject", caller.subject))
+      .collect();
+    for (const session of sessions) {
+      await ctx.db.delete(session._id);
+    }
+    // Deleting the rows also makes every stored Logto refresh token
+    // unreachable. We intentionally avoid an N-request RFC 7009 loop here;
+    // those now-unusable grants expire at their own Logto TTL.
+    return {
+      count: sessions.length,
+      subject: caller.subject,
+      idTokenHint: caller.lastIdToken,
+    };
+  },
+});
+
 /** Kill every session of a subject — webhook revocation (User.Deleted / suspension) and "sign out everywhere". */
 export const killSubjectSessions = mutation({
   args: { subject: v.string() },

--- a/packages/convex-logto/src/component/lib.ts
+++ b/packages/convex-logto/src/component/lib.ts
@@ -21,7 +21,9 @@ import {
   generatePkce,
   generateToken,
   hashToken,
+  isPreviousTokenWithinReuseWindow,
   rotateTokenHashes,
+  sessionReuseDetectedError,
   terminal,
   transient,
   type DevicePublicKey,
@@ -344,10 +346,7 @@ export const refresh = action({
       case "reuse": {
         // Reuse handling: the session died in beginRefresh; revoke its grant.
         await revokeGrant(args, begin.refreshToken);
-        throw terminal(
-          "session_reuse_detected",
-          "This session token was already rotated away — the session has been revoked. Sign in again.",
-        );
+        throw sessionReuseDetectedError();
       }
       case "refresh": {
         let tokens: Awaited<ReturnType<typeof tokenEndpoint>>;
@@ -643,25 +642,47 @@ export const hasActiveSessionForSubject = query({
  * grace behavior as refresh. Never accept a client-supplied subject here.
  */
 export const killSubjectSessionsByToken = mutation({
-  args: { presentedHash: v.string() },
-  returns: v.object({
-    count: v.number(),
-    subject: v.string(),
-    idTokenHint: v.string(),
-  }),
+  args: {
+    presentedHash: v.string(),
+    now: v.number(),
+    reuseWindowMs: v.number(),
+  },
+  returns: v.union(
+    v.object({
+      outcome: v.literal("signed-out"),
+      count: v.number(),
+      subject: v.string(),
+    }),
+    v.object({ outcome: v.literal("reuse") }),
+  ),
   handler: async (ctx, args) => {
     const byCurrent = await ctx.db
       .query("sessions")
       .withIndex("by_tokenHash", (q) => q.eq("tokenHash", args.presentedHash))
       .unique();
-    const caller =
-      byCurrent ??
-      (await ctx.db
+    let caller = byCurrent;
+    if (caller === null) {
+      const byPrevious = await ctx.db
         .query("sessions")
         .withIndex("by_prevTokenHash", (q) =>
           q.eq("prevTokenHash", args.presentedHash),
         )
-        .unique());
+        .unique();
+      if (
+        byPrevious !== null &&
+        !isPreviousTokenWithinReuseWindow({
+          rotatedAt: byPrevious.rotatedAt,
+          now: args.now,
+          reuseWindowMs: args.reuseWindowMs,
+        })
+      ) {
+        // Commit this theft response before the app action raises the terminal
+        // error. Throwing inside this mutation would roll the deletion back.
+        await ctx.db.delete(byPrevious._id);
+        return { outcome: "reuse" as const };
+      }
+      caller = byPrevious;
+    }
     if (!caller) {
       throw terminal(
         "session_not_found",
@@ -680,9 +701,9 @@ export const killSubjectSessionsByToken = mutation({
     // unreachable. We intentionally avoid an N-request RFC 7009 loop here;
     // those now-unusable grants expire at their own Logto TTL.
     return {
+      outcome: "signed-out" as const,
       count: sessions.length,
       subject: caller.subject,
-      idTokenHint: caller.lastIdToken,
     };
   },
 });

--- a/packages/convex-logto/src/native-session-client.test.ts
+++ b/packages/convex-logto/src/native-session-client.test.ts
@@ -68,6 +68,7 @@ const api = {
   callback: { fn: "callback" },
   refresh: { fn: "refresh" },
   signOut: { fn: "signOut" },
+  signOutEverywhere: { fn: "signOutEverywhere" },
   sessionValid: { fn: "sessionValid" },
 } as unknown as LogtoSessionApi;
 
@@ -76,6 +77,7 @@ type Handlers = {
   callback: ReturnType<typeof vi.fn>;
   refresh: ReturnType<typeof vi.fn>;
   signOut: ReturnType<typeof vi.fn>;
+  signOutEverywhere: ReturnType<typeof vi.fn>;
 };
 
 function makeHarness(options?: {
@@ -106,6 +108,10 @@ function makeHarness(options?: {
     }),
     signOut: vi.fn().mockResolvedValue({
       endSessionUrl: "https://auth.example.com/oidc/session/end",
+    }),
+    signOutEverywhere: vi.fn().mockResolvedValue({
+      count: 2,
+      endSessionUrl: "https://auth.example.com/oidc/session/end?all=1",
     }),
   };
   const transport = {
@@ -306,6 +312,58 @@ describe("native session adapters", () => {
       "io.logto://signed-out",
     );
     expect(engine.getSnapshot().status).toBe("unauthenticated");
+  });
+
+  it("signs out every device and completes federated logout in the native browser", async () => {
+    const secureStore = fakeSecureStore();
+    await seedSession(secureStore, freshToken());
+    const webBrowser = fakeWebBrowser({ type: "dismiss" });
+    const { engine, handlers } = makeHarness({ secureStore, webBrowser });
+    handlers.signOutEverywhere.mockImplementation(() => {
+      expect(secureStore.data.size).toBe(0);
+      return Promise.resolve({
+        count: 2,
+        endSessionUrl: "https://auth.example.com/oidc/session/end?all=1",
+      });
+    });
+    engine.start();
+    await settled(engine);
+
+    await engine.signOutEverywhere({
+      postLogoutRedirectUri: "io.logto://signed-out-everywhere",
+    });
+
+    expect(handlers.signOutEverywhere).toHaveBeenCalledWith({
+      sessionToken: "session-token-old",
+      postLogoutRedirectUri: "io.logto://signed-out-everywhere",
+    });
+    expect(webBrowser.openAuthSessionAsync).toHaveBeenCalledWith(
+      "https://auth.example.com/oidc/session/end?all=1",
+      "io.logto://signed-out-everywhere",
+    );
+    expect(engine.getSnapshot().status).toBe("unauthenticated");
+  });
+
+  it("preserves loud durable-cleanup failure semantics for sign out everywhere", async () => {
+    const secureStore = fakeSecureStore();
+    await seedSession(secureStore, freshToken());
+    secureStore.deleteItemAsync = vi
+      .fn()
+      .mockRejectedValue(new Error("keystore delete failed"));
+    const { engine, handlers, onAuthError } = makeHarness({ secureStore });
+    engine.start();
+    await settled(engine);
+
+    await expect(engine.signOutEverywhere()).rejects.toMatchObject({
+      name: "SessionSignOutError",
+      code: "local_cleanup_failed",
+      serverSessionStatus: "revoked",
+    });
+
+    expect(handlers.signOutEverywhere).toHaveBeenCalledTimes(1);
+    expect(secureStore.deleteItemAsync).toHaveBeenCalledTimes(6);
+    expect(secureStore.data.size).toBe(2);
+    expect(onAuthError).toHaveBeenCalledWith(expect.any(SessionSignOutError));
   });
 
   it("rejects loudly when durable cleanup and server revocation both fail", async () => {

--- a/packages/convex-logto/src/native-session.tsx
+++ b/packages/convex-logto/src/native-session.tsx
@@ -182,6 +182,13 @@ export type LogtoSessionAuth = {
     postLogoutRedirectUri?: string;
     federated?: boolean;
   }) => Promise<void>;
+  /**
+   * Delete every component session for the current subject, then end this
+   * device's Logto browser SSO session.
+   */
+  signOutEverywhere: (options?: {
+    postLogoutRedirectUri?: string;
+  }) => Promise<void>;
 };
 
 export function useLogtoAuth(): LogtoSessionAuth {
@@ -198,6 +205,11 @@ export function useLogtoAuth(): LogtoSessionAuth {
       engine.signOut(options),
     [engine],
   );
+  const signOutEverywhere = useCallback(
+    (options?: { postLogoutRedirectUri?: string }) =>
+      engine.signOutEverywhere(options),
+    [engine],
+  );
   return useMemo(
     () => ({
       isAuthenticated,
@@ -205,8 +217,16 @@ export function useLogtoAuth(): LogtoSessionAuth {
       user: isAuthenticated ? snapshot.user : undefined,
       signIn,
       signOut,
+      signOutEverywhere,
     }),
-    [isAuthenticated, isLoading, snapshot.user, signIn, signOut],
+    [
+      isAuthenticated,
+      isLoading,
+      snapshot.user,
+      signIn,
+      signOut,
+      signOutEverywhere,
+    ],
   );
 }
 

--- a/packages/convex-logto/src/react-session.tsx
+++ b/packages/convex-logto/src/react-session.tsx
@@ -55,7 +55,7 @@ export type ConvexLogtoSessionProviderProps = {
   /**
    * The module re-exporting `logtoSessionApi(...)`'s functions, e.g. `api.auth`.
    * The provider expects the exact names `signIn` / `callback` / `refresh` /
-   * `signOut` / `sessionValid`.
+   * `signOut` / `signOutEverywhere` / `sessionValid`.
    */
   sessionApi: LogtoSessionApi;
   /**
@@ -323,6 +323,14 @@ export type LogtoSessionAuth = {
     postLogoutRedirectUri?: string;
     federated?: boolean;
   }) => Promise<void>;
+  /**
+   * Delete every component session for the current subject, then end this
+   * browser's Logto SSO session. Other live devices drop through the existing
+   * reactive revocation subscription.
+   */
+  signOutEverywhere: (options?: {
+    postLogoutRedirectUri?: string;
+  }) => Promise<void>;
 };
 
 /**
@@ -330,7 +338,8 @@ export type LogtoSessionAuth = {
  * from Convex, so they're true only once Convex has accepted the token.
  *
  * @example
- * const { isAuthenticated, user, signIn, signOut } = useLogtoAuth();
+ * const { isAuthenticated, user, signIn, signOut, signOutEverywhere } =
+ *   useLogtoAuth();
  */
 export function useLogtoAuth(): LogtoSessionAuth {
   const { engine } = useSessionContext("useLogtoAuth");
@@ -349,6 +358,11 @@ export function useLogtoAuth(): LogtoSessionAuth {
       engine.signOut(options),
     [engine],
   );
+  const signOutEverywhere = useCallback(
+    (options?: { postLogoutRedirectUri?: string }) =>
+      engine.signOutEverywhere(options),
+    [engine],
+  );
   return useMemo(
     () => ({
       isAuthenticated,
@@ -356,8 +370,16 @@ export function useLogtoAuth(): LogtoSessionAuth {
       user: isAuthenticated ? snapshot.user : undefined,
       signIn,
       signOut,
+      signOutEverywhere,
     }),
-    [isAuthenticated, isLoading, snapshot.user, signIn, signOut],
+    [
+      isAuthenticated,
+      isLoading,
+      snapshot.user,
+      signIn,
+      signOut,
+      signOutEverywhere,
+    ],
   );
 }
 

--- a/packages/convex-logto/src/session-client.test.ts
+++ b/packages/convex-logto/src/session-client.test.ts
@@ -67,6 +67,7 @@ const api = {
   callback: { fn: "callback" },
   refresh: { fn: "refresh" },
   signOut: { fn: "signOut" },
+  signOutEverywhere: { fn: "signOutEverywhere" },
   sessionValid: { fn: "sessionValid" },
 } as unknown as LogtoSessionApi;
 
@@ -75,6 +76,7 @@ type Handlers = {
   callback: ReturnType<typeof vi.fn>;
   refresh: ReturnType<typeof vi.fn>;
   signOut: ReturnType<typeof vi.fn>;
+  signOutEverywhere: ReturnType<typeof vi.fn>;
 };
 
 function makeHarness(options?: {
@@ -86,12 +88,14 @@ function makeHarness(options?: {
   storedSession?: StoredSession;
   cookieBootstrap?: { initialSessionId?: string | null };
   deviceBinding?: SessionDeviceBinding;
+  sessionApi?: LogtoSessionApi;
 }) {
   const handlers: Handlers = {
     signIn: vi.fn(),
     callback: vi.fn(),
     refresh: vi.fn(),
     signOut: vi.fn(),
+    signOutEverywhere: vi.fn(),
   };
   const transport = {
     action: (ref: unknown, args: unknown) =>
@@ -113,7 +117,7 @@ function makeHarness(options?: {
   const onAuthError = vi.fn();
   const engine = new SessionAuthEngine({
     transport,
-    api,
+    api: options?.sessionApi ?? api,
     storage,
     callbackPath: "/callback",
     afterSignIn: options?.afterSignIn ?? "/",
@@ -701,6 +705,99 @@ describe("signOut", () => {
     const { engine, handlers } = makeHarness();
     await engine.signOut();
     expect(handlers.signOut).not.toHaveBeenCalled();
+  });
+});
+
+describe("signOutEverywhere", () => {
+  it("clears local state first, kills the subject sessions, then navigates to Logto", async () => {
+    const { engine, storage, handlers } = makeHarness();
+    storage.writeSession({ token: "t1", sessionId: "s1" });
+    storage.writeIdToken(freshToken());
+    let sessionAtCallTime: unknown = "not-called";
+    handlers.signOutEverywhere.mockImplementation((args: unknown) => {
+      sessionAtCallTime = storage.readSession();
+      expect(args).toEqual({
+        sessionToken: "t1",
+        postLogoutRedirectUri: "https://app.example.com/signed-out",
+      });
+      return Promise.resolve({
+        count: 3,
+        endSessionUrl: "https://auth.example.com/oidc/session/end?all=1",
+      });
+    });
+
+    await engine.signOutEverywhere({
+      postLogoutRedirectUri: "https://app.example.com/signed-out",
+    });
+
+    expect(sessionAtCallTime).toBeNull();
+    expect(engine.getSnapshot().status).toBe("unauthenticated");
+    expect(window.location.assign).toHaveBeenCalledWith(
+      "https://auth.example.com/oidc/session/end?all=1",
+    );
+  });
+
+  it("clears locally before reporting a legacy app module's missing action", async () => {
+    const legacyApi = {
+      signIn: api.signIn,
+      callback: api.callback,
+      refresh: api.refresh,
+      signOut: api.signOut,
+      sessionValid: api.sessionValid,
+    } as LogtoSessionApi;
+    const { engine, storage, handlers, onAuthError } = makeHarness({
+      sessionApi: legacyApi,
+    });
+    storage.writeSession({ token: "t1", sessionId: "s1" });
+
+    await expect(engine.signOutEverywhere()).rejects.toThrow(
+      /Re-export signOutEverywhere from logtoSessionApi/,
+    );
+
+    expect(storage.readSession()).toBeNull();
+    expect(engine.getSnapshot().status).toBe("unauthenticated");
+    expect(handlers.signOutEverywhere).not.toHaveBeenCalled();
+    expect(onAuthError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringMatching(/sessionApi does not export it/),
+      }),
+    );
+  });
+
+  it("translates the generated-api proxy's missing-function response", async () => {
+    const { engine, storage, handlers, onAuthError } = makeHarness();
+    storage.writeSession({ token: "t1", sessionId: "s1" });
+    handlers.signOutEverywhere.mockRejectedValue(
+      new Error("Could not find public function auth:signOutEverywhere"),
+    );
+
+    await expect(engine.signOutEverywhere()).rejects.toThrow(
+      /Re-export signOutEverywhere from logtoSessionApi/,
+    );
+
+    expect(storage.readSession()).toBeNull();
+    expect(engine.getSnapshot().status).toBe("unauthenticated");
+    expect(onAuthError).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Error" }),
+    );
+  });
+
+  it("rejects a server failure after completing the unblockable local clear", async () => {
+    const { engine, storage, handlers, onAuthError } = makeHarness();
+    storage.writeSession({ token: "t1", sessionId: "s1" });
+    handlers.signOutEverywhere.mockRejectedValue(
+      new Error("network unavailable"),
+    );
+
+    await expect(engine.signOutEverywhere()).rejects.toThrow(
+      "network unavailable",
+    );
+
+    expect(storage.readSession()).toBeNull();
+    expect(engine.getSnapshot().status).toBe("unauthenticated");
+    expect(onAuthError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "network unavailable" }),
+    );
   });
 });
 

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -92,6 +92,33 @@ export class SessionSignOutError extends Error {
   }
 }
 
+class SessionApiUpgradeError extends Error {}
+
+function signOutEverywhereUpgradeError(
+  cause?: unknown,
+): SessionApiUpgradeError {
+  return new SessionApiUpgradeError(
+    "convex-logto: signOutEverywhere is unavailable because sessionApi does not export it. Re-export signOutEverywhere from logtoSessionApi(components.logto) in your Convex auth module, then deploy your Convex functions.",
+    cause === undefined ? undefined : { cause },
+  );
+}
+
+function isMissingSignOutEverywhereAction(error: unknown): boolean {
+  const data =
+    error instanceof ConvexError
+      ? (error.data as { code?: unknown; message?: unknown })
+      : undefined;
+  if (data?.code === "sign_out_everywhere_unavailable") return true;
+  const message = [
+    error instanceof Error ? error.message : "",
+    typeof data?.message === "string" ? data.message : "",
+  ].join(" ");
+  return (
+    message.includes("signOutEverywhere") &&
+    /(?:function.*not found|could not find.*function)/i.test(message)
+  );
+}
+
 export function decodeJwtPayload(
   token: string,
 ): Record<string, unknown> | null {
@@ -722,6 +749,56 @@ export class SessionAuthEngine {
     postLogoutRedirectUri?: string;
     federated?: boolean;
   }): Promise<void> {
+    await this.performSignOut({
+      postLogoutRedirectUri: options?.postLogoutRedirectUri,
+      federated: options?.federated !== false,
+      requireServerSuccess: false,
+      revoke: async (sessionToken, postLogoutRedirectUri) =>
+        await this.options.transport.action(this.options.api.signOut, {
+          sessionToken,
+          postLogoutRedirectUri,
+        }),
+    });
+  }
+
+  async signOutEverywhere(options?: {
+    postLogoutRedirectUri?: string;
+  }): Promise<void> {
+    const action = this.options.api.signOutEverywhere;
+    await this.performSignOut({
+      postLogoutRedirectUri: options?.postLogoutRedirectUri,
+      federated: true,
+      // A single-device sign-out is locally complete even if the network is
+      // down. "Everywhere" is not: report failure when the subject-wide
+      // mutation did not run so callers never mistake a partial result for
+      // success.
+      requireServerSuccess: true,
+      revoke: async (sessionToken, postLogoutRedirectUri) => {
+        if (action === undefined) throw signOutEverywhereUpgradeError();
+        try {
+          return await this.options.transport.action(action, {
+            sessionToken,
+            postLogoutRedirectUri,
+          });
+        } catch (error) {
+          if (isMissingSignOutEverywhereAction(error)) {
+            throw signOutEverywhereUpgradeError(error);
+          }
+          throw error;
+        }
+      },
+    });
+  }
+
+  private async performSignOut(options: {
+    postLogoutRedirectUri?: string;
+    federated: boolean;
+    requireServerSuccess: boolean;
+    revoke: (
+      sessionToken: string,
+      postLogoutRedirectUri: string,
+    ) => Promise<{ endSessionUrl?: string }>;
+  }): Promise<void> {
     try {
       await this.prepareStorage();
     } catch (error) {
@@ -759,22 +836,33 @@ export class SessionAuthEngine {
     let serverSessionStatus: SessionSignOutServerStatus =
       session === null ? "not_present" : "revocation_failed";
     let serverRevocationError: unknown;
+    let fatalServerError: Error | undefined;
     if (session !== null) {
       postLogoutRedirectUri =
-        options?.postLogoutRedirectUri ??
+        options.postLogoutRedirectUri ??
         this.options.authFlow?.redirectUri ??
         window.location.origin;
       try {
-        ({ endSessionUrl } = await this.options.transport.action(
-          this.options.api.signOut,
-          {
-            sessionToken: session.token,
-            postLogoutRedirectUri,
-          },
+        ({ endSessionUrl } = await options.revoke(
+          session.token,
+          postLogoutRedirectUri,
         ));
         serverSessionStatus = "revoked";
       } catch (error) {
         serverRevocationError = error;
+        if (
+          error instanceof SessionApiUpgradeError ||
+          options.requireServerSuccess
+        ) {
+          fatalServerError =
+            error instanceof Error
+              ? error
+              : new Error(
+                  "convex-logto: the server could not complete sign out everywhere.",
+                  { cause: error },
+                );
+          this.reportError(fatalServerError);
+        }
         // Best effort when local cleanup succeeded; a combined failure is
         // converted into a loud SessionSignOutError below.
       }
@@ -800,7 +888,7 @@ export class SessionAuthEngine {
     }
     // Federated by default: also end Logto's SSO session so the next sign-in
     // isn't silent. The post sign-out redirect URI must be registered on the app.
-    if (options?.federated !== false && endSessionUrl !== undefined) {
+    if (options.federated && endSessionUrl !== undefined) {
       if (
         this.options.authFlow !== undefined &&
         postLogoutRedirectUri !== undefined
@@ -818,6 +906,7 @@ export class SessionAuthEngine {
       }
     }
     if (signOutError !== undefined) throw signOutError;
+    if (fatalServerError !== undefined) throw fatalServerError;
   }
 
   // -- external events --

--- a/packages/convex-logto/src/session-cookie.test.ts
+++ b/packages/convex-logto/src/session-cookie.test.ts
@@ -19,7 +19,12 @@ const BASE_PATH = "/api/logto";
 
 const api = anyApi.auth as unknown as LogtoSessionApi;
 
-type HandlerName = "signIn" | "callback" | "refresh" | "signOut";
+type HandlerName =
+  | "signIn"
+  | "callback"
+  | "refresh"
+  | "signOut"
+  | "signOutEverywhere";
 type Handlers = Record<HandlerName, ReturnType<typeof vi.fn>>;
 
 function makeHarness(options?: { deviceBinding?: boolean }) {
@@ -40,6 +45,10 @@ function makeHarness(options?: { deviceBinding?: boolean }) {
     }),
     signOut: vi.fn().mockResolvedValue({
       endSessionUrl: "https://auth.example.com/oidc/session/end",
+    }),
+    signOutEverywhere: vi.fn().mockResolvedValue({
+      count: 2,
+      endSessionUrl: "https://auth.example.com/oidc/session/end?all=1",
     }),
   };
   const action = vi.fn((reference: unknown, args: unknown) => {
@@ -291,6 +300,52 @@ describe("cookie session flows", () => {
     });
   });
 
+  it("multiplexes sign out everywhere through the existing sign-out route", async () => {
+    const { handler, handlers } = makeHarness();
+    const response = await handler(
+      request("sign-out", {
+        cookie: cookie("session-token-2"),
+        body: { postLogoutRedirectUri: APP_ORIGIN, everywhere: true },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(handlers.signOutEverywhere).toHaveBeenCalledWith({
+      sessionToken: "session-token-2",
+      postLogoutRedirectUri: APP_ORIGIN,
+    });
+    expect(handlers.signOut).not.toHaveBeenCalled();
+    expect(response.headers.get("set-cookie")).toContain("Max-Age=0");
+    await expect(response.json()).resolves.toEqual({
+      count: 2,
+      endSessionUrl: "https://auth.example.com/oidc/session/end?all=1",
+    });
+  });
+
+  it("translates a legacy app module's missing sign-out-everywhere action", async () => {
+    const { handler, handlers } = makeHarness();
+    handlers.signOutEverywhere.mockRejectedValue(
+      new Error("Function not found: auth:signOutEverywhere"),
+    );
+
+    const response = await handler(
+      request("sign-out", {
+        cookie: cookie("session-token-2"),
+        body: { everywhere: true },
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(response.headers.get("set-cookie")).toContain("Max-Age=0");
+    await expect(response.json()).resolves.toMatchObject({
+      error: {
+        kind: "terminal",
+        code: "sign_out_everywhere_unavailable",
+        message: expect.stringMatching(/re-export signOutEverywhere/),
+      },
+    });
+  });
+
   it("clears a terminal token cookie", async () => {
     const { handler, handlers } = makeHarness();
     handlers.refresh.mockRejectedValueOnce(
@@ -412,6 +467,31 @@ describe("browser transport", () => {
     expect(new Headers(init?.headers).get(LOGTO_SESSION_CSRF_HEADER)).toBe(
       LOGTO_SESSION_CSRF_VALUE,
     );
+  });
+
+  it("dispatches sign out everywhere through the sign-out route selector", async () => {
+    const fetchMock = vi.fn<typeof globalThis.fetch>().mockResolvedValue(
+      Response.json({
+        count: 2,
+        endSessionUrl: "https://auth.example.com/oidc/session/end?all=1",
+      }),
+    );
+    const transport = createLogtoSessionCookieTransport(api, {
+      endpoint: BASE_PATH,
+      fetch: fetchMock,
+    });
+
+    await transport.action(api.signOutEverywhere!, {
+      sessionToken: COOKIE_SESSION_MARKER,
+      postLogoutRedirectUri: APP_ORIGIN,
+    });
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe(`${BASE_PATH}/sign-out`);
+    expect(JSON.parse(String(init?.body))).toEqual({
+      postLogoutRedirectUri: APP_ORIGIN,
+      everywhere: true,
+    });
   });
 });
 

--- a/packages/convex-logto/src/session-cookie.ts
+++ b/packages/convex-logto/src/session-cookie.ts
@@ -247,6 +247,14 @@ function errorData(error: unknown): SessionError | null {
     : null;
 }
 
+function isMissingSignOutEverywhereAction(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return (
+    message.includes("signOutEverywhere") &&
+    /(?:function.*not found|could not find.*function)/i.test(message)
+  );
+}
+
 class RequestValidationError extends Error {}
 
 function actionErrorResponse(
@@ -309,6 +317,18 @@ function optionalString(
     throw new RequestValidationError(
       `${name} must be a non-empty string when provided`,
     );
+  }
+  return value;
+}
+
+function optionalBoolean(
+  body: Record<string, unknown>,
+  name: string,
+): boolean | undefined {
+  const value = body[name];
+  if (value === undefined) return undefined;
+  if (typeof value !== "boolean") {
+    throw new RequestValidationError(`${name} must be a boolean when provided`);
   }
   return value;
 }
@@ -448,16 +468,43 @@ export function createLogtoSessionCookieHandler(
             body,
             "postLogoutRedirectUri",
           );
+          const everywhere = optionalBoolean(body, "everywhere") ?? false;
           const sessionToken = readCookie(request);
           if (sessionToken === null)
             return jsonResponse({}, { headers }, origin);
           try {
-            const result = await options.action(options.sessionApi.signOut, {
-              sessionToken,
-              postLogoutRedirectUri,
-            });
+            const signOutEverywhere = options.sessionApi.signOutEverywhere;
+            if (everywhere && signOutEverywhere === undefined) {
+              throw new RequestValidationError(
+                "sessionApi must export signOutEverywhere before using this operation",
+              );
+            }
+            const result = everywhere
+              ? await options.action(signOutEverywhere!, {
+                  sessionToken,
+                  postLogoutRedirectUri,
+                })
+              : await options.action(options.sessionApi.signOut, {
+                  sessionToken,
+                  postLogoutRedirectUri,
+                });
             return jsonResponse(result, { headers }, origin);
           } catch (error) {
+            if (error instanceof RequestValidationError) throw error;
+            if (everywhere && isMissingSignOutEverywhereAction(error)) {
+              return jsonResponse(
+                {
+                  error: {
+                    kind: "terminal",
+                    code: "sign_out_everywhere_unavailable",
+                    message:
+                      "convex-logto: sessionApi must re-export signOutEverywhere from logtoSessionApi(components.logto), then deploy the Convex functions.",
+                  } satisfies SessionError,
+                },
+                { status: 409, headers },
+                origin,
+              );
+            }
             return actionErrorResponse(error, origin, headers);
           }
         }
@@ -637,6 +684,10 @@ export function createLogtoSessionCookieTransport(
     callback: getFunctionName(sessionApi.callback),
     refresh: getFunctionName(sessionApi.refresh),
     signOut: getFunctionName(sessionApi.signOut),
+    signOutEverywhere:
+      sessionApi.signOutEverywhere === undefined
+        ? undefined
+        : getFunctionName(sessionApi.signOutEverywhere),
   };
 
   const post = async (route: CookieRoute, body: unknown): Promise<unknown> => {
@@ -686,6 +737,16 @@ export function createLogtoSessionCookieTransport(
         return (await post("sign-out", {
           postLogoutRedirectUri: (args as { postLogoutRedirectUri?: string })
             .postLogoutRedirectUri,
+        })) as Action["_returnType"];
+      }
+      if (
+        actionNames.signOutEverywhere !== undefined &&
+        actionName === actionNames.signOutEverywhere
+      ) {
+        return (await post("sign-out", {
+          postLogoutRedirectUri: (args as { postLogoutRedirectUri?: string })
+            .postLogoutRedirectUri,
+          everywhere: true,
         })) as Action["_returnType"];
       }
       throw new Error(

--- a/packages/convex-logto/src/session.test.ts
+++ b/packages/convex-logto/src/session.test.ts
@@ -3,7 +3,7 @@ import { hashToken } from "./component/core";
 import { logtoSessionApi, type LogtoSessionComponent } from "./session";
 
 describe("logtoSessionApi signOutEverywhere", () => {
-  it("hashes the caller token, delegates subject derivation, and builds federated logout", async () => {
+  it("passes the default reuse policy and builds logout without an ID-token hint", async () => {
     const mutation = { fn: "killSubjectSessionsByToken" };
     const component = {
       lib: { killSubjectSessionsByToken: mutation },
@@ -14,10 +14,11 @@ describe("logtoSessionApi signOutEverywhere", () => {
       clientSecret: "secret",
     });
     const runMutation = vi.fn().mockResolvedValue({
+      outcome: "signed-out",
       count: 3,
       subject: "subject-from-session",
-      idTokenHint: "last-id-token",
     });
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_234_567);
     type Handler = (
       ctx: { runMutation: typeof runMutation },
       args: { sessionToken: string; postLogoutRedirectUri?: string },
@@ -36,7 +37,10 @@ describe("logtoSessionApi signOutEverywhere", () => {
 
     expect(runMutation).toHaveBeenCalledWith(mutation, {
       presentedHash: await hashToken("caller-session-token"),
+      now: 1_234_567,
+      reuseWindowMs: 10_000,
     });
+    now.mockRestore();
     expect(result.count).toBe(3);
     const endSessionUrl = new URL(result.endSessionUrl!);
     expect(endSessionUrl.origin).toBe("https://auth.example.com");
@@ -45,8 +49,41 @@ describe("logtoSessionApi signOutEverywhere", () => {
     expect(endSessionUrl.searchParams.get("post_logout_redirect_uri")).toBe(
       "https://app.example.com/signed-out",
     );
-    expect(endSessionUrl.searchParams.get("id_token_hint")).toBe(
-      "last-id-token",
-    );
+    expect(endSessionUrl.searchParams.get("id_token_hint")).toBeNull();
+  });
+
+  it("turns committed stale-token containment into the terminal reuse error", async () => {
+    const mutation = { fn: "killSubjectSessionsByToken" };
+    const component = {
+      lib: { killSubjectSessionsByToken: mutation },
+    } as unknown as LogtoSessionComponent;
+    const api = logtoSessionApi(component, {
+      endpoint: "https://auth.example.com",
+      appId: "app-1",
+      clientSecret: "secret",
+      reuseWindowMs: 321,
+    });
+    const runMutation = vi.fn().mockResolvedValue({ outcome: "reuse" });
+    type Handler = (
+      ctx: { runMutation: typeof runMutation },
+      args: { sessionToken: string },
+    ) => Promise<{ endSessionUrl?: string; count: number }>;
+    const handler = (
+      api.signOutEverywhere as unknown as Record<string, Handler>
+    )["_handler"]!;
+
+    await expect(
+      handler({ runMutation }, { sessionToken: "stale-token" }),
+    ).rejects.toMatchObject({
+      data: {
+        kind: "terminal",
+        code: "session_reuse_detected",
+      },
+    });
+    expect(runMutation).toHaveBeenCalledWith(mutation, {
+      presentedHash: await hashToken("stale-token"),
+      now: expect.any(Number),
+      reuseWindowMs: 321,
+    });
   });
 });

--- a/packages/convex-logto/src/session.test.ts
+++ b/packages/convex-logto/src/session.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { hashToken } from "./component/core";
+import { logtoSessionApi, type LogtoSessionComponent } from "./session";
+
+describe("logtoSessionApi signOutEverywhere", () => {
+  it("hashes the caller token, delegates subject derivation, and builds federated logout", async () => {
+    const mutation = { fn: "killSubjectSessionsByToken" };
+    const component = {
+      lib: { killSubjectSessionsByToken: mutation },
+    } as unknown as LogtoSessionComponent;
+    const api = logtoSessionApi(component, {
+      endpoint: "https://auth.example.com",
+      appId: "app-1",
+      clientSecret: "secret",
+    });
+    const runMutation = vi.fn().mockResolvedValue({
+      count: 3,
+      subject: "subject-from-session",
+      idTokenHint: "last-id-token",
+    });
+    type Handler = (
+      ctx: { runMutation: typeof runMutation },
+      args: { sessionToken: string; postLogoutRedirectUri?: string },
+    ) => Promise<{ endSessionUrl?: string; count: number }>;
+    const handler = (
+      api.signOutEverywhere as unknown as Record<string, Handler>
+    )["_handler"]!;
+
+    const result = await handler(
+      { runMutation },
+      {
+        sessionToken: "caller-session-token",
+        postLogoutRedirectUri: "https://app.example.com/signed-out",
+      },
+    );
+
+    expect(runMutation).toHaveBeenCalledWith(mutation, {
+      presentedHash: await hashToken("caller-session-token"),
+    });
+    expect(result.count).toBe(3);
+    const endSessionUrl = new URL(result.endSessionUrl!);
+    expect(endSessionUrl.origin).toBe("https://auth.example.com");
+    expect(endSessionUrl.pathname).toBe("/oidc/session/end");
+    expect(endSessionUrl.searchParams.get("client_id")).toBe("app-1");
+    expect(endSessionUrl.searchParams.get("post_logout_redirect_uri")).toBe(
+      "https://app.example.com/signed-out",
+    );
+    expect(endSessionUrl.searchParams.get("id_token_hint")).toBe(
+      "last-id-token",
+    );
+  });
+});

--- a/packages/convex-logto/src/session.ts
+++ b/packages/convex-logto/src/session.ts
@@ -7,7 +7,12 @@ import {
   type RegisteredQuery,
 } from "convex/server";
 import { ConvexError, v } from "convex/values";
-import { buildEndSessionUrl, hashToken } from "./component/core.js";
+import {
+  DEFAULT_REUSE_WINDOW_MS,
+  buildEndSessionUrl,
+  hashToken,
+  sessionReuseDetectedError,
+} from "./component/core.js";
 import { readEndpointAndAppId } from "./config";
 
 // --- component reference typing ---------------------------------------------
@@ -114,8 +119,9 @@ export type LogtoSessionComponent = {
     killSubjectSessionsByToken: FunctionReference<
       "mutation",
       "internal",
-      { presentedHash: string },
-      { count: number; subject: string; idTokenHint: string }
+      { presentedHash: string; now: number; reuseWindowMs: number },
+      | { outcome: "signed-out"; count: number; subject: string }
+      | { outcome: "reuse" }
     >;
     killSessionsBySid: FunctionReference<
       "mutation",
@@ -388,15 +394,19 @@ export function logtoSessionApi(
         const { endpoint, appId } = readSessionConfig(options);
         const result = await ctx.runMutation(
           component.lib.killSubjectSessionsByToken,
-          { presentedHash: await hashToken(args.sessionToken) },
+          {
+            presentedHash: await hashToken(args.sessionToken),
+            now: Date.now(),
+            reuseWindowMs: options.reuseWindowMs ?? DEFAULT_REUSE_WINDOW_MS,
+          },
         );
+        if (result.outcome === "reuse") throw sessionReuseDetectedError();
         return {
           count: result.count,
           endSessionUrl: buildEndSessionUrl({
             endpoint,
             appId,
             postLogoutRedirectUri: args.postLogoutRedirectUri,
-            idTokenHint: result.idTokenHint,
           }),
         };
       },

--- a/packages/convex-logto/src/session.ts
+++ b/packages/convex-logto/src/session.ts
@@ -7,6 +7,7 @@ import {
   type RegisteredQuery,
 } from "convex/server";
 import { ConvexError, v } from "convex/values";
+import { buildEndSessionUrl, hashToken } from "./component/core.js";
 import { readEndpointAndAppId } from "./config";
 
 // --- component reference typing ---------------------------------------------
@@ -110,6 +111,12 @@ export type LogtoSessionComponent = {
       { subject: string },
       number
     >;
+    killSubjectSessionsByToken: FunctionReference<
+      "mutation",
+      "internal",
+      { presentedHash: string },
+      { count: number; subject: string; idTokenHint: string }
+    >;
     killSessionsBySid: FunctionReference<
       "mutation",
       "internal",
@@ -134,7 +141,7 @@ export type LogtoSessionComponent = {
 // --- public function surface -------------------------------------------------
 
 /**
- * The five public functions {@link logtoSessionApi} registers, as the frontend
+ * The six public functions {@link logtoSessionApi} registers, as the frontend
  * sees them. `ConvexLogtoSessionProvider` takes a reference to the module that
  * re-exports them (e.g. `api.auth`).
  */
@@ -172,6 +179,16 @@ export type LogtoSessionApi = {
     "public",
     { sessionToken: string; postLogoutRedirectUri?: string },
     { endSessionUrl?: string }
+  >;
+  /**
+   * Optional only for rolling upgrades: providers feature-detect an app module
+   * that has not re-exported the new action yet and report the exact fix.
+   */
+  signOutEverywhere?: FunctionReference<
+    "action",
+    "public",
+    { sessionToken: string; postLogoutRedirectUri?: string },
+    { endSessionUrl?: string; count: number }
   >;
   sessionValid: FunctionReference<
     "query",
@@ -225,15 +242,21 @@ function readSessionConfig(options: LogtoSessionApiOptions): {
  * Build the public auth functions for session mode, backed by the Logto session
  * component. Reads `LOGTO_ENDPOINT`, `LOGTO_APP_ID` and `LOGTO_CLIENT_SECRET`
  * from the deployment's env (the secret never leaves the server). Re-export all
- * five — the frontend provider expects these exact names:
+ * six — the frontend provider expects these exact names:
  *
  * @example
  * // convex/auth.ts
  * import { components } from "./_generated/api";
  * import { logtoSessionApi } from "convex-logto";
  *
- * export const { signIn, callback, refresh, signOut, sessionValid } =
- *   logtoSessionApi(components.logto);
+ * export const {
+ *   signIn,
+ *   callback,
+ *   refresh,
+ *   signOut,
+ *   signOutEverywhere,
+ *   sessionValid,
+ * } = logtoSessionApi(components.logto);
  */
 export function logtoSessionApi(
   component: LogtoSessionComponent,
@@ -268,6 +291,11 @@ export function logtoSessionApi(
     "public",
     { sessionToken: string; postLogoutRedirectUri?: string },
     Promise<{ endSessionUrl?: string }>
+  >;
+  signOutEverywhere: RegisteredAction<
+    "public",
+    { sessionToken: string; postLogoutRedirectUri?: string },
+    Promise<{ endSessionUrl?: string; count: number }>
   >;
   sessionValid: RegisteredQuery<
     "public",
@@ -345,6 +373,32 @@ export function logtoSessionApi(
           sessionToken: args.sessionToken,
           postLogoutRedirectUri: args.postLogoutRedirectUri,
         });
+      },
+    }),
+    signOutEverywhere: actionGeneric({
+      args: {
+        sessionToken: v.string(),
+        postLogoutRedirectUri: v.optional(v.string()),
+      },
+      returns: v.object({
+        endSessionUrl: v.optional(v.string()),
+        count: v.number(),
+      }),
+      handler: async (ctx, args) => {
+        const { endpoint, appId } = readSessionConfig(options);
+        const result = await ctx.runMutation(
+          component.lib.killSubjectSessionsByToken,
+          { presentedHash: await hashToken(args.sessionToken) },
+        );
+        return {
+          count: result.count,
+          endSessionUrl: buildEndSessionUrl({
+            endpoint,
+            appId,
+            postLogoutRedirectUri: args.postLogoutRedirectUri,
+            idTokenHint: result.idTokenHint,
+          }),
+        };
       },
     }),
     sessionValid: queryGeneric({


### PR DESCRIPTION
Closes #32

## Summary

- add a token-scoped atomic component mutation and public signOutEverywhere action
- expose sign out everywhere through the web and native session providers, including cookie transport compatibility and clear rolling-upgrade errors
- document reactive revocation, the Logto OP-session boundary, and deferred refresh-grant expiry

## Design notes

- Cookie transport multiplexes this operation through the existing sign-out route so the settled four-route contract remains intact.
- LogtoSessionApi keeps the new reference optional at the consumer boundary only, allowing providers to translate a stale app deployment into an actionable re-export/deploy error; logtoSessionApi itself always returns all six functions.
- The calling device is cleared before the server request, and subject-wide server failures reject after that unblockable cleanup; normal single-device sign-out remains best effort.
- Previous-token authorization uses the same configured reuse window as refresh; a stale previous token deletes only its matched session and returns the standard terminal reuse error.
- End-session URLs deliberately omit the ID token, matching the shipped signOut path and preventing a public action from disclosing the stored bearer token.

## Validation

- pnpm --filter convex-logto test (224 passed)
- pnpm --filter convex-logto check-types
- pnpm --filter convex-logto lint
- pnpm --filter convex-logto format
- pnpm --filter convex-logto build
- pnpm --filter convex-logto lint:package
- pnpm --filter docs build
- component codegen regenerated from examples/vite-react-session

Changeset: .changeset/frank-ties-travel.md
Follow-up: #49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Sign out everywhere” for web and native sessions.
  * Revokes active sessions across devices and supports optional post-logout redirects.
  * Added federated logout and reactive sign-out updates on other devices.
  * Added clear errors for session reuse, unavailable functionality, and failed revocation.

* **Documentation**
  * Updated API references, guides, and examples to describe the expanded session authentication API and cross-device sign-out behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->