### PR TITLE
docs: give each framework page its session-mode wiring

### DIFF
--- a/docs/content/docs/nextjs.mdx
+++ b/docs/content/docs/nextjs.mdx
@@ -44,3 +44,65 @@ export default function CallbackPage() {
 ```
 
 Full app: [`examples/nextjs`](https://github.com/Fanzzzd/convex-logto/tree/main/examples/nextjs).
+
+## Session mode
+
+[Session mode](/docs/session-mode) keeps the same client boundary: the provider
+uses hooks and `window`, so it stays inside `app/providers.tsx`, and
+`app/layout.tsx` stays a Server Component that renders it.
+
+```tsx title="app/providers.tsx"
+"use client";
+import { ConvexReactClient } from "convex/react";
+import { ConvexLogtoSessionProvider } from "convex-logto/react-session";
+import { useRouter } from "next/navigation";
+import { api } from "../convex/_generated/api";
+
+const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  return (
+    <ConvexLogtoSessionProvider
+      client={convex}
+      sessionApi={api.auth}
+      navigate={(to) => router.replace(to)}
+    >
+      {children}
+    </ConvexLogtoSessionProvider>
+  );
+}
+```
+
+`configQuery` is gone — session mode keeps every Logto value on the Convex
+deployment, so the bundle carries none of it. `app/callback/page.tsx` stays the
+Server Component shown above; the provider finishes the exchange under it and
+replace-navigates away.
+
+### Cookie transport
+
+App Router route handlers take and return standard `Request`/`Response`, so the
+handler mounts as a catch-all:
+
+```ts title="app/api/logto/[route]/route.ts"
+import { logtoCookieHandler } from "@/server/logto-cookie";
+
+export const POST = logtoCookieHandler;
+export const OPTIONS = logtoCookieHandler;
+```
+
+Add `cookieTransport={{ endpoint: "/api/logto" }}` to the provider above. The
+handler module and its `allowedOrigins` are in
+[the cookie transport section](/docs/session-mode#httponly-cookie-transport-optional).
+
+<Callout type="warn">
+Do **not** call `getInitialToken()` from a layout or page to seed SSR in the App
+Router. It rotates the session cookie, and a Server Component cannot set cookies —
+Next.js only allows that in Route Handlers, Server Actions, and middleware. The
+rotated cookie would be dropped, leaving the browser holding a superseded token
+that is eventually presented outside the reuse window and read as token reuse,
+which kills the session. Skip seeding here: the provider fetches a fresh ID token
+from `/api/logto/token` right after hydration.
+</Callout>
+
+Full walkthrough: [Session mode](/docs/session-mode).

--- a/docs/content/docs/session-mode.mdx
+++ b/docs/content/docs/session-mode.mdx
@@ -371,6 +371,13 @@ paths. Keep `CONVEX_URL` server-only.
 
 ### Next.js App Router
 
+<Callout>
+Per-framework wiring — where the provider goes, what stays a Server Component,
+and which SSR seeding is safe — is on the [Next.js](/docs/nextjs),
+[TanStack Start](/docs/tanstack-start), [TanStack Router](/docs/tanstack-router)
+and [Vite](/docs/vite) pages.
+</Callout>
+
 Mount the handler in a catch-all Route Handler:
 
 ```ts title="app/api/logto/[route]/route.ts"

