### PR TITLE
fix: surface sign-in initiation failures

### DIFF
--- a/.changeset/nine-jeans-add.md
+++ b/.changeset/nine-jeans-add.md
@@ -1,0 +1,5 @@
+---
+"convex-logto": patch
+---
+
+Report bridge and session sign-in initiation failures through onAuthError.

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -218,7 +218,7 @@ to resolve it from the backend at runtime. Exactly one of the two.
 | `callbackPath` | — | The route that finishes the OIDC redirect. Default `/callback`. Must match a registered Redirect URI's path; only this exact path runs callback handling. |
 | `afterSignIn` | — | Where to go once sign-in completes. Default `/`. `signIn({ returnTo })` overrides it. |
 | `navigate` | — | Soft navigation (your router's `navigate`). Optional for plain Vite; **recommended for any router** (TanStack / Next) so post-sign-in is a soft navigation rather than a full-page reload that drops router state. Prefer a replace-style navigate. Falls back to a hard `location.replace`. |
-| `onAuthError` | — | Called on recoverable sign-in failures (stale/replayed callback, setup errors like `invalid_scope`). The user is returned to the app logged out either way; also logged to the console. |
+| `onAuthError` | — | Called on sign-in initiation failures (Logto unreachable, blocked storage, in-app browser restrictions) and recoverable callback failures (stale/replayed callback, setup errors like `invalid_scope`). Errors are also logged to the console. |
 | `discoveryCache` | — | Cache OIDC discovery + JWKS in sessionStorage. Default `true`. |
 | `scopes` / `resources` | — | Extra OIDC scopes / API resources. `openid`, `profile`, `offline_access`, and `email` are always included. |
 
@@ -241,7 +241,9 @@ const { isAuthenticated, isLoading, user, signIn, signOut } = useLogtoAuth();
 completes — a same-origin path starting with `/` (anything else is rejected, to
 prevent open redirects). Without `returnTo`, the provider's `afterSignIn` is
 used. `signIn(redirectUri: string)` is **deprecated**: set `callbackPath` on the
-provider instead if your callback route isn't `/callback`.
+provider instead if your callback route isn't `/callback`. Event handlers may
+continue to use `void signIn()`: initiation failures are logged and delivered
+to `onAuthError` even though `@logto/react` catches them into SDK state.
 
 ## Session mode (`convex-logto/react-session`)
 
@@ -268,7 +270,7 @@ in the bundle — it talks to the functions from `logtoSessionApi(...)`.
 | `cookieTransport` | — | `{ endpoint?, fetch?, deviceBinding? }`; use the same-site handler instead of exposing the rotating session token to JavaScript. Its reserved `deviceBinding` flag only activates the shared incompatibility assertion. |
 | `initialToken` / `initialSessionId` | — | Paired SSR seed returned by `handler.getInitialToken(request)`. |
 | `reactiveRevocation` | — | Subscribe to session liveness; drop auth live on revocation. Default `true`. |
-| `onAuthError` | — | Recoverable sign-in failures or opted-in device-key storage failures. Also logged to the console. |
+| `onAuthError` | — | Sign-in initiation failures, recoverable callback failures, or opted-in device-key storage failures. Initiation failures are reported before `signIn()` rejects; all are logged to the console. |
 
 There is no callback component to add — the provider completes the exchange on
 `callbackPath` and replace-navigates into the app itself.
@@ -285,7 +287,9 @@ Returns `{ isAuthenticated, isLoading, user, signIn, signOut,
 signOutEverywhere }`.
 
 - `signIn({ returnTo? })` — one round-trip to mint the sign-in URL, then a
-  full-page redirect. `returnTo` must be a same-origin path.
+  full-page redirect. `returnTo` must be a same-origin path. A failed action is
+  delivered to `onAuthError` before the promise rejects, so `void signIn()`
+  remains observable.
 - `signOut({ postLogoutRedirectUri?, federated? })` — kills the session and
   revokes the Logto grant server-side, clears every tab, then (unless
   `federated: false`) ends the Logto SSO session and returns to
@@ -321,7 +325,7 @@ device-binding option.
 | `sessionApi` | yes | The module re-exporting all six `logtoSessionApi(...)` functions. |
 | `redirectUri` | yes | Custom-scheme or universal-link callback registered as both a Redirect URI and Post sign-out redirect URI in Logto. |
 | `reactiveRevocation` | — | Subscribe to `sessionValid` and clear SecureStore immediately when revoked. Default `true`. |
-| `onAuthError` | — | Receives recoverable OAuth, SecureStore, and system-browser failures; errors are also logged. |
+| `onAuthError` | — | Receives sign-in initiation failures plus recoverable OAuth, SecureStore, and system-browser failures; initiation failures are reported before `signIn()` rejects and all errors are logged. |
 
 `useLogtoAuth()` returns `{ isAuthenticated, isLoading, user, signIn,
 signOut, signOutEverywhere }`. `signIn()` opens and completes the system-browser flow in place.

--- a/docs/content/docs/quick-start.mdx
+++ b/docs/content/docs/quick-start.mdx
@@ -130,6 +130,12 @@ function Header() {
 }
 ```
 
+The `void signIn()` event-handler form is intentional. If starting sign-in
+fails—for example, Logto is unreachable or browser storage is blocked—the
+provider logs the failure and delivers it to `onAuthError`, even though
+`@logto/react` catches the underlying rejection into its SDK error state. Pass
+`onAuthError` to `ConvexLogtoProvider` to show a toast or send telemetry.
+
 `signOut()` ends the Logto session and returns the user to your app's origin (the
 **Post sign-out redirect URI** from step 1). Pass `signOut("https://app.com/bye")`
 to land somewhere else — just register that URI too.

--- a/docs/content/docs/react-native.mdx
+++ b/docs/content/docs/react-native.mdx
@@ -286,8 +286,9 @@ devices, and always ends this device's Logto browser session.
 
 Native session mode therefore has no `tokenStorage`, `cookieTransport`, or
 `deviceBinding` provider props. If SecureStore is unavailable or fails, auth
-fails loudly through `onAuthError`; it never falls back to AsyncStorage or an
-unbound plaintext credential.
+fails loudly through `onAuthError`; a sign-in action or system-browser
+initiation failure is likewise reported before `signIn()` rejects. It never
+falls back to AsyncStorage or an unbound plaintext credential.
 
 ## Expo SDK and `@logto/rn` versions
 

--- a/docs/content/docs/session-mode.mdx
+++ b/docs/content/docs/session-mode.mdx
@@ -507,7 +507,7 @@ destroy the grant.
 | `cookieTransport` | — | `{ endpoint?, fetch?, deviceBinding? }`: move the rotating session token into a persistent same-site HttpOnly cookie whose 190-day lifetime renews on every rotation. The reserved `deviceBinding` flag only activates the shared incompatibility assertion. |
 | `initialToken` / `initialSessionId` | — | Paired values from `handler.getInitialToken(request)` for authenticated SSR/hydration. |
 | `reactiveRevocation` | `true` | Subscribe to session liveness and drop auth live on revocation. |
-| `onAuthError` | — | Recoverable sign-in failures and opted-in device-key storage failures. |
+| `onAuthError` | — | Sign-in initiation and callback failures, plus opted-in device-key storage failures. Initiation failures are reported before `signIn()` rejects, so `void signIn()` remains observable. |
 
 `logtoSessionApi(component, opts?)` accepts `scopes`, `resources` (server-set —
 the browser can't request its own), `reuseWindowMs`, and env overrides.

--- a/packages/convex-logto/README.md
+++ b/packages/convex-logto/README.md
@@ -124,6 +124,10 @@ function Header() {
 }
 ```
 
+The `void signIn()` handler is safe: initiation failures are logged and routed
+to the provider's `onAuthError`, even when the underlying Logto SDK catches the
+rejection into its own error state.
+
 In any Convex function, the Logto identity is already there:
 
 ```ts

--- a/packages/convex-logto/src/native-session-client.test.ts
+++ b/packages/convex-logto/src/native-session-client.test.ts
@@ -245,6 +245,21 @@ describe("native session adapters", () => {
     await Promise.all([first, second]);
   });
 
+  it("reports and rejects a native sign-in action failure exactly once", async () => {
+    const failure = new Error("Convex unreachable");
+    const { engine, handlers, webBrowser, onAuthError } = makeHarness();
+    handlers.signIn.mockRejectedValue(failure);
+    engine.start();
+    await settled(engine);
+
+    await expect(engine.signIn()).rejects.toBe(failure);
+
+    expect(onAuthError).toHaveBeenCalledTimes(1);
+    expect(onAuthError).toHaveBeenCalledWith(failure);
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(webBrowser.openAuthSessionAsync).not.toHaveBeenCalled();
+  });
+
   it("hydrates a cold start and rotates a stale session token", async () => {
     const secureStore = fakeSecureStore();
     await seedSession(secureStore, staleToken());

--- a/packages/convex-logto/src/native-session-client.test.ts
+++ b/packages/convex-logto/src/native-session-client.test.ts
@@ -260,6 +260,36 @@ describe("native session adapters", () => {
     expect(webBrowser.openAuthSessionAsync).not.toHaveBeenCalled();
   });
 
+  it("reports a callback SecureStore flush failure exactly once", async () => {
+    const secureStore = fakeSecureStore();
+    let deleteCount = 0;
+    secureStore.deleteItemAsync = vi.fn((key: string) => {
+      deleteCount += 1;
+      if (deleteCount === 2) {
+        return Promise.reject(new Error("keystore delete failed"));
+      }
+      secureStore.data.delete(key);
+      return Promise.resolve();
+    });
+    const { engine, handlers, webBrowser, onAuthError } = makeHarness({
+      secureStore,
+    });
+    engine.start();
+    await settled(engine);
+
+    await expect(engine.signIn()).rejects.toBeInstanceOf(
+      NativeSessionStorageError,
+    );
+
+    expect(webBrowser.openAuthSessionAsync).toHaveBeenCalledTimes(1);
+    expect(handlers.callback).not.toHaveBeenCalled();
+    expect(onAuthError).toHaveBeenCalledTimes(1);
+    expect(onAuthError).toHaveBeenCalledWith(
+      expect.any(NativeSessionStorageError),
+    );
+    expect(console.error).toHaveBeenCalledTimes(1);
+  });
+
   it("hydrates a cold start and rotates a stale session token", async () => {
     const secureStore = fakeSecureStore();
     await seedSession(secureStore, staleToken());

--- a/packages/convex-logto/src/native-session.tsx
+++ b/packages/convex-logto/src/native-session.tsx
@@ -51,7 +51,7 @@ export type ConvexLogtoSessionProviderProps = {
   redirectUri: string;
   /** Subscribe to `sessionValid` and drop auth immediately on revocation. Default true. */
   reactiveRevocation?: boolean;
-  /** Recoverable OAuth, SecureStore, and system-browser failures. */
+  /** Sign-in initiation plus recoverable OAuth, SecureStore, and system-browser failures. */
   onAuthError?: (error: Error) => void;
   children: ReactNode;
 };
@@ -171,6 +171,7 @@ export type LogtoSessionAuth = {
   /**
    * Open Logto in the system browser and complete the deep-link return in
    * place. Concurrent calls share the one in-progress native browser flow.
+   * Initiation failures reach `onAuthError` before this promise rejects.
    */
   signIn: () => Promise<void>;
   /**

--- a/packages/convex-logto/src/react-session.tsx
+++ b/packages/convex-logto/src/react-session.tsx
@@ -102,10 +102,10 @@ export type ConvexLogtoSessionProviderProps = {
    */
   reactiveRevocation?: boolean;
   /**
-   * Called when finishing a sign-in fails recoverably (a stale/replayed/forged
-   * callback, Logto unreachable) or opted-in device-key storage fails. The user
-   * is returned to the app logged out either way; use this to toast/telemetry
-   * the failure. Errors are also logged to the console.
+   * Called when starting or finishing sign-in fails recoverably (a failed
+   * action, stale/replayed/forged callback, or Logto unreachable), or opted-in
+   * device-key storage fails. This makes `void signIn()` safe for event
+   * handlers; errors are also logged to the console.
    */
   onAuthError?: (error: Error) => void;
   children: ReactNode;
@@ -309,7 +309,8 @@ export type LogtoSessionAuth = {
    * Start sign-in: one round-trip to mint the sign-in URL, then a full-page
    * redirect to Logto and back to the provider's `callbackPath`. `returnTo`
    * (a same-origin path starting with `/`) is where the user lands after
-   * sign-in completes; it overrides the provider's `afterSignIn`.
+   * sign-in completes; it overrides the provider's `afterSignIn`. Initiation
+   * failures reach `onAuthError` before this promise rejects.
    */
   signIn: (options?: { returnTo?: string }) => Promise<void>;
   /**

--- a/packages/convex-logto/src/react.bridge.test.tsx
+++ b/packages/convex-logto/src/react.bridge.test.tsx
@@ -76,7 +76,7 @@ function ApiProbe() {
 }
 
 let root: Root | null = null;
-async function renderProvider(
+function providerTree(
   props?: Partial<ConvexLogtoProviderProps> & { probe?: boolean },
 ) {
   const { probe, ...rest } = props ?? {};
@@ -86,13 +86,28 @@ async function renderProvider(
     Extract<ConvexLogtoProviderProps, { config: typeof config }>,
     "children"
   >;
+  return (
+    <ConvexLogtoProvider {...merged}>
+      {probe ? <ApiProbe /> : <span />}
+    </ConvexLogtoProvider>
+  );
+}
+
+async function renderProvider(
+  props?: Partial<ConvexLogtoProviderProps> & { probe?: boolean },
+) {
   root = createRoot(document.createElement("div"));
   await act(async () => {
-    root!.render(
-      <ConvexLogtoProvider {...merged}>
-        {probe ? <ApiProbe /> : <span />}
-      </ConvexLogtoProvider>,
-    );
+    root!.render(providerTree(props));
+  });
+}
+
+async function rerenderProvider(
+  props?: Partial<ConvexLogtoProviderProps> & { probe?: boolean },
+) {
+  if (root === null) throw new Error("renderProvider must run first");
+  await act(async () => {
+    root!.render(providerTree(props));
   });
 }
 
@@ -228,15 +243,96 @@ it("signIn({ returnTo }) stashes the destination and uses the callback redirect"
 });
 
 it.each(["//evil.example.com", "https://evil.example.com", "back\\slash"])(
-  "signIn rejects unsafe returnTo %s",
+  "signIn reports and rejects unsafe returnTo %s",
   async (returnTo) => {
-    await renderProvider({ probe: true });
-    await expect(capturedApi!.signIn({ returnTo })).rejects.toThrow(
-      /same-origin path/,
-    );
-    expect(mockLogto.signIn).not.toHaveBeenCalled();
+    const onAuthError = vi.fn();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    try {
+      await renderProvider({ probe: true, onAuthError });
+      await expect(capturedApi!.signIn({ returnTo })).rejects.toThrow(
+        /same-origin path/,
+      );
+      expect(onAuthError).toHaveBeenCalledTimes(1);
+      expect(onAuthError).toHaveBeenCalledWith(expect.any(Error));
+      expect(consoleError).toHaveBeenCalledTimes(1);
+      expect(mockLogto.signIn).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
   },
 );
+
+it("reports an SDK-stored initiation error once when signIn() is discarded", async () => {
+  const failure = new Error("OIDC discovery unreachable");
+  const onAuthError = vi.fn();
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  mockLogto.signIn.mockImplementation(async () => {
+    // @logto/react's proxy catches the real rejection, stores this error in
+    // context, and resolves the public promise.
+    mockLogto.error = failure;
+  });
+  try {
+    await renderProvider({ probe: true, onAuthError });
+    await act(async () => {
+      void capturedApi!.signIn();
+      await Promise.resolve();
+    });
+    expect(onAuthError).not.toHaveBeenCalled();
+
+    // The SDK context update is what exposes the swallowed failure.
+    await rerenderProvider({ probe: true, onAuthError });
+    expect(onAuthError).toHaveBeenCalledTimes(1);
+    expect(onAuthError).toHaveBeenCalledWith(failure);
+    expect(consoleError).toHaveBeenCalledTimes(1);
+
+    // The same SDK error object surviving another render is not a new failure.
+    await rerenderProvider({ probe: true, onAuthError });
+    expect(onAuthError).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledTimes(1);
+  } finally {
+    consoleError.mockRestore();
+  }
+});
+
+it("reports and rethrows a direct signIn rejection exactly once", async () => {
+  const failure = new Error("future SDK rejection");
+  const onAuthError = vi.fn();
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  mockLogto.signIn.mockRejectedValue(failure);
+  try {
+    await renderProvider({ probe: true, onAuthError });
+    await expect(capturedApi!.signIn()).rejects.toBe(failure);
+    expect(onAuthError).toHaveBeenCalledTimes(1);
+    expect(onAuthError).toHaveBeenCalledWith(failure);
+    expect(consoleError).toHaveBeenCalledTimes(1);
+  } finally {
+    consoleError.mockRestore();
+  }
+});
+
+it("does not double-report callback errors through the initiation observer", async () => {
+  setUrl("http://localhost:3000/callback?code=c123&state=s456");
+  mockLogto.error = new Error("callback exchange failed");
+  const navigate = vi.fn();
+  const onAuthError = vi.fn();
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    await renderProvider({ probe: true, navigate, onAuthError });
+    await flush();
+    expect(onAuthError).toHaveBeenCalledTimes(1);
+    expect(String(onAuthError.mock.calls[0]?.[0])).toMatch(/callback/i);
+    expect(consoleError).toHaveBeenCalledTimes(1);
+
+    await rerenderProvider({ probe: true, navigate, onAuthError });
+    await flush();
+    expect(onAuthError).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledTimes(1);
+  } finally {
+    consoleError.mockRestore();
+  }
+});
 
 it("deprecated signIn(string) passes through, warning when the path can't be handled", async () => {
   await renderProvider({ probe: true });

--- a/packages/convex-logto/src/react.tsx
+++ b/packages/convex-logto/src/react.tsx
@@ -41,8 +41,29 @@ const STALE_CALLBACK_TIMEOUT_MS = 10_000;
 
 // Provider-level settings the bridge hooks need but can't take as props, since
 // `ConvexProviderWithAuth` owns the `useAuth` call site.
-const BridgeContext = createContext<{ callbackPath: string }>({
+type BridgeSignInAttempt = {
+  baselineError: Error | undefined;
+  handled: boolean;
+};
+
+type BridgeSignInErrors = {
+  begin: (baselineError: Error | undefined) => BridgeSignInAttempt;
+  fail: (attempt: BridgeSignInAttempt, error: Error) => void;
+  observe: (error: Error | undefined) => void;
+};
+
+const NOOP_SIGN_IN_ERRORS: BridgeSignInErrors = {
+  begin: (baselineError) => ({ baselineError, handled: false }),
+  fail: () => {},
+  observe: () => {},
+};
+
+const BridgeContext = createContext<{
+  callbackPath: string;
+  signInErrors: BridgeSignInErrors;
+}>({
   callbackPath: DEFAULT_CALLBACK_PATH,
+  signInErrors: NOOP_SIGN_IN_ERRORS,
 });
 
 /** True only when the current document is on the provider's callback route. */
@@ -159,7 +180,28 @@ function reportAuthError(
   error: Error,
 ): void {
   console.error(`convex-logto: ${error.message}`, error);
-  onAuthError?.(error);
+  try {
+    onAuthError?.(error);
+  } catch {
+    // A throwing observer must not replace the auth failure or break recovery.
+  }
+}
+
+function asAuthError(error: unknown, fallback: string): Error {
+  return error instanceof Error ? error : new Error(fallback, { cause: error });
+}
+
+/** Observes initiation failures that @logto/react catches into its error state. */
+function LogtoSignInErrorObserver({
+  signInErrors,
+}: {
+  signInErrors: BridgeSignInErrors;
+}) {
+  const { error } = useLogto();
+  useEffect(() => {
+    signInErrors.observe(error);
+  }, [error, signInErrors]);
+  return null;
 }
 
 /** Finishes the OIDC redirect then navigates to `returnTo`/`afterSignIn`; errors are recoverable. */
@@ -317,10 +359,10 @@ type CommonProviderProps = {
    */
   callbackPath?: string;
   /**
-   * Called when finishing a sign-in fails recoverably (a stale/replayed
-   * callback, a setup error like `invalid_scope`). The user is returned to the
-   * app logged out either way; use this to toast/telemetry the failure.
-   * Errors are also logged to the console.
+   * Called when starting or finishing sign-in fails recoverably (Logto
+   * unreachable, blocked storage, a stale/replayed callback, or a setup error
+   * like `invalid_scope`). This makes `void signIn()` safe for event handlers:
+   * failures are observable here and are also logged to the console.
    */
   onAuthError?: (error: Error) => void;
   /**
@@ -445,7 +487,44 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
     }),
     [endpoint, appId, scopesKey, resourcesKey],
   );
-  const bridgeValue = useMemo(() => ({ callbackPath }), [callbackPath]);
+  const onAuthErrorRef = useRef(onAuthError);
+  useEffect(() => {
+    onAuthErrorRef.current = onAuthError;
+  }, [onAuthError]);
+  const signInErrorState = useRef<{
+    latestAttempt: BridgeSignInAttempt | undefined;
+  }>({ latestAttempt: undefined });
+  const signInErrors = useMemo<BridgeSignInErrors>(() => {
+    return {
+      begin: (baselineError) => {
+        const attempt = { baselineError, handled: false };
+        signInErrorState.current.latestAttempt = attempt;
+        return attempt;
+      },
+      fail: (attempt, error) => {
+        if (attempt.handled) return;
+        attempt.handled = true;
+        reportAuthError(onAuthErrorRef.current, error);
+      },
+      observe: (error) => {
+        const attempt = signInErrorState.current.latestAttempt;
+        if (
+          attempt === undefined ||
+          attempt.handled ||
+          error === undefined ||
+          error === attempt.baselineError
+        ) {
+          return;
+        }
+        attempt.handled = true;
+        reportAuthError(onAuthErrorRef.current, error);
+      },
+    };
+  }, []);
+  const bridgeValue = useMemo(
+    () => ({ callbackPath, signInErrors }),
+    [callbackPath, signInErrors],
+  );
 
   if (configQuery && fetched.status === "error") {
     // A missing/broken config query is a setup error: throw so an error
@@ -459,12 +538,20 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
 
   if (!resolved) return <>{fallback}</>;
 
+  const callbackRoute = onCallbackRoute(callbackPath);
+
   return (
     <BridgeContext.Provider value={bridgeValue}>
       <LogtoProvider config={logtoConfig} unstable_enableCache={discoveryCache}>
+        {/* @logto/react catches signIn failures into context and resolves its
+            public promise. Observe that state only on the initiating page;
+            callback errors are already handled by LogtoCallback below. */}
+        {!callbackRoute ? (
+          <LogtoSignInErrorObserver signInErrors={signInErrors} />
+        ) : null}
         {/* Callback handling is gated to the exact callback route: a real OIDC
             redirect always lands as a full-page load, so mount == landing. */}
-        {onCallbackRoute(callbackPath) ? (
+        {callbackRoute ? (
           <LogtoCallback
             afterSignIn={afterSignIn}
             navigate={navigate}
@@ -488,6 +575,8 @@ export type LogtoAuth = {
    * Start sign-in. Redirects to Logto and back to the provider's `callbackPath`.
    * `returnTo` (a same-origin path starting with `/`) is where the user lands
    * after sign-in completes; it overrides the provider's `afterSignIn`.
+   * Initiation failures are always sent to the provider's `onAuthError`, even
+   * when the caller deliberately discards this promise with `void signIn()`.
    */
   signIn: {
     (options?: { returnTo?: string }): Promise<void>;
@@ -515,8 +604,8 @@ export type LogtoAuth = {
  */
 export function useLogtoAuth(): LogtoAuth {
   const { isAuthenticated, isLoading } = useConvexAuth();
-  const { signIn, signOut, getIdTokenClaims } = useLogto();
-  const { callbackPath } = useContext(BridgeContext);
+  const { signIn, signOut, getIdTokenClaims, error } = useLogto();
+  const { callbackPath, signInErrors } = useContext(BridgeContext);
   const [user, setUser] = useState<IdTokenClaims>();
 
   useEffect(() => {
@@ -535,41 +624,50 @@ export function useLogtoAuth(): LogtoAuth {
   }, [isAuthenticated, getIdTokenClaims]);
 
   const doSignIn = useCallback(
-    (redirectUriOrOptions?: string | { returnTo?: string }) => {
-      // Deprecated escape hatch: a full redirect URI. Kept working for 0.3.x
-      // callers, but callback handling only runs on `callbackPath` — warn loudly
-      // when the two can't meet.
-      if (typeof redirectUriOrOptions === "string") {
-        try {
-          const url = new URL(redirectUriOrOptions, window.location.origin);
-          if (url.pathname !== callbackPath) {
-            console.error(
-              `convex-logto: signIn("${redirectUriOrOptions}") uses a path that isn't the ` +
-                `provider's callbackPath ("${callbackPath}"), so the sign-in redirect will ` +
-                `not be handled. Set callbackPath on <ConvexLogtoProvider> instead.`,
-            );
+    async (redirectUriOrOptions?: string | { returnTo?: string }) => {
+      const attempt = signInErrors.begin(error);
+      try {
+        // Deprecated escape hatch: a full redirect URI. Kept working for 0.3.x
+        // callers, but callback handling only runs on `callbackPath` — warn loudly
+        // when the two can't meet.
+        if (typeof redirectUriOrOptions === "string") {
+          try {
+            const url = new URL(redirectUriOrOptions, window.location.origin);
+            if (url.pathname !== callbackPath) {
+              console.error(
+                `convex-logto: signIn("${redirectUriOrOptions}") uses a path that isn't the ` +
+                  `provider's callbackPath ("${callbackPath}"), so the sign-in redirect will ` +
+                  `not be handled. Set callbackPath on <ConvexLogtoProvider> instead.`,
+              );
+            }
+          } catch {
+            // Unparseable URI: let the SDK surface its own error.
           }
-        } catch {
-          // Unparseable URI: let the SDK surface its own error.
+          await signIn(redirectUriOrOptions);
+          return;
         }
-        return signIn(redirectUriOrOptions);
-      }
-      const returnTo = redirectUriOrOptions?.returnTo;
-      if (returnTo !== undefined) {
-        if (!isSafeReturnTo(returnTo)) {
-          return Promise.reject(
-            new Error(
+        const returnTo = redirectUriOrOptions?.returnTo;
+        if (returnTo !== undefined) {
+          if (!isSafeReturnTo(returnTo)) {
+            throw new Error(
               `convex-logto: signIn returnTo must be a same-origin path starting with "/" ` +
                 `(got "${returnTo}") — full URLs and protocol-relative paths are rejected ` +
                 `to prevent open redirects.`,
-            ),
-          );
+            );
+          }
+          stashReturnTo(returnTo);
         }
-        stashReturnTo(returnTo);
+        await signIn(`${window.location.origin}${callbackPath}`);
+      } catch (caught) {
+        const failure = asAuthError(
+          caught,
+          "convex-logto: starting Logto sign-in failed.",
+        );
+        signInErrors.fail(attempt, failure);
+        throw failure;
       }
-      return signIn(`${window.location.origin}${callbackPath}`);
     },
-    [signIn, callbackPath],
+    [signIn, callbackPath, error, signInErrors],
   );
   // Federated sign-out: ends the SSO session (so the next sign-in isn't silent),
   // then returns to origin — which must be a registered Post sign-out redirect URI.

