### PR TITLE
chore: stop Dependabot from proposing unbuildable dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,24 @@ updates:
         update-types:
           - minor
           - patch
+      # React and React DOM must be the exact same version — React throws
+      # "Incompatible React versions" at runtime otherwise — so they can only
+      # move together.
+      react:
+        patterns:
+          - react
+          - react-dom
+          - "@types/react"
+          - "@types/react-dom"
+    ignore:
+      # Expo SDK modules are versioned in lockstep with the SDK: `expo@56`
+      # bundles `expo-crypto@~56.0.4`, and a module from another SDK breaks the
+      # native build while still typechecking, so CI cannot catch it. Upgrade
+      # the whole SDK with `npx expo install --fix` instead.
+      - dependency-name: expo
+      - dependency-name: expo-*
+      - dependency-name: react-native
+      - dependency-name: "@expo/*"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Dependabot's first run produced two PRs that cannot work, for two different reasons.

**#86 — react without react-dom.** It bumped `react` and `@types/react` but left `react-dom` behind. React requires both at the exact same version and throws `Incompatible React versions` at runtime. `verify` did catch this, but only by burning a full CI run on a PR that could never merge. They now bump as one group.

**#82 — a single Expo module across an SDK boundary.** It bumped `expo-crypto` 56 → 57 while `examples/expo` pins `expo@~56.0.12` and every other Expo module at 56. Expo SDK modules are versioned in lockstep: `expo@56`'s own `bundledNativeModules.json` pins `expo-crypto` to `~56.0.4`. A module from a different SDK breaks the native build while still typechecking cleanly — so unlike #86, **CI cannot catch this one at all**. `expo-crypto`'s peer range is just `expo: "*"`, so the package manager stays quiet too.

Expo modules and `react-native` are now ignored; that SDK is upgraded as a unit with `npx expo install --fix`, not one package at a time.

Closing #82 and #86 alongside this.