### PR TITLE
docs(expo): list the native session-mode example

### DIFF
--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -103,4 +103,7 @@ framework:
   <Card title="Expo (React Native)" href="https://github.com/Fanzzzd/convex-logto/tree/main/examples/expo">
     Native auth via convex-logto/native — no callback route, deep-link sign-in.
   </Card>
+  <Card title="Expo, session mode" href="https://github.com/Fanzzzd/convex-logto/tree/main/examples/expo-session">
+    Server-held refresh token, SecureStore credentials, device list.
+  </Card>
 </Cards>

--- a/docs/content/docs/react-native.mdx
+++ b/docs/content/docs/react-native.mdx
@@ -289,6 +289,11 @@ Logto browser session.
 | Cookie transport | optional, same-site only | unavailable |
 | Software device binding | optional on web | intentionally absent; SecureStore uses the OS keystore |
 
+Full runnable app: [`examples/expo-session`](https://github.com/Fanzzzd/convex-logto/tree/main/examples/expo-session)
+— the native counterpart of `vite-react-session`, with the same nine-function
+`convex/auth.ts`, a device list, and a side-by-side comparison against the
+bridge-mode [`examples/expo`](https://github.com/Fanzzzd/convex-logto/tree/main/examples/expo).
+
 Native session mode therefore has no `tokenStorage`, `cookieTransport`, or
 `deviceBinding` provider props. If SecureStore is unavailable or fails, auth
 fails loudly through `onAuthError`; a sign-in action or system-browser

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,7 @@ Each is a standalone app — see its README to run it.
 | [`tanstack-start`](./tanstack-start) | TanStack Start (SSR): one SSR-safe provider + `beforeLoad` route guards. |
 | [`nextjs`](./nextjs) | Next.js App Router: client provider boundary + callback route. |
 | [`expo`](./expo) | Expo (React Native): native auth via `convex-logto/native` — deep-link sign-in, no callback route. |
+| [`expo-session`](./expo-session) | Expo (React Native) **session mode**: server-held refresh token, SecureStore-only credentials, and the "where am I signed in" session list — no Logto SDK on the device. |
 
 > The webhook user-sync and RBAC shown in `tanstack-router-spa` are **framework-agnostic** —
 > the `convex/` backend code is identical everywhere, so a Vite, Next.js, or Expo app wires them the same way.
@@ -21,3 +22,4 @@ Standalone, install it from npm with the Logto peer for your platform:
 - Web (Vite / Next.js / TanStack): `npm i convex-logto @logto/react`
 - Web, session mode: `npm i convex-logto` (no Logto package needed)
 - React Native / Expo: `npm i convex-logto @logto/rn` (plus the Expo modules — see the [`expo`](./expo) README)
+- React Native / Expo, session mode: `npm i convex-logto` + `npx expo install expo-secure-store expo-web-browser`

--- a/packages/convex-logto/README.md
+++ b/packages/convex-logto/README.md
@@ -368,7 +368,7 @@ Convex validates an OIDC **ID token**. Logto's access tokens are typed `at+jwt`,
 
 ### React Native / Expo
 
-For Expo bridge mode, import from **`convex-logto/native`** (built on [`@logto/rn`](https://github.com/logto-io/react-native)) instead of `convex-logto/react`. For server-held session mode, use **`convex-logto/native-session`** with `expo-secure-store` and `expo-web-browser`. Neither native entry needs a callback route — `signIn` opens the system browser and resolves on the deep-link return. See the [React Native guide](https://github.com/Fanzzzd/convex-logto/blob/main/docs/content/docs/react-native.mdx) and the runnable bridge-mode [`examples/expo`](https://github.com/Fanzzzd/convex-logto/tree/main/examples/expo) app; a dedicated session-mode example is tracked in [#43](https://github.com/Fanzzzd/convex-logto/issues/43).
+For Expo bridge mode, import from **`convex-logto/native`** (built on [`@logto/rn`](https://github.com/logto-io/react-native)) instead of `convex-logto/react`. For server-held session mode, use **`convex-logto/native-session`** with `expo-secure-store` and `expo-web-browser`. Neither native entry needs a callback route — `signIn` opens the system browser and resolves on the deep-link return. See the [React Native guide](https://github.com/Fanzzzd/convex-logto/blob/main/docs/content/docs/react-native.mdx) and the two runnable apps: bridge-mode [`examples/expo`](https://github.com/Fanzzzd/convex-logto/tree/main/examples/expo) and session-mode [`examples/expo-session`](https://github.com/Fanzzzd/convex-logto/tree/main/examples/expo-session).
 
 ## License
 


### PR DESCRIPTION
Closes #43.

`examples/expo-session` landed alongside #100. This points the four places that route people to examples at it — `examples/README.md`, the docs landing cards, the React Native guide, and the package README — and removes the "a dedicated session-mode example is tracked in #43" placeholder.

The example itself demonstrates what #43 asked for: `convex-logto/native-session` against the shared session component and `logtoSessionApi`, SecureStore persistence, `expo-web-browser` sign-in through a registered custom scheme (`io.logto.session`), cold-start restore, reactive revocation, federated sign-out, and the new device list. Its README covers the development-build deep-link setup for iOS and Android and contrasts the app with the bridge-mode `examples/expo` line by line (Logto app type, where the refresh token lives, which dependencies each needs).