--- a/packages/convex-logto/src/session-client.test.ts
+++ b/packages/convex-logto/src/session-client.test.ts
@@ -633,11 +633,24 @@ describe("signIn", () => {
   });
 
   it("rejects an unsafe returnTo before any network call", async () => {
-    const { engine, handlers } = makeHarness();
+    const { engine, handlers, onAuthError } = makeHarness();
     await expect(
       engine.signIn({ returnTo: "https://evil.com" }),
     ).rejects.toThrow(/same-origin path/);
+    expect(onAuthError).toHaveBeenCalledTimes(1);
     expect(handlers.signIn).not.toHaveBeenCalled();
+  });
+
+  it("reports and rejects a sign-in action failure exactly once", async () => {
+    const failure = new Error("Convex unreachable");
+    const { engine, handlers, onAuthError } = makeHarness();
+    handlers.signIn.mockRejectedValue(failure);
+
+    await expect(engine.signIn()).rejects.toBe(failure);
+
+    expect(onAuthError).toHaveBeenCalledTimes(1);
+    expect(onAuthError).toHaveBeenCalledWith(failure);
+    expect(console.error).toHaveBeenCalledTimes(1);
   });
 
   it("reports and rejects a device-key preparation failure", async () => {
@@ -653,6 +666,7 @@ describe("signIn", () => {
     expect(onAuthError).toHaveBeenCalledWith(
       expect.any(SessionDeviceBindingError),
     );
+    expect(onAuthError).toHaveBeenCalledTimes(1);
     expect(handlers.signIn).not.toHaveBeenCalled();
   });
 });

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -20,6 +20,9 @@ const ID_TOKEN_SKEW_MS = 30 * 1000;
 /** Backoff between retries of a transiently-failing action call. */
 const RETRY_DELAYS_MS = [500, 2000];
 
