### PR TITLE
fix(cookie): make a failed sign-out fail instead of reporting success

### DIFF
--- a/.changeset/cookie-sign-out-fails-loudly.md
+++ b/.changeset/cookie-sign-out-fails-loudly.md
@@ -1,0 +1,16 @@
+---
+"convex-logto": minor
+---
+
+Make cookie-transport sign-out honest. The session credential in cookie mode is
+an HttpOnly cookie that only the server can expire, so a failed revoke is a
+failed sign-out: `signOut()` now rejects instead of resolving while the user
+stays signed in, and a revoke failure always reaches `onAuthError` even in
+localStorage mode, where sign-out remains locally complete. Every sign-out
+response from the cookie route now carries the clear-cookie header, including
+the request-validation and malformed-body paths, and validation errors are
+returned in the structured `{ kind, code, message }` shape so the client can
+classify them — an `everywhere: true` call against a handler without
+`signOutEverywhere` gets the 409 upgrade guidance rather than an opaque 400.
+An empty `postLogoutRedirectUri` is treated as absent instead of being
+forwarded to a validator that rejects it.

--- a/packages/convex-logto/src/react-session.tsx
+++ b/packages/convex-logto/src/react-session.tsx
@@ -193,6 +193,9 @@ export function ConvexLogtoSessionProvider({
       initialSession: usesCookieTransport
         ? createCookieSessionMarker(storage.readSession(), initialSessionId)
         : undefined,
+      // The credential is an HttpOnly cookie only the server can expire, so a
+      // failed revoke is a failed sign-out — not something to swallow.
+      serverHeldCredential: usesCookieTransport,
       deviceBinding: deviceBinding
         ? createSessionDeviceBinding(namespace)
         : undefined,

--- a/packages/convex-logto/src/session-client.test.ts
+++ b/packages/convex-logto/src/session-client.test.ts
@@ -733,6 +733,39 @@ describe("callback", () => {
     expect(engine.getSnapshot().status).toBe("unauthenticated");
   });
 
+  it("a sign-out during the storage flush does not flip back to authenticated", async () => {
+    // The credentials are already written at this point, so sign-out finds and
+    // revokes the session properly — but the callback must not then re-assert
+    // an authenticated snapshot on top of it.
+    const { engine, storage, handlers, onAuthError } = makeHarness();
+    setURL("http://localhost:5173/callback?code=c1&state=s1");
+    storage.stashTransaction({ state: "s1" });
+    const flushed = deferred<void>();
+    const realFlush = storage.flush.bind(storage);
+    let signOutDuringFlush: Promise<void> | undefined;
+    storage.flush = () => {
+      if (signOutDuringFlush === undefined && storage.readSession() !== null) {
+        signOutDuringFlush = engine.signOut({ federated: false });
+        return flushed.promise;
+      }
+      return realFlush();
+    };
+    handlers.callback.mockResolvedValue(sessionResult(9));
+    handlers.signOut.mockResolvedValue({});
+
+    engine.start();
+    await vi.waitFor(() => expect(signOutDuringFlush).toBeDefined());
+    flushed.resolve(undefined);
+    await signOutDuringFlush;
+    await vi.waitFor(() =>
+      expect(engine.getSnapshot().status).not.toBe("restoring"),
+    );
+
+    expect(engine.getSnapshot().status).toBe("unauthenticated");
+    expect(storage.readSession()).toBeNull();
+    void onAuthError;
+  });
+
   it("an unsafe server returnTo falls back to afterSignIn", async () => {
     const { engine, storage, handlers, navigate } = makeHarness({
       afterSignIn: "/home",

--- a/packages/convex-logto/src/session-client.test.ts
+++ b/packages/convex-logto/src/session-client.test.ts
@@ -91,6 +91,7 @@ function makeHarness(options?: {
   deviceBinding?: SessionDeviceBinding;
   sessionApi?: LogtoSessionApi;
   storage?: SessionStorageAdapter;
+  serverHeldCredential?: boolean;
 }) {
   const handlers: Handlers = {
     signIn: vi.fn(),
@@ -125,6 +126,7 @@ function makeHarness(options?: {
     initialToken: options?.initialToken,
     initialSession,
     deviceBinding: options?.deviceBinding,
+    serverHeldCredential: options?.serverHeldCredential,
     navigate,
     onAuthError,
     sleep: () => Promise.resolve(), // skip retry backoff in tests
@@ -1257,6 +1259,52 @@ describe("signOut", () => {
     expect(storage.readSession()).toBeNull();
     expect(storage.readIdToken()).toBeNull();
     expect(engine.getSnapshot().status).toBe("unauthenticated");
+  });
+});
+
+describe("server-held credential sign-out", () => {
+  it("rejects and reports when the server revoke fails", async () => {
+    // Cookie mode: the credential is an HttpOnly cookie only the server can
+    // expire. Reporting success would leave the user signed in.
+    const { engine, storage, handlers, onAuthError } = makeHarness({
+      serverHeldCredential: true,
+      storedSession: { token: "cookie-session", sessionId: "session-id-1" },
+    });
+    void storage;
+    handlers.signOut.mockRejectedValue(new Error("network unavailable"));
+
+    await expect(engine.signOut({ federated: false })).rejects.toThrow(
+      /network unavailable/,
+    );
+    expect(onAuthError).toHaveBeenCalled();
+    expect(engine.getSnapshot().status).toBe("unauthenticated");
+  });
+
+  it("still resolves for a local credential, but never silently", async () => {
+    // A local session token is destroyed without the server, so a dead Logto
+    // must not block sign-out — the failure still has to surface.
+    const { engine, handlers, onAuthError } = makeHarness({
+      storedSession: { token: "local-session", sessionId: "session-id-1" },
+    });
+    handlers.signOut.mockRejectedValue(new Error("network unavailable"));
+
+    await expect(engine.signOut({ federated: false })).resolves.toBeUndefined();
+    expect(onAuthError).toHaveBeenCalled();
+  });
+
+  it("treats an empty postLogoutRedirectUri as absent", async () => {
+    const { engine, handlers } = makeHarness({
+      storedSession: { token: "local-session", sessionId: "session-id-1" },
+    });
+    handlers.signOut.mockResolvedValue({});
+
+    await engine.signOut({ postLogoutRedirectUri: "  ", federated: false });
+
+    expect(handlers.signOut).toHaveBeenCalledWith(
+      expect.objectContaining({
+        postLogoutRedirectUri: "http://localhost:5173",
+      }),
+    );
   });
 });
 

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -425,6 +425,13 @@ export type SessionEngineOptions = {
   initialSession?: StoredSession;
   /** Opt-in proof-of-possession key; absent keeps the legacy unbound flow. */
   deviceBinding?: SessionDeviceBinding;
+  /**
+   * The session credential lives somewhere this code cannot delete — the
+   * HttpOnly cookie of the same-site transport. Sign-out then has no local
+   * fallback: if the server does not revoke, the user is still signed in, so
+   * the failure must reach the caller instead of being reported as success.
+   */
+  serverHeldCredential?: boolean;
   /** Replace-style navigation; falls back to `location.replace`. */
   navigate?: (to: string) => void;
   /** Native system-browser/deep-link flow; absent preserves the web flow. */
@@ -963,7 +970,10 @@ export class SessionAuthEngine {
     await this.performSignOut({
       postLogoutRedirectUri: options?.postLogoutRedirectUri,
       federated: options?.federated !== false,
-      requireServerSuccess: false,
+      // A local credential can be destroyed without the server, so a dead Logto
+      // must not block sign-out. A server-held one cannot: there the revoke
+      // *is* the sign-out.
+      requireServerSuccess: this.options.serverHeldCredential === true,
       revoke: async (sessionToken, deviceProof, postLogoutRedirectUri) =>
         await this.options.transport.action(this.options.api.signOut, {
           sessionToken,
@@ -1062,8 +1072,11 @@ export class SessionAuthEngine {
     let serverRevocationError: unknown;
     let fatalServerError: Error | undefined;
     if (session !== null) {
+      // `??` alone would forward an empty string, which every server-side
+      // validator rejects — a caller passing `""` means "use the default".
+      const requested = options.postLogoutRedirectUri?.trim();
       postLogoutRedirectUri =
-        options.postLogoutRedirectUri ??
+        (requested === undefined || requested === "" ? undefined : requested) ??
         this.options.authFlow?.redirectUri ??
         window.location.origin;
       if (deviceProofError !== undefined) {
@@ -1092,9 +1105,14 @@ export class SessionAuthEngine {
                     { cause: error },
                   );
             this.reportError(fatalServerError);
+          } else {
+            // Best effort, but never silent: the server session outlives this
+            // sign-out until it expires, and only the app can decide whether
+            // that matters enough to retry.
+            this.reportError(this.asError(error));
           }
-          // Best effort when local cleanup succeeded; a combined failure is
-          // converted into a loud SessionSignOutError below.
+          // A combined failure is converted into a loud SessionSignOutError
+          // below.
         }
       }
     }

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -641,6 +641,10 @@ export class SessionAuthEngine {
       });
       this.options.storage.writeIdToken(result.idToken);
       await this.flushStorage();
+      // The credentials are stored by now, so a sign-out landing during the
+      // flush finds and revokes the session itself. It must not then be
+      // overwritten with an authenticated snapshot built from this exchange.
+      if (generation !== this.authGeneration) return;
       this.lastServed = null;
       this.setAuthenticated(result.idToken);
       const destination =

--- a/packages/convex-logto/src/session-cookie.test.ts
+++ b/packages/convex-logto/src/session-cookie.test.ts
@@ -200,8 +200,14 @@ describe("request validation", () => {
         }),
       );
       expect(response.status).toBe(400);
+      // Structured, so the client can classify it rather than surfacing a bare
+      // "responded 400" that swallows the reason.
       await expect(response.json()).resolves.toEqual({
-        error: testCase.message,
+        error: {
+          kind: "terminal",
+          code: "invalid_request",
+          message: testCase.message,
+        },
       });
     }
     expect(action).not.toHaveBeenCalled();
@@ -411,6 +417,72 @@ describe("cookie session flows", () => {
     expect(response.status).toBe(401);
     expect(response.headers.get("set-cookie")).toContain("Max-Age=0");
     expect(response.headers.get("set-cookie")).toContain("Path=/");
+  });
+});
+
+describe("sign-out always expires the cookie", () => {
+  const clears = (res: Response) =>
+    (res.headers.get("Set-Cookie") ?? "").includes("Max-Age=0");
+
+  it.each([
+    ["a rejected postLogoutRedirectUri", { postLogoutRedirectUri: 123 }],
+    ["a rejected everywhere flag", { everywhere: "yes" }],
+  ])("clears the cookie on %s", async (_name, body) => {
+    const { handler } = makeHarness();
+
+    const res = await handler(
+      request("sign-out", { cookie: cookie("session-token-1"), body }),
+    );
+
+    expect(res.status).toBe(400);
+    // The cookie is the only credential and JavaScript cannot delete it, so a
+    // rejected request must not leave the caller signed in.
+    expect(clears(res)).toBe(true);
+    const payload = (await res.json()) as { error: { code: string } };
+    expect(payload.error.code).toBe("invalid_request");
+  });
+
+  it("clears the cookie on a malformed body", async () => {
+    const { handler } = makeHarness();
+    const headers = new Headers({
+      Origin: APP_ORIGIN,
+      [LOGTO_SESSION_CSRF_HEADER]: LOGTO_SESSION_CSRF_VALUE,
+      "Content-Type": "application/json",
+      Cookie: cookie("session-token-1"),
+    });
+    const res = await handler(
+      new Request(`${APP_ORIGIN}${BASE_PATH}/sign-out`, {
+        method: "POST",
+        headers,
+        body: "{not json",
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(clears(res)).toBe(true);
+  });
+
+  it("answers 409 with the upgrade hint when signOutEverywhere is absent", async () => {
+    const { handler } = makeHarness();
+    const withoutEverywhere = createLogtoSessionCookieHandler({
+      sessionApi: { ...api, signOutEverywhere: undefined },
+      action: vi.fn() as unknown as LogtoSessionAction,
+      allowedOrigins: [APP_ORIGIN],
+      basePath: BASE_PATH,
+    });
+    void handler;
+
+    const res = await withoutEverywhere(
+      request("sign-out", {
+        cookie: cookie("session-token-1"),
+        body: { everywhere: true },
+      }),
+    );
+
+    expect(res.status).toBe(409);
+    expect(clears(res)).toBe(true);
+    const payload = (await res.json()) as { error: { code: string } };
+    expect(payload.error.code).toBe("sign_out_everywhere_unavailable");
   });
 });
 

--- a/packages/convex-logto/src/session-cookie.ts
+++ b/packages/convex-logto/src/session-cookie.ts
@@ -423,6 +423,13 @@ export function createLogtoSessionCookieHandler(
     request: Request,
     origin: string,
   ): Promise<Response> => {
+    // Sign-out must expire the cookie on *every* exit. It is the only credential
+    // in this mode and JavaScript cannot delete it, so a response without this
+    // header leaves the caller signed in while reporting a failure it cannot act
+    // on. Rejecting the request is not a reason to keep the session alive.
+    const clearing =
+      route === "sign-out" ? { "Set-Cookie": clearCookieHeader() } : undefined;
+
     const bodyResult = await readJsonObject(request);
     if (!bodyResult.ok) {
       return jsonResponse(
@@ -432,7 +439,10 @@ export function createLogtoSessionCookieHandler(
               ? "Request body is too large"
               : "Malformed JSON request body",
         },
-        { status: bodyResult.reason === "too_large" ? 413 : 400 },
+        {
+          status: bodyResult.reason === "too_large" ? 413 : 400,
+          ...(clearing === undefined ? {} : { headers: clearing }),
+        },
         origin,
       );
     }
@@ -501,8 +511,19 @@ export function createLogtoSessionCookieHandler(
           try {
             const signOutEverywhere = options.sessionApi.signOutEverywhere;
             if (everywhere && signOutEverywhere === undefined) {
-              throw new RequestValidationError(
-                "sessionApi must export signOutEverywhere before using this operation",
+              // Same 409 the deployed-but-missing case returns, so the client
+              // gets the upgrade guidance either way.
+              return jsonResponse(
+                {
+                  error: {
+                    kind: "terminal",
+                    code: "sign_out_everywhere_unavailable",
+                    message:
+                      "convex-logto: sessionApi must re-export signOutEverywhere from logtoSessionApi(components.logto), then deploy the Convex functions.",
+                  } satisfies SessionError,
+                },
+                { status: 409, headers },
+                origin,
               );
             }
             const result =
@@ -539,13 +560,30 @@ export function createLogtoSessionCookieHandler(
       throw new Error("convex-logto: unsupported cookie route.");
     } catch (error) {
       if (error instanceof RequestValidationError) {
-        return jsonResponse({ error: error.message }, { status: 400 }, origin);
+        return jsonResponse(
+          {
+            // Structured so the client can classify it instead of seeing a bare
+            // "responded 400" — that is how the signOutEverywhere upgrade hint
+            // used to get lost.
+            error: {
+              kind: "terminal",
+              code: "invalid_request",
+              message: error.message,
+            } satisfies SessionError,
+          },
+          {
+            status: 400,
+            ...(clearing === undefined ? {} : { headers: clearing }),
+          },
+          origin,
+        );
       }
       const data = errorData(error);
       const headers =
-        route === "token" && data?.kind === "terminal"
+        clearing ??
+        (route === "token" && data?.kind === "terminal"
           ? { "Set-Cookie": clearCookieHeader() }
-          : undefined;
+          : undefined);
       return actionErrorResponse(error, origin, headers);
     }
   };


### PR DESCRIPTION
Two defects in cookie transport mode, both found by verifying leads left over from the #69 audit and both proved with tests before being fixed.

## The session survives a "successful" sign-out (#79)

In cookie mode the credential is the HttpOnly `__Host-convex-logto-session` cookie, which JavaScript cannot delete. `signOut()` used `requireServerSuccess: false` — correct for a localStorage session token, wrong here — and the recorded `serverRevocationError` was only read when local cleanup had *also* failed. A failed or timed-out revoke therefore:

1. resolved successfully,
2. never reached `onAuthError` (completely silent, not merely non-fatal),
3. and was undone on the next mount: the marker is rewritten, `/token` succeeds against the still-valid cookie, and the user is signed back in.

Verified with a loopback harness joining the real `SessionAuthEngine`, the real cookie transport and the real route handler through an HttpOnly cookie jar that only `Set-Cookie` can mutate. A sanity control confirms a working sign-out empties the jar and the server's live-session set; the failure cases then show `signOut()` resolving with the jar unchanged, the server session live, and a remount reaching `authenticated` as the same user.

The engine now takes `serverHeldCredential` and requires server success when it is set. Ordering is unchanged — local state is cleared and the UI moves to unauthenticated first — so the failure becomes visible without stranding the tree. localStorage mode still resolves on a dead server, since there sign-out really is locally complete, but the failure is now always reported.

## A rejected request leaves the cookie valid (#80)

Every sign-out exit carried the clear-cookie header except the validation-error path and the malformed-body branch, which fell through to the outer catch with no headers. So a caller could be rejected *and* left signed in — reachable with `signOut({ postLogoutRedirectUri: "" })`, because the client forwarded the empty string with `??`.

All sign-out responses now clear the cookie. Validation errors carry the structured `{ kind, code, message }` shape instead of a bare string that degraded to "responded 400", so `everywhere: true` against a handler without `signOutEverywhere` gets the 409 upgrade guidance instead of an opaque error. An empty `postLogoutRedirectUri` is treated as absent.

## Behaviour change

`signOut()` can now reject in cookie mode. An app doing `await signOut(); navigate("/")` without a catch will see it — which is the point: previously it silently left the user signed in. Called out in the changeset.

Library tests 397 → 404; each new test was verified to fail without its fix.

## Also fixed here

Review of #70's fix surfaced one more await boundary on the same path: `completeCallback` re-checked the generation before writing credentials but not after `await flushStorage()`, so a sign-out landing in that window was correctly revoked server-side and then overwritten by an authenticated snapshot. Reproduced with a test that resolves the flush only after a sign-out has run, and fixed. Closes #89.
