### PR TITLE
chore(deps): stop proposing two updates CI cannot judge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,18 @@ updates:
       - dependency-name: expo-*
       - dependency-name: react-native
       - dependency-name: "@expo/*"
+      # Also SDK-pinned, just not under an `expo` name: `expo@56` bundles
+      # async-storage 2.2.0 (see expo/bundledNativeModules.json). Nothing in CI
+      # builds native code, so a bump to 3.x goes green while
+      # `npx expo install --check` would reject it.
+      - dependency-name: "@react-native-async-storage/async-storage"
+      # TypeScript 7 typechecks this workspace, but tsup 8.5.1 bundles
+      # rollup-plugin-dts 6.1.1, which crashes against it — and because it is
+      # bundled, a pnpm override cannot replace it. Revisit when tsup ships with
+      # rollup-plugin-dts >= 6.5 (issue #102).
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: github-actions
     directory: /

--- a/packages/convex-logto/src/component/http_body.ts
+++ b/packages/convex-logto/src/component/http_body.ts
@@ -1,6 +1,13 @@
-/** A successful bounded body read or the controlled reason it stopped. */
+/**
+ * A successful bounded body read or the controlled reason it stopped.
+ *
+ * The buffer is pinned to `ArrayBuffer` rather than the default
+ * `ArrayBufferLike`: every caller hands these bytes to `crypto.subtle`, whose
+ * `BufferSource` parameter excludes `SharedArrayBuffer`. TypeScript 7's lib
+ * definitions enforce that; 5.x accepted the wider type.
+ */
 export type BoundedBodyResult =
-  | { ok: true; bytes: Uint8Array }
+  | { ok: true; bytes: Uint8Array<ArrayBuffer> }
   | { ok: false; reason: "too_large" | "read_error" };
 
 type BodySource = Pick<Request, "body" | "headers">;


### PR DESCRIPTION
Closes #102. Lets us close #87 and #99.

Two Dependabot PRs pass `verify` and would still be wrong to merge, because the thing they break is something CI does not exercise.

### `@react-native-async-storage/async-storage` 2.2.0 → 3.1.1 (#99)

Expo SDK 56 pins it to **2.2.0** in `expo/bundledNativeModules.json`, the same lockstep rule that already put `expo`, `expo-*`, `react-native` and `@expo/*` on the ignore list in #93 — this one just doesn't have an `expo` name. No example builds native code in CI, so it goes green while `npx expo install --check` would reject it.

### `typescript` 5.8.3 → 7.0.2 (#87)

TS 7 typechecks the whole workspace (after the fix below), and then the **build** fails:

```
TypeError: Cannot read properties of undefined (reading 'useCaseSensitiveFileNames')
    at .../rollup-plugin-dts@6.1.1_.../rollup-plugin-dts.cjs
    at .../tsup@8.5.1/dist/rollup.js:4857:37
```

`rollup-plugin-dts@6.5.1` declares `typescript: "^4.5 || ^5 || ^6 || ^7"`, but tsup bundles 6.1.1 into its own `dist/rollup.js`, so a `pnpm.overrides` entry has no effect — verified. tsup 8.5.1 is the current latest. Ignoring **majors only** keeps 5.x patches flowing.

### The one source fix, landed here

TS 7's lib definitions enforce that `BufferSource` excludes `SharedArrayBuffer`, so an unparameterized `Uint8Array` (`Uint8Array<ArrayBufferLike>`) can no longer be passed to `crypto.subtle`. `readBoundedBody` now returns `Uint8Array<ArrayBuffer>`, which is what it already constructs. Valid since TS 5.7, so it is forward-compatible today and removes the only TS 7 error in our source.