--- a/docs/content/docs/tanstack-router.mdx
+++ b/docs/content/docs/tanstack-router.mdx
@@ -42,3 +42,42 @@ full pattern (with the `isLoading`-first check that avoids bouncing a just-retur
 user) is in [Auth in your app → Route guards](/docs/auth-in-your-app#route-guards-tanstack-router).
 
 Full app: [`examples/tanstack-router-spa`](https://github.com/Fanzzzd/convex-logto/tree/main/examples/tanstack-router-spa).
+
+## Session mode
+
+[Session mode](/docs/session-mode) changes the provider and drops `configQuery`
+(no Logto config reaches the bundle); the router wiring is unchanged.
+
+```tsx title="src/main.tsx"
+import { ConvexLogtoSessionProvider } from "convex-logto/react-session";
+
+root.render(
+  <ConvexLogtoSessionProvider
+    client={convex}
+    sessionApi={api.auth}
+    navigate={(to) => void router.navigate({ to, replace: true })}
+  >
+    <RouterProvider router={router} />
+  </ConvexLogtoSessionProvider>,
+);
+```
+
+Keep the `/callback` route. The provider completes the exchange and then calls
+your `navigate`, but the router still renders that path first — without a route
+for it the user sees a 404 for the length of one round-trip. `replace: true`
+keeps the code-bearing URL out of history.
+
+Route guards work exactly as above: `useLogtoAuth()` from
+`convex-logto/react-session` has the same `isAuthenticated` / `isLoading` pair
+(both come from Convex, so they flip only once Convex has accepted the token),
+and it adds `signOutEverywhere()` plus the `listSessions()` /
+`renameSession()` / `revokeSession()` device list.
+
+A router-level guard is not an authorization boundary in either mode — it decides
+what to render, and the Convex function still has to check the identity itself.
+Session mode adds `assertSubjectHasActiveSession(ctx, components.logto)` for
+functions that must also fail the moment a session is revoked, rather than when
+the ID token expires.
+
+Full app: [`examples/vite-react-session`](https://github.com/Fanzzzd/convex-logto/tree/main/examples/vite-react-session)
+(the session-mode wiring is router-independent).

--- a/docs/content/docs/tanstack-start.mdx
+++ b/docs/content/docs/tanstack-start.mdx
@@ -33,3 +33,74 @@ export const Route = createFileRoute("/callback")({
 ```
 
 Full app: [`examples/tanstack-start`](https://github.com/Fanzzzd/convex-logto/tree/main/examples/tanstack-start).
+
+## Session mode
+
+`ConvexLogtoSessionProvider` is SSR-safe for the same reason: on the server it
+renders one fixed `restoring` snapshot and touches no browser API, so it mounts
+in the same place with no client boundary.
+
+```tsx title="src/router.tsx"
+import { ConvexLogtoSessionProvider } from "convex-logto/react-session";
+
+<ConvexLogtoSessionProvider
+  client={convex}
+  sessionApi={api.auth}
+  navigate={(to) => void router.navigate({ to, replace: true })}
+>
+  <RouterProvider router={router} />
+</ConvexLogtoSessionProvider>;
+```
+
+Keep the `/callback` route — the provider finishes the exchange there before
+navigating on.
+
+### The pieces that are Start-specific
+
+Start is the framework where session mode has *more* to offer than a SPA, because
+it has a server on the same origin:
+
+1. **Mount the cookie handler as a server route.** Start's server handlers receive
+   a standard `Request`, which is exactly what the handler takes:
+
+   ```ts title="src/routes/api/logto/$.ts"
+   import { createFileRoute } from "@tanstack/react-router";
+   import { logtoCookieHandler } from "~/server/logto-cookie";
+
+   export const Route = createFileRoute("/api/logto/$")({
+     server: {
+       handlers: {
+         POST: ({ request }) => logtoCookieHandler(request),
+         OPTIONS: ({ request }) => logtoCookieHandler(request),
+       },
+     },
+   });
+   ```
+
+   Then pass `cookieTransport={{ endpoint: "/api/logto" }}` to the provider. The
+   rotating session token moves into an HttpOnly `__Host-` cookie that JavaScript
+   cannot read. See [the cookie transport](/docs/session-mode#httponly-cookie-transport-optional)
+   for the handler module and its `allowedOrigins`.
+
+2. **Seed the first paint.** With the cookie in place, a server function can
+   exchange it for a fresh ID token during the root loader, so the first render is
+   already authenticated:
+
+   ```tsx
+   const seedSession = createServerFn().handler(async () => {
+     const seed = await logtoCookieHandler.getInitialToken(getRequest());
+     setResponseHeaders(Object.fromEntries(seed.headers));
+     return {
+       initialToken: seed.initialToken,
+       initialSessionId: seed.initialSessionId,
+     };
+   });
+   ```
+
+   Pass the pair to `initialToken` / `initialSessionId`. **Forwarding
+   `seed.headers` is not optional**: that response carries the rotated cookie, and
+   dropping it leaves the browser holding a superseded token that will eventually
+   be presented outside the reuse window and read as reuse. Call it at most once
+   per document request.
+
+Full walkthrough: [Session mode](/docs/session-mode).

--- a/docs/content/docs/vite.mdx
+++ b/docs/content/docs/vite.mdx
@@ -40,3 +40,42 @@ if (window.location.pathname === "/callback") return <p>Finishing sign in…</p>
 ```
 
 Full app: [`examples/vite-react`](https://github.com/Fanzzzd/convex-logto/tree/main/examples/vite-react).
+
+## Session mode
+
+[Session mode](/docs/session-mode) swaps the entry and the props; the mount point
+and callback route are the same two Vite-specific pieces.
+
+```tsx title="src/main.tsx"
+import { ConvexLogtoSessionProvider } from "convex-logto/react-session";
+import { api } from "../convex/_generated/api";
+
+root.render(
+  <ConvexLogtoSessionProvider client={convex} sessionApi={api.auth}>
+    <App />
+  </ConvexLogtoSessionProvider>,
+);
+```
+
+There is no `configQuery`: session mode keeps every Logto value on the Convex
+deployment, so nothing needs to reach the bundle. `sessionApi` is the module
+re-exporting `logtoSessionApi(...)` — `api.auth` above.
+
+The callback is still `/callback`, and the provider still owns it — but it now
+POSTs the code to Convex and replace-navigates to `afterSignIn` itself, so the
+view you render there is only ever a flash:
+
+```tsx title="src/App.tsx"
+if (window.location.pathname === "/callback") return <p>Finishing sign in…</p>;
+```
+
+<Callout>
+A plain Vite SPA usually ships to a static host, which has no same-site server to
+mount the [cookie transport](/docs/session-mode#httponly-cookie-transport-optional)
+on. That is fine: the default localStorage transport is the supported
+static-hosting path — the session token there is one-time, rotates on every use,
+and is stored server-side only as a hash. Add the cookie transport when you have a
+server on the same site, not before.
+</Callout>
+
+Full app: [`examples/vite-react-session`](https://github.com/Fanzzzd/convex-logto/tree/main/examples/vite-react-session).


### PR DESCRIPTION
Closes #76.

The [session-mode guide](https://convex-logto-docs.vercel.app/docs/session-mode) is framework-generic, while the integration pages only showed bridge mode — so someone landing on the Next.js page had no path to session mode at all. Each page now carries its own provider mount, callback wiring, and the one thing that only matters there.

| Page | The framework-specific part |
| --- | --- |
| Vite | A static host has no same-site server, so the default localStorage transport is the supported path, not a compromise — add the cookie transport when you *have* a server. |
| TanStack Router | The `/callback` route still has to exist, or the router renders a 404 for the length of the exchange; `replace: true` keeps the code-bearing URL out of history. |
| TanStack Start | The server route the cookie handler mounts on, and the root-loader seed — including why `seed.headers` must be forwarded. |
| Next.js App Router | The provider stays inside the `"use client"` boundary; the catch-all Route Handler for the cookie transport; and a warning against seeding from a layout. |

Two of those are load-bearing rather than stylistic. `getInitialToken()` rotates the session cookie, so a caller that cannot set cookies on the response silently drops the new token — and the browser then presents the superseded one, which reads as **token reuse** once it falls outside the reuse window and kills the session. In the App Router a Server Component cannot set cookies (only Route Handlers, Server Actions and middleware can), so the correct advice there is not to seed at all and let the provider's `/token` round-trip run after hydration. The Start page states the same constraint positively, since `setResponseHeaders` in a server function *can* honour it.

The session-mode guide now links back to all four pages from its cookie-transport section. Docs site builds clean.