+/** Error objects already surfaced through the public auth-error channel. */
+const REPORTED_AUTH_ERRORS = new WeakSet<Error>();
+
 export type SessionSnapshot = {
   status: "restoring" | "authenticated" | "unauthenticated";
   sessionId: string | null;
@@ -994,6 +997,10 @@ export class SessionAuthEngine {
   }
 
   private reportError(error: Error): void {
+    // Nested recovery helpers may report and rethrow the same Error. Preserve
+    // the rejection while routing that object through the observer only once.
+    if (REPORTED_AUTH_ERRORS.has(error)) return;
+    REPORTED_AUTH_ERRORS.add(error);
     console.error(error);
     try {
       this.options.onAuthError?.(error);

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -635,12 +635,25 @@ export class SessionAuthEngine {
     // storage intentionally has one OAuth transaction slot. Share the entire
     // flow so a double-tap cannot overwrite its own login-CSRF state. The web
     // redirect path remains independent and unchanged.
-    if (this.options.authFlow === undefined) return this.signInInner(options);
+    if (this.options.authFlow === undefined)
+      return this.signInReporting(options);
     if (this.inflightSignIn !== null) return this.inflightSignIn;
-    this.inflightSignIn = this.signInInner(options).finally(() => {
+    this.inflightSignIn = this.signInReporting(options).finally(() => {
       this.inflightSignIn = null;
     });
     return this.inflightSignIn;
+  }
+
+  private async signInReporting(options?: {
+    returnTo?: string;
+  }): Promise<void> {
+    try {
+      await this.signInInner(options);
+    } catch (error) {
+      const normalizedError = this.asError(error);
+      this.reportError(normalizedError);
+      throw normalizedError;
+    }
   }
 
   private async signInInner(options?: { returnTo?: string }): Promise<void> {
@@ -652,14 +665,8 @@ export class SessionAuthEngine {
           `to prevent open redirects.`,
       );
     }
-    try {
-      await this.prepareStorage();
-      await this.options.deviceBinding?.prepare();
-    } catch (error) {
-      const normalizedError = this.asError(error);
-      this.reportError(normalizedError);
-      throw normalizedError;
-    }
+    await this.prepareStorage();
+    await this.options.deviceBinding?.prepare();
     const redirectUri =
       this.options.authFlow?.redirectUri ??
       `${window.location.origin}${this.options.callbackPath}`;
@@ -676,7 +683,7 @@ export class SessionAuthEngine {
     this.options.storage.takeTransaction();
     const state = new URL(url).searchParams.get("state");
     if (state !== null) this.options.storage.stashTransaction({ state });
-    await this.flushStorageReporting();
+    await this.flushStorage();
     const authFlow = this.options.authFlow;
     if (authFlow === undefined) {
       window.location.assign(url);
@@ -688,16 +695,14 @@ export class SessionAuthEngine {
       callbackUrl = await authFlow.openAuthorization(url);
     } catch (error) {
       this.options.storage.takeTransaction();
-      await this.flushStorageReporting();
-      const normalizedError = this.asError(error);
-      this.reportError(normalizedError);
-      throw normalizedError;
+      await this.flushStorage();
+      throw error;
     }
     if (callbackUrl === null) {
       // A cancelled browser session must not leave an OIDC state value that a
       // later deep link could replay against.
       this.options.storage.takeTransaction();
-      await this.flushStorageReporting();
+      await this.flushStorage();
       return;
     }
     await this.completeSignIn(callbackUrl, redirectUri);


### PR DESCRIPTION
## Summary

- Route bridge, web-session, and native-session sign-in initiation failures through `onAuthError` and console reporting while preserving rejection behavior where a promise really rejects.
- Keep `void signIn()` event handlers observable for the freight-investigation class where Logto is unreachable, browser storage is blocked, or an in-app webview prevents initiation.
- Document the provider contract and add patch changeset `.changeset/nine-jeans-add.md`.

## Bridge mechanism and evidence

The installed `@logto/react@4.0.14` source defines `signIn: proxy(client.signIn.bind(client), false)`. That proxy catches every thrown value, calls `handleError`, which stores the `Error` through `setError` and logs it, and does not rethrow; `resetLoadingState=false` also means the public promise resolves after the catch.

`ConvexLogtoProvider` now tracks each public sign-in initiation with the SDK error object that existed before it started. A provider-side observer reports only a new error that appears for that attempt, only away from the callback route; the attempt latch prevents repeats on rerender, while the existing callback reporter remains the sole callback path. Direct local or future SDK rejections are reported and rethrown, and a throwing `onAuthError` observer cannot replace the original failure.

Session mode uses one engine-level reporting wrapper around sign-in initiation, shared by web and native. Transport, validation, storage preparation, and system-browser initiation failures are reported before rethrowing; callback completion retains its existing recovery reporting. A follow-up identity guard inside the engine's central reporter now ensures that an error reported by a nested storage/callback helper and rethrown into the initiation wrapper reaches `onAuthError` and `console.error` exactly once.

The bridge fail/observe paths do not have the same nested-report issue: `fail()` marks its attempt handled before reporting, `observe()` ignores handled attempts and the baseline error, and the callback route does not mount the initiation observer. The direct-rejection, rerender, and callback-dedup regression tests verify those guards.

## Tests

- Bridge: swallowed SDK-state failure with discarded promise, rerender dedupe, direct rejection, local validation, and callback non-duplication.
- Session and native: failed sign-in action rejects and reports exactly once; native callback-stage SecureStore flush failures also reject while reporting exactly once; existing device-binding and SecureStore failure coverage remains green.
- `pnpm --filter convex-logto test` — 230 passed
- `pnpm --filter convex-logto check-types` — passed
- `pnpm --filter convex-logto lint` — passed
- `pnpm --filter convex-logto format` / `format:check` — passed
- `pnpm --filter convex-logto build` — passed
- `pnpm --filter convex-logto lint:package` — passed
- `pnpm --filter docs build` — passed in the original round; known warnings remain tracked by #36

Closes #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sign-in initiation failures are now reported through `onAuthError` before `signIn()` rejects.
  * Errors are logged once, preserved for callers, and no longer open the browser when sign-in cannot begin.
  * Improved handling of invalid redirect paths, storage failures, and native authorization cancellations.

* **Documentation**
  * Expanded guidance for error handling, `void signIn()`, feedback, and telemetry across web, session, and native integrations.

* **Tests**
  * Added coverage for error reporting, logging, deduplication, and prevented authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
