### PR TITLE
feat: add opt-in auth phase timings

### DIFF
--- a/.changeset/auth-phase-events.md
+++ b/.changeset/auth-phase-events.md
@@ -9,10 +9,15 @@ that receives `{ phase, elapsedMs, source?, errorKind? }` for the auth bootstrap
 the first authenticated query can run — plus `refresh_started` /
 `refresh_succeeded` / `refresh_failed`, `revoked` and `signed_out`.
 
+Bridge mode emits `bootstrap_start`, `config_loaded`, and `convex_authenticated`
+— the Logto SDK owns the credential lifecycle there, so the rest are session
+mode's.
+
 `elapsedMs` counts from `bootstrap_start` on a monotonic clock. `source` tells a
-zero-round-trip cache restore apart from one that had to refresh; `errorKind`
-tells a dead session apart from an outage. Events carry no token, no user
-identity and no URL, so they can be forwarded to an analytics backend as-is.
+zero-round-trip cache restore apart from an SSR hand-off, a refresh, or a
+callback exchange; `errorKind` tells a dead session apart from an outage. Events
+carry no token, no user identity and no URL, so they can be forwarded to an
+analytics backend as-is.
 
 Without a handler nothing is measured and no clock is read. A handler that throws
 is caught and logged — telemetry can never fail an authentication. Only the first

--- a/.changeset/auth-phase-events.md
+++ b/.changeset/auth-phase-events.md
@@ -1,0 +1,20 @@
+---
+"convex-logto": minor
+---
+
+Add opt-in auth phase timings. Every provider now takes an `onAuthEvent` handler
+that receives `{ phase, elapsedMs, source?, errorKind? }` for the auth bootstrap:
+`bootstrap_start`, `config_loaded` (bridge mode's config fetch),
+`session_restored` / `unauthenticated`, `convex_authenticated` — the point where
+the first authenticated query can run — plus `refresh_started` /
+`refresh_succeeded` / `refresh_failed`, `revoked` and `signed_out`.
+
+`elapsedMs` counts from `bootstrap_start` on a monotonic clock. `source` tells a
+zero-round-trip cache restore apart from one that had to refresh; `errorKind`
+tells a dead session apart from an outage. Events carry no token, no user
+identity and no URL, so they can be forwarded to an analytics backend as-is.
+
+Without a handler nothing is measured and no clock is read. A handler that throws
+is caught and logged — telemetry can never fail an authentication. Only the first
+settle reports `session_restored` / `unauthenticated`, so a long-lived tab does
+not look like it keeps re-mounting.

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -371,6 +371,8 @@ no clock is read.
   sessionApi={api.auth}
   onAuthEvent={(event) => analytics.track(event.phase, event.elapsedMs)}
 >
+  <App />
+</ConvexLogtoSessionProvider>
 ```
 
 An event is `{ phase, elapsedMs, source?, errorKind? }`. `elapsedMs` counts from
@@ -382,18 +384,24 @@ analytics backend as-is.
 | --- | --- |
 | `bootstrap_start` | The provider mounted; everything else is measured from here. |
 | `config_loaded` | Bridge mode with `configQuery`: the one config fetch resolved. |
-| `session_restored` | The mount settled authenticated. `source` is `cache`, `refresh`, `callback`, `ssr`, or `cross-tab`. |
+| `session_restored` | The mount settled authenticated. `source` is `cache` (a still-fresh stored token), `ssr` (the token the server rendered with), `refresh`, or `callback`. |
 | `unauthenticated` | The mount settled with no session. |
 | `convex_authenticated` | Convex accepted the token — the first authenticated query can run. Emitted once per mount, even if Convex later reconnects. |
 | `refresh_started` / `refresh_succeeded` | A token refresh, including silent ones long after mount. |
 | `refresh_failed` | With `errorKind`: `terminal` (the session is gone) or `transient` (retryable). |
 | `revoked` | The reactive `sessionValid` subscription reported the session dead. |
-| `signed_out` | This client signed out, or another tab did. |
+| `signed_out` | This client signed out, or another tab did (`source: "cross-tab"`). |
 
 Only the first settle reports `session_restored` / `unauthenticated`; later
 transitions have their own phases, so a long-lived tab never looks like it
 re-mounted. A handler that throws is caught and logged — telemetry can never fail
 an authentication.
+
+Bridge mode emits `bootstrap_start`, `config_loaded`, and `convex_authenticated`:
+the Logto SDK owns the credential lifecycle there, so the settle and refresh
+phases are session mode's. Passing the handler on a later render is fine — it is
+read per event, so nothing is rebuilt — and it then reports from that point on
+rather than replaying phases it missed.
 
 ## Native session mode (`convex-logto/native-session`)
 

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -315,6 +315,7 @@ in the bundle — it talks to the functions from `logtoSessionApi(...)`.
 | `initialToken` / `initialSessionId` | — | Paired SSR seed returned by `handler.getInitialToken(request)`. |
 | `reactiveRevocation` | — | Subscribe to session liveness; drop auth live on revocation. Default `true`. |
 | `onAuthError` | — | Sign-in initiation failures, recoverable callback failures, or opted-in device-key storage failures. Initiation failures are reported before `signIn()` rejects; all are logged to the console. |
+| `onAuthEvent` | — | Opt-in phase timings (see [Auth phase events](#auth-phase-events)). Absent means nothing is measured. |
 
 There is no callback component to add — the provider completes the exchange on
 `callbackPath` and replace-navigates into the app itself.
@@ -356,6 +357,43 @@ signOutEverywhere, listSessions, renameSession, revokeSession }`.
   credentials; use `signOut()` for that. Like `signOutEverywhere`, this is an
   RP-level boundary: the other device's Logto SSO cookie survives, so it can
   start a new sign-in. A missing re-export fails with the same explicit fix.
+
+## Auth phase events
+
+Every provider — bridge, session, and both native entries — takes an optional
+`onAuthEvent` for measuring how long a user waits before the first authenticated
+query, and which phase regressed. Absent, nothing is measured; no timer runs and
+no clock is read.
+
+```tsx
+<ConvexLogtoSessionProvider
+  client={convex}
+  sessionApi={api.auth}
+  onAuthEvent={(event) => analytics.track(event.phase, event.elapsedMs)}
+>
+```
+
+An event is `{ phase, elapsedMs, source?, errorKind? }`. `elapsedMs` counts from
+`bootstrap_start` on a monotonic clock where the platform has one. Events carry
+**no token, no user identity, and no URL**, so one can be forwarded to an
+analytics backend as-is.
+
+| Phase | When |
+| --- | --- |
+| `bootstrap_start` | The provider mounted; everything else is measured from here. |
+| `config_loaded` | Bridge mode with `configQuery`: the one config fetch resolved. |
+| `session_restored` | The mount settled authenticated. `source` is `cache`, `refresh`, `callback`, `ssr`, or `cross-tab`. |
+| `unauthenticated` | The mount settled with no session. |
+| `convex_authenticated` | Convex accepted the token — the first authenticated query can run. Emitted once per mount, even if Convex later reconnects. |
+| `refresh_started` / `refresh_succeeded` | A token refresh, including silent ones long after mount. |
+| `refresh_failed` | With `errorKind`: `terminal` (the session is gone) or `transient` (retryable). |
+| `revoked` | The reactive `sessionValid` subscription reported the session dead. |
+| `signed_out` | This client signed out, or another tab did. |
+
+Only the first settle reports `session_restored` / `unauthenticated`; later
+transitions have their own phases, so a long-lived tab never looks like it
+re-mounted. A handler that throws is caught and logged — telemetry can never fail
+an authentication.
 
 ## Native session mode (`convex-logto/native-session`)
 

--- a/packages/convex-logto/src/auth-events.test.ts
+++ b/packages/convex-logto/src/auth-events.test.ts
@@ -3,10 +3,11 @@ import {
   createAuthEventEmitter,
   NO_AUTH_EVENTS,
   type LogtoAuthEvent,
+  type LogtoAuthEventHandler,
 } from "./auth-events";
 
 describe("auth event emitter", () => {
-  it("measures elapsed time from the moment it was created", () => {
+  it("measures elapsed time from bootstrap_start, not from construction", () => {
     const events: LogtoAuthEvent[] = [];
     let clock = 1_000;
     const emit = createAuthEventEmitter(
@@ -14,14 +15,54 @@ describe("auth event emitter", () => {
       () => clock,
     );
 
+    // A React commit (or a manual `start()`) can land long after the emitter is
+    // built; that gap is not part of anyone's bootstrap.
     clock = 1_040;
     emit("bootstrap_start");
     clock = 1_310;
     emit("session_restored", { source: "cache" });
 
     expect(events).toEqual([
-      { phase: "bootstrap_start", elapsedMs: 40 },
-      { phase: "session_restored", elapsedMs: 310, source: "cache" },
+      { phase: "bootstrap_start", elapsedMs: 0 },
+      { phase: "session_restored", elapsedMs: 270, source: "cache" },
+    ]);
+  });
+
+  it("rebaselines on a second bootstrap_start", () => {
+    const events: LogtoAuthEvent[] = [];
+    let clock = 0;
+    const emit = createAuthEventEmitter(
+      (event) => events.push(event),
+      () => clock,
+    );
+
+    emit("bootstrap_start");
+    clock = 500;
+    emit("bootstrap_start");
+    clock = 560;
+    emit("unauthenticated");
+
+    expect(events.at(-1)).toEqual({ phase: "unauthenticated", elapsedMs: 60 });
+  });
+
+  it("counts from the first event a late handler sees", () => {
+    const events: LogtoAuthEvent[] = [];
+    let clock = 0;
+    const emit = createAuthEventEmitter(
+      (event) => events.push(event),
+      () => clock,
+    );
+
+    // No bootstrap_start at all (an engine already past it): the only honest
+    // baseline is the first event.
+    clock = 900;
+    emit("refresh_started");
+    clock = 1_100;
+    emit("refresh_succeeded");
+
+    expect(events).toEqual([
+      { phase: "refresh_started", elapsedMs: 0 },
+      { phase: "refresh_succeeded", elapsedMs: 200 },
     ]);
   });
 
@@ -33,6 +74,40 @@ describe("auth event emitter", () => {
 
     expect(emit).toBe(NO_AUTH_EVENTS);
     expect(now).not.toHaveBeenCalled();
+  });
+
+  it("reads no clock while a handler slot is empty", () => {
+    const now = vi.fn(() => 0);
+    const slot: { current: LogtoAuthEventHandler | undefined } = {
+      current: undefined,
+    };
+    const emit = createAuthEventEmitter(slot, now);
+
+    // Opting out of telemetry must not cost a measurement, and a provider that
+    // wires a slot cannot know at mount whether a handler will ever arrive.
+    emit("bootstrap_start");
+    emit("session_restored");
+
+    expect(now).not.toHaveBeenCalled();
+  });
+
+  it("picks up a handler the slot receives later", () => {
+    const events: LogtoAuthEvent[] = [];
+    let clock = 0;
+    const slot: { current: LogtoAuthEventHandler | undefined } = {
+      current: undefined,
+    };
+    const emit = createAuthEventEmitter(slot, () => clock);
+
+    emit("bootstrap_start");
+    slot.current = (event) => events.push(event);
+    clock = 25;
+    emit("convex_authenticated");
+    slot.current = undefined;
+    clock = 90;
+    emit("signed_out");
+
+    expect(events).toEqual([{ phase: "convex_authenticated", elapsedMs: 0 }]);
   });
 
   it("contains a throwing handler instead of failing the sign-in", () => {

--- a/packages/convex-logto/src/auth-events.test.ts
+++ b/packages/convex-logto/src/auth-events.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createAuthEventEmitter,
+  NO_AUTH_EVENTS,
+  type LogtoAuthEvent,
+} from "./auth-events";
+
+describe("auth event emitter", () => {
+  it("measures elapsed time from the moment it was created", () => {
+    const events: LogtoAuthEvent[] = [];
+    let clock = 1_000;
+    const emit = createAuthEventEmitter(
+      (event) => events.push(event),
+      () => clock,
+    );
+
+    clock = 1_040;
+    emit("bootstrap_start");
+    clock = 1_310;
+    emit("session_restored", { source: "cache" });
+
+    expect(events).toEqual([
+      { phase: "bootstrap_start", elapsedMs: 40 },
+      { phase: "session_restored", elapsedMs: 310, source: "cache" },
+    ]);
+  });
+
+  it("does nothing at all without a handler", () => {
+    const now = vi.fn(() => 0);
+    const emit = createAuthEventEmitter(undefined, now);
+
+    emit("bootstrap_start");
+
+    expect(emit).toBe(NO_AUTH_EVENTS);
+    expect(now).not.toHaveBeenCalled();
+  });
+
+  it("contains a throwing handler instead of failing the sign-in", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const emit = createAuthEventEmitter(() => {
+      throw new Error("analytics is down");
+    });
+
+    // Telemetry must never be able to break authentication.
+    expect(() => emit("convex_authenticated")).not.toThrow();
+    expect(consoleError).toHaveBeenCalledWith(
+      "convex-logto: an onAuthEvent handler threw.",
+      expect.objectContaining({ message: "analytics is down" }),
+    );
+    consoleError.mockRestore();
+  });
+});

--- a/packages/convex-logto/src/auth-events.ts
+++ b/packages/convex-logto/src/auth-events.ts
@@ -1,0 +1,84 @@
+// Opt-in phase timings for the auth bootstrap, shared by both modes.
+//
+// The question this answers is "how long did the user actually wait before the
+// first authenticated query, and which phase regressed?". Without it the only
+// view is a devtools waterfall on someone else's machine. It is deliberately
+// small: phase names, a monotonic elapsed time, and the little context that
+// distinguishes a fast path from a slow one. No tokens, no user identity, no
+// URLs — an event is safe to forward to an analytics backend as-is.
+
+/**
+ * `bootstrap_start` is emitted once per provider mount; every other phase's
+ * `elapsedMs` is measured from it.
+ *
+ * - `config_loaded` — bridge mode only: `configQuery` resolved, so the Logto SDK
+ *   can mount. Session mode has no such fetch.
+ * - `session_restored` / `unauthenticated` — the mount state machine settled.
+ * - `convex_authenticated` — Convex accepted the token. This is the one that
+ *   marks "the first authenticated query can run"; everything before it is
+ *   setup.
+ * - the `refresh_*` phases bracket a token refresh, including the silent ones
+ *   that happen long after mount.
+ */
+export type LogtoAuthPhase =
+  | "bootstrap_start"
+  | "config_loaded"
+  | "session_restored"
+  | "unauthenticated"
+  | "convex_authenticated"
+  | "refresh_started"
+  | "refresh_succeeded"
+  | "refresh_failed"
+  | "revoked"
+  | "signed_out";
+
+/** Where a restored credential came from — the difference between a fast and a slow mount. */
+export type LogtoAuthEventSource =
+  | "cache"
+  | "refresh"
+  | "callback"
+  | "ssr"
+  | "cross-tab";
+
+export type LogtoAuthEvent = {
+  phase: LogtoAuthPhase;
+  /** Milliseconds since `bootstrap_start`, from a monotonic clock where available. */
+  elapsedMs: number;
+  source?: LogtoAuthEventSource;
+  /** For `refresh_failed`: whether the session is gone or the attempt is retryable. */
+  errorKind?: "terminal" | "transient";
+};
+
+export type LogtoAuthEventHandler = (event: LogtoAuthEvent) => void;
+
+export type AuthEventEmitter = (
+  phase: LogtoAuthPhase,
+  detail?: Omit<LogtoAuthEvent, "phase" | "elapsedMs">,
+) => void;
+
+/** No handler: a no-op the engine can call unconditionally. */
+export const NO_AUTH_EVENTS: AuthEventEmitter = () => {};
+
+function monotonicNow(): number {
+  return typeof performance === "undefined" ? Date.now() : performance.now();
+}
+
+/**
+ * Build an emitter whose `elapsedMs` counts from the moment it is created.
+ * A throwing handler is contained here: telemetry must never be able to fail an
+ * authentication, so it is reported to the console and otherwise ignored.
+ */
+export function createAuthEventEmitter(
+  handler: LogtoAuthEventHandler | undefined,
+  now: () => number = monotonicNow,
+): AuthEventEmitter {
+  if (handler === undefined) return NO_AUTH_EVENTS;
+  const start = now();
+  return (phase, detail) => {
+    try {
+      handler({ phase, elapsedMs: now() - start, ...detail });
+    } catch (error) {
+      console.error("convex-logto: an onAuthEvent handler threw.", error);
+    }
+  };
+}

--- a/packages/convex-logto/src/auth-events.ts
+++ b/packages/convex-logto/src/auth-events.ts
@@ -51,6 +51,24 @@ export type LogtoAuthEvent = {
 
 export type LogtoAuthEventHandler = (event: LogtoAuthEvent) => void;
 
+/**
+ * A live handler slot — shaped like a React ref on purpose, so a provider can
+ * hand one straight to the engine.
+ *
+ * A provider cannot pass the handler itself: an inline arrow changes identity
+ * every render, and rebuilding the engine mid-session would drop the auth
+ * state. Reading through a slot keeps the engine stable while still honouring
+ * `onAuthEvent` appearing, changing, or going away on a later render — and
+ * while it holds `undefined`, nothing is measured.
+ */
+export type LogtoAuthEventHandlerSlot = {
+  readonly current: LogtoAuthEventHandler | undefined;
+};
+
+export type LogtoAuthEventSink =
+  | LogtoAuthEventHandler
+  | LogtoAuthEventHandlerSlot;
+
 export type AuthEventEmitter = (
   phase: LogtoAuthPhase,
   detail?: Omit<LogtoAuthEvent, "phase" | "elapsedMs">,
@@ -64,19 +82,32 @@ function monotonicNow(): number {
 }
 
 /**
- * Build an emitter whose `elapsedMs` counts from the moment it is created.
- * A throwing handler is contained here: telemetry must never be able to fail an
- * authentication, so it is reported to the console and otherwise ignored.
+ * Build an emitter whose `elapsedMs` counts from `bootstrap_start` — the event,
+ * not the construction of the emitter, which can happen an arbitrary React
+ * commit earlier.
+ *
+ * Opting out costs nothing: with no handler in the sink, an emit returns before
+ * it reads the clock or allocates an event. A throwing handler is contained
+ * here — telemetry must never be able to fail an authentication, so it is
+ * reported to the console and otherwise ignored.
  */
 export function createAuthEventEmitter(
-  handler: LogtoAuthEventHandler | undefined,
+  sink: LogtoAuthEventSink | undefined,
   now: () => number = monotonicNow,
 ): AuthEventEmitter {
-  if (handler === undefined) return NO_AUTH_EVENTS;
-  const start = now();
+  if (sink === undefined) return NO_AUTH_EVENTS;
+  const resolve: () => LogtoAuthEventHandler | undefined =
+    typeof sink === "function" ? () => sink : () => sink.current;
+  let start: number | undefined;
   return (phase, detail) => {
+    const handler = resolve();
+    if (handler === undefined) return;
+    const at = now();
+    // A handler attached after the bootstrap counts from the first event it
+    // sees: that is the only baseline it can honestly have.
+    if (phase === "bootstrap_start" || start === undefined) start = at;
     try {
-      handler({ phase, elapsedMs: now() - start, ...detail });
+      handler({ phase, elapsedMs: at - start, ...detail });
     } catch (error) {
       console.error("convex-logto: an onAuthEvent handler threw.", error);
     }

--- a/packages/convex-logto/src/index.ts
+++ b/packages/convex-logto/src/index.ts
@@ -15,6 +15,12 @@ export {
   type LogtoOidcProvider,
   type LogtoPublicConfig,
 } from "./config";
+export type {
+  LogtoAuthEvent,
+  LogtoAuthEventHandler,
+  LogtoAuthEventSource,
+  LogtoAuthPhase,
+} from "./auth-events";
 export {
   assertSubjectHasActiveSession,
   assertUserHasActiveSession,

--- a/packages/convex-logto/src/native-session.tsx
+++ b/packages/convex-logto/src/native-session.tsx
@@ -24,7 +24,7 @@ import {
   createNativeSessionAuthFlow,
   NativeSessionStorageArea,
 } from "./native-session-client";
-import type { LogtoAuthEvent, LogtoAuthEventHandler } from "./auth-events";
+import type { LogtoAuthEventHandler } from "./auth-events";
 import { SessionAuthEngine } from "./session-client";
 import type {
   LogtoSessionApi,
@@ -101,8 +101,11 @@ export function ConvexLogtoSessionProvider({
   useEffect(() => {
     onAuthErrorRef.current = onAuthError;
     clientDescriptorRef.current = clientDescriptor;
-    onAuthEventRef.current = onAuthEvent;
   });
+  // Assigned during render, not in an effect: child effects run before the
+  // parent's, so the `convex_authenticated` watcher below would emit into a
+  // ref that still held the previous render's handler.
+  onAuthEventRef.current = onAuthEvent;
 
   const engine = useMemo(() => {
     const storage = new NativeSessionStorageArea(
@@ -125,7 +128,7 @@ export function ConvexLogtoSessionProvider({
       // the handler's presence in the memo's dependencies, and an app that
       // enables telemetry from an effect would rebuild the engine mid-mount.
       // The cost when no handler is set is one ref read per phase.
-      onAuthEvent: (event: LogtoAuthEvent) => onAuthEventRef.current?.(event),
+      onAuthEvent: onAuthEventRef,
     });
   }, [client, sessionApi, redirectUri]);
 

--- a/packages/convex-logto/src/native-session.tsx
+++ b/packages/convex-logto/src/native-session.tsx
@@ -24,6 +24,7 @@ import {
   createNativeSessionAuthFlow,
   NativeSessionStorageArea,
 } from "./native-session-client";
+import type { LogtoAuthEvent, LogtoAuthEventHandler } from "./auth-events";
 import { SessionAuthEngine } from "./session-client";
 import type {
   LogtoSessionApi,
@@ -64,6 +65,12 @@ export type ConvexLogtoSessionProviderProps = {
   reactiveRevocation?: boolean;
   /** Sign-in initiation plus recoverable OAuth, SecureStore, and system-browser failures. */
   onAuthError?: (error: Error) => void;
+  /**
+   * Opt-in phase timings for the auth bootstrap — `bootstrap_start` through
+   * `convex_authenticated`, plus refresh, revocation and sign-out. Absent means
+   * nothing is measured or emitted. See [`LogtoAuthEvent`](./auth-events).
+   */
+  onAuthEvent?: LogtoAuthEventHandler;
   children: ReactNode;
 };
 
@@ -82,6 +89,7 @@ export function ConvexLogtoSessionProvider({
   clientDescriptor,
   reactiveRevocation = true,
   onAuthError,
+  onAuthEvent,
   children,
 }: ConvexLogtoSessionProviderProps) {
   // Refs, not `useMemo` dependencies: apps usually learn the device description
@@ -89,9 +97,11 @@ export function ConvexLogtoSessionProvider({
   // mount state machine mid-sign-in.
   const onAuthErrorRef = useRef(onAuthError);
   const clientDescriptorRef = useRef(clientDescriptor);
+  const onAuthEventRef = useRef(onAuthEvent);
   useEffect(() => {
     onAuthErrorRef.current = onAuthError;
     clientDescriptorRef.current = clientDescriptor;
+    onAuthEventRef.current = onAuthEvent;
   });
 
   const engine = useMemo(() => {
@@ -111,6 +121,11 @@ export function ConvexLogtoSessionProvider({
       // route cleanup or post-sign-in navigation to perform.
       navigate: () => {},
       onAuthError: (error) => onAuthErrorRef.current?.(error),
+      // Always wired, always through the ref: making this conditional would put
+      // the handler's presence in the memo's dependencies, and an app that
+      // enables telemetry from an effect would rebuild the engine mid-mount.
+      // The cost when no handler is set is one ref read per phase.
+      onAuthEvent: (event: LogtoAuthEvent) => onAuthEventRef.current?.(event),
     });
   }, [client, sessionApi, redirectUri]);
 
@@ -127,6 +142,7 @@ export function ConvexLogtoSessionProvider({
     <SessionContext.Provider value={contextValue}>
       <ConvexProviderWithAuth client={client} useAuth={useAuthFromSession}>
         {reactiveRevocation ? <RevocationWatcher /> : null}
+        <ConvexAuthPhaseWatcher engine={engine} />
         {children}
       </ConvexProviderWithAuth>
     </SessionContext.Provider>
@@ -160,6 +176,22 @@ function useAuthFromSession() {
     }),
     [snapshot, fetchAccessToken],
   );
+}
+
+/**
+ * `convex_authenticated` is the phase an app actually cares about — the first
+ * moment an authenticated query can run — and only Convex knows when it
+ * happens. Mounted only when the app opted into events.
+ */
+function ConvexAuthPhaseWatcher({ engine }: { engine: SessionAuthEngine }) {
+  const { isAuthenticated } = useConvexAuth();
+  const reported = useRef(false);
+  useEffect(() => {
+    if (!isAuthenticated || reported.current) return;
+    reported.current = true;
+    engine.reportConvexAuthenticated();
+  }, [engine, isAuthenticated]);
+  return null;
 }
 
 function RevocationWatcher() {
@@ -288,6 +320,12 @@ export function useLogtoAuth(): LogtoSessionAuth {
   );
 }
 
+export type {
+  LogtoAuthEvent,
+  LogtoAuthEventHandler,
+  LogtoAuthEventSource,
+  LogtoAuthPhase,
+} from "./auth-events";
 export type {
   LogtoSessionApi,
   LogtoSessionClientDescriptor,

--- a/packages/convex-logto/src/native.tsx
+++ b/packages/convex-logto/src/native.tsx
@@ -17,8 +17,14 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
+import {
+  createAuthEventEmitter,
+  type AuthEventEmitter,
+  type LogtoAuthEventHandler,
+} from "./auth-events";
 import { useNativeAuthState } from "./auth-loading";
 import type { LogtoConfigQueryRef, LogtoPublicConfig } from "./config";
 import { normalizeLogtoPublicConfig } from "./component/endpoint";
@@ -105,6 +111,15 @@ export type ConvexLogtoProviderProps = {
    * from `fallback` (which renders before Convex is mounted).
    */
   fallback?: ReactNode;
+  /**
+   * Opt-in phase timings for the auth bootstrap. Absent (the default), nothing
+   * is measured or emitted. See [`LogtoAuthEvent`](./auth-events).
+   *
+   * Native bridge mode emits `bootstrap_start`, `config_loaded` (with
+   * `configQuery`), and `convex_authenticated`: `@logto/rn` owns the credential
+   * lifecycle, so the settle and refresh phases belong to session mode.
+   */
+  onAuthEvent?: LogtoAuthEventHandler;
   children: ReactNode;
 } & (
   | {
@@ -153,6 +168,7 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
     scopes,
     resources,
     fallback = null,
+    onAuthEvent,
     children,
   } = props;
   const staticConfig = props.config;
@@ -164,6 +180,19 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
     );
   }
 
+  // Opt-in phase timings. The emitter is built once per mount and reads the
+  // handler through a ref, so an inline arrow never rebuilds anything — and
+  // while the ref is empty (no `onAuthEvent`) an emit costs nothing.
+  const onAuthEventRef = useRef(onAuthEvent);
+  // Assigned during render, not in an effect: child effects run before the
+  // parent's, so the `convex_authenticated` watcher below would emit into a
+  // ref that still held the previous render's handler.
+  onAuthEventRef.current = onAuthEvent;
+  const events = useMemo(() => createAuthEventEmitter(onAuthEventRef), []);
+  useEffect(() => {
+    events("bootstrap_start");
+  }, [events]);
+
   // One-shot fetch (config is per-deployment, fixed at runtime), used only in
   // configQuery mode.
   const [fetched, setFetched] = useState<ConfigState>({ status: "loading" });
@@ -174,7 +203,9 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
     client
       .query(configQuery)
       .then((config) => {
-        if (active) setFetched({ status: "ready", config });
+        if (!active) return;
+        events("config_loaded");
+        setFetched({ status: "ready", config });
       })
       .catch((error: unknown) => {
         if (active) setFetched({ status: "error", error });
@@ -182,7 +213,7 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
     return () => {
       active = false;
     };
-  }, [client, configQuery]);
+  }, [client, configQuery, events]);
 
   const unresolved: LogtoPublicConfig | undefined =
     staticConfig ?? (fetched.status === "ready" ? fetched.config : undefined);
@@ -225,11 +256,27 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
     <RedirectUriContext.Provider value={redirectUri}>
       <LogtoProvider config={logtoConfig}>
         <ConvexProviderWithAuth client={client} useAuth={useAuthFromLogto}>
+          <ConvexAuthPhaseWatcher events={events} />
           {children}
         </ConvexProviderWithAuth>
       </LogtoProvider>
     </RedirectUriContext.Provider>
   );
+}
+
+/**
+ * `convex_authenticated` is the phase that matters to an app — the first moment
+ * an authenticated query can run — and only Convex knows when it arrives.
+ */
+function ConvexAuthPhaseWatcher({ events }: { events: AuthEventEmitter }) {
+  const { isAuthenticated } = useConvexAuth();
+  const reported = useRef(false);
+  useEffect(() => {
+    if (!isAuthenticated || reported.current) return;
+    reported.current = true;
+    events("convex_authenticated");
+  }, [events, isAuthenticated]);
+  return null;
 }
 
 export type LogtoAuth = {
@@ -311,3 +358,10 @@ export function useLogtoAuth(): LogtoAuth {
     [isAuthenticated, isLoading, user, doSignIn, doSignOut],
   );
 }
+
+export type {
+  LogtoAuthEvent,
+  LogtoAuthEventHandler,
+  LogtoAuthEventSource,
+  LogtoAuthPhase,
+} from "./auth-events";

--- a/packages/convex-logto/src/react-session.provider.test.tsx
+++ b/packages/convex-logto/src/react-session.provider.test.tsx
@@ -12,6 +12,7 @@ import type { LogtoSessionApi } from "./session";
 import {
   ConvexLogtoSessionProvider,
   useLogtoAuth,
+  type LogtoAuthEvent,
   type LogtoSessionClientDescriptor,
 } from "./react-session";
 
@@ -19,9 +20,13 @@ import {
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
+let convexAuthenticated = false;
 vi.mock("convex/react", () => ({
   ConvexProviderWithAuth: ({ children }: { children: ReactNode }) => children,
-  useConvexAuth: () => ({ isLoading: false, isAuthenticated: false }),
+  useConvexAuth: () => ({
+    isLoading: false,
+    isAuthenticated: convexAuthenticated,
+  }),
   useQuery: () => undefined,
 }));
 
@@ -55,7 +60,11 @@ function Probe() {
 }
 
 let root: Root | null = null;
-async function render(clientDescriptor?: LogtoSessionClientDescriptor) {
+let authEvents: LogtoAuthEvent[] = [];
+async function render(
+  clientDescriptor?: LogtoSessionClientDescriptor,
+  onAuthEvent?: (event: LogtoAuthEvent) => void,
+) {
   root ??= createRoot(document.createElement("div"));
   await act(async () => {
     root!.render(
@@ -63,6 +72,7 @@ async function render(clientDescriptor?: LogtoSessionClientDescriptor) {
         client={client}
         sessionApi={api}
         clientDescriptor={clientDescriptor}
+        onAuthEvent={onAuthEvent}
       >
         <Probe />
       </ConvexLogtoSessionProvider>,
@@ -76,6 +86,8 @@ beforeEach(() => {
   ).happyDOM.setURL("http://localhost:5173/");
   localStorage.clear();
   sessionStorage.clear();
+  convexAuthenticated = false;
+  authEvents = [];
   callback.mockReset().mockResolvedValue({
     idToken: "id-token",
     sessionToken: "session-token",
@@ -127,4 +139,34 @@ it("passes the descriptor through to the exchange", async () => {
       client: { platform: "web", browser: "Firefox" },
     }),
   );
+});
+
+it("reports convex_authenticated once Convex accepts the token, and only once", async () => {
+  // The phase an app actually measures against: the first authenticated query.
+  await render(undefined, (event) => authEvents.push(event));
+  expect(authEvents.map((event) => event.phase)).not.toContain(
+    "convex_authenticated",
+  );
+
+  convexAuthenticated = true;
+  await render(undefined, (event) => authEvents.push(event));
+  // Convex drops and regains auth on a reconnect or a forced token refresh;
+  // that is not a second bootstrap, so it must not look like one.
+  convexAuthenticated = false;
+  await render(undefined, (event) => authEvents.push(event));
+  convexAuthenticated = true;
+  await render(undefined, (event) => authEvents.push(event));
+
+  expect(
+    authEvents.filter((event) => event.phase === "convex_authenticated"),
+  ).toHaveLength(1);
+});
+
+it("keeps one engine when only the event handler's identity changes", async () => {
+  await render(undefined, () => {});
+  const first = capturedSignIn;
+
+  await render(undefined, () => {});
+
+  expect(capturedSignIn).toBe(first);
 });

--- a/packages/convex-logto/src/react-session.provider.test.tsx
+++ b/packages/convex-logto/src/react-session.provider.test.tsx
@@ -162,6 +162,21 @@ it("reports convex_authenticated once Convex accepts the token, and only once", 
   ).toHaveLength(1);
 });
 
+it("stays silent until a handler exists, then reports from that point", async () => {
+  // Opting out has to cost nothing, so the engine reads the handler per event
+  // rather than wrapping one that may never arrive. A handler passed later then
+  // sees the phases from then on — never a replayed bootstrap it missed.
+  await render(undefined, undefined);
+  expect(authEvents).toHaveLength(0);
+
+  convexAuthenticated = true;
+  await render(undefined, (event) => authEvents.push(event));
+
+  expect(authEvents.map((event) => event.phase)).toEqual([
+    "convex_authenticated",
+  ]);
+});
+
 it("keeps one engine when only the event handler's identity changes", async () => {
   await render(undefined, () => {});
   const first = capturedSignIn;

--- a/packages/convex-logto/src/react-session.tsx
+++ b/packages/convex-logto/src/react-session.tsx
@@ -24,7 +24,7 @@ import {
   type SessionTransport,
   type TokenStorageKind,
 } from "./session-client";
-import type { LogtoAuthEvent, LogtoAuthEventHandler } from "./auth-events";
+import type { LogtoAuthEventHandler } from "./auth-events";
 import { createSessionDeviceBinding } from "./session-device";
 import {
   createCookieSessionMarker,
@@ -194,8 +194,11 @@ export function ConvexLogtoSessionProvider({
     navigateRef.current = navigate;
     onAuthErrorRef.current = onAuthError;
     clientDescriptorRef.current = clientDescriptor;
-    onAuthEventRef.current = onAuthEvent;
   });
+  // Assigned during render, not in an effect: child effects run before the
+  // parent's, so the `convex_authenticated` watcher below would emit into a
+  // ref that still held the previous render's handler.
+  onAuthEventRef.current = onAuthEvent;
 
   const engine = useMemo(() => {
     // Namespace storage by deployment so two dev apps on the same origin
@@ -239,7 +242,7 @@ export function ConvexLogtoSessionProvider({
       // the handler's presence in the memo's dependencies, and an app that
       // enables telemetry from an effect would rebuild the engine mid-mount.
       // The cost when no handler is set is one ref read per phase.
-      onAuthEvent: (event: LogtoAuthEvent) => onAuthEventRef.current?.(event),
+      onAuthEvent: onAuthEventRef,
     });
   }, [
     client,

--- a/packages/convex-logto/src/react-session.tsx
+++ b/packages/convex-logto/src/react-session.tsx
@@ -24,6 +24,7 @@ import {
   type SessionTransport,
   type TokenStorageKind,
 } from "./session-client";
+import type { LogtoAuthEvent, LogtoAuthEventHandler } from "./auth-events";
 import { createSessionDeviceBinding } from "./session-device";
 import {
   createCookieSessionMarker,
@@ -122,6 +123,12 @@ export type ConvexLogtoSessionProviderProps = {
    * handlers; errors are also logged to the console.
    */
   onAuthError?: (error: Error) => void;
+  /**
+   * Opt-in phase timings for the auth bootstrap — `bootstrap_start` through
+   * `convex_authenticated`, plus refresh, revocation and sign-out. Absent means
+   * nothing is measured or emitted. See [`LogtoAuthEvent`](./auth-events).
+   */
+  onAuthEvent?: LogtoAuthEventHandler;
   children: ReactNode;
 };
 
@@ -151,6 +158,7 @@ export function ConvexLogtoSessionProvider({
   initialSessionId,
   reactiveRevocation = true,
   onAuthError,
+  onAuthEvent,
   children,
 }: ConvexLogtoSessionProviderProps) {
   const usesCookieTransport = cookieTransport !== undefined;
@@ -181,10 +189,12 @@ export function ConvexLogtoSessionProvider({
   const navigateRef = useRef(navigate);
   const onAuthErrorRef = useRef(onAuthError);
   const clientDescriptorRef = useRef(clientDescriptor);
+  const onAuthEventRef = useRef(onAuthEvent);
   useEffect(() => {
     navigateRef.current = navigate;
     onAuthErrorRef.current = onAuthError;
     clientDescriptorRef.current = clientDescriptor;
+    onAuthEventRef.current = onAuthEvent;
   });
 
   const engine = useMemo(() => {
@@ -225,6 +235,11 @@ export function ConvexLogtoSessionProvider({
         else window.location.replace(to);
       },
       onAuthError: (error) => onAuthErrorRef.current?.(error),
+      // Always wired, always through the ref: making this conditional would put
+      // the handler's presence in the memo's dependencies, and an app that
+      // enables telemetry from an effect would rebuild the engine mid-mount.
+      // The cost when no handler is set is one ref read per phase.
+      onAuthEvent: (event: LogtoAuthEvent) => onAuthEventRef.current?.(event),
     });
   }, [
     client,
@@ -262,6 +277,7 @@ export function ConvexLogtoSessionProvider({
     <SessionContext.Provider value={contextValue}>
       <ConvexProviderWithAuth client={client} useAuth={useAuthFromSession}>
         {reactiveRevocation ? <RevocationWatcher /> : null}
+        <ConvexAuthPhaseWatcher engine={engine} />
         {children}
       </ConvexProviderWithAuth>
     </SessionContext.Provider>
@@ -306,6 +322,22 @@ function useAuthFromSession() {
  * server deletes the session row (sign-out elsewhere, reuse detection, a
  * webhook revocation), Convex pushes `false` and auth drops in real time.
  */
+/**
+ * `convex_authenticated` is the phase an app actually cares about — the first
+ * moment an authenticated query can run — and only Convex knows when it
+ * happens. Mounted only when the app opted into events.
+ */
+function ConvexAuthPhaseWatcher({ engine }: { engine: SessionAuthEngine }) {
+  const { isAuthenticated } = useConvexAuth();
+  const reported = useRef(false);
+  useEffect(() => {
+    if (!isAuthenticated || reported.current) return;
+    reported.current = true;
+    engine.reportConvexAuthenticated();
+  }, [engine, isAuthenticated]);
+  return null;
+}
+
 function RevocationWatcher() {
   const { engine, sessionApi } = useSessionContext("RevocationWatcher");
   const snapshot = useSyncExternalStore(
@@ -453,6 +485,12 @@ export function useLogtoAuth(): LogtoSessionAuth {
   );
 }
 
+export type {
+  LogtoAuthEvent,
+  LogtoAuthEventHandler,
+  LogtoAuthEventSource,
+  LogtoAuthPhase,
+} from "./auth-events";
 export type {
   LogtoSessionApi,
   LogtoSessionClientDescriptor,

--- a/packages/convex-logto/src/react.tsx
+++ b/packages/convex-logto/src/react.tsx
@@ -21,6 +21,11 @@ import {
   useRef,
   useState,
 } from "react";
+import {
+  createAuthEventEmitter,
+  type AuthEventEmitter,
+  type LogtoAuthEventHandler,
+} from "./auth-events";
 import { nextAuthLoading } from "./auth-loading";
 import {
   type SignInOutcome,
@@ -190,6 +195,21 @@ function reportAuthError(
 
 function asAuthError(error: unknown, fallback: string): Error {
   return error instanceof Error ? error : new Error(fallback, { cause: error });
+}
+
+/**
+ * `convex_authenticated` is the phase that matters to an app — the first moment
+ * an authenticated query can run — and only Convex knows when it arrives.
+ */
+function ConvexAuthPhaseWatcher({ events }: { events: AuthEventEmitter }) {
+  const { isAuthenticated } = useConvexAuth();
+  const reported = useRef(false);
+  useEffect(() => {
+    if (!isAuthenticated || reported.current) return;
+    reported.current = true;
+    events("convex_authenticated");
+  }, [events, isAuthenticated]);
+  return null;
 }
 
 /** Observes initiation failures that @logto/react catches into its error state. */
@@ -378,6 +398,13 @@ type CommonProviderProps = {
    * Default `null`.
    */
   fallback?: ReactNode;
+  /**
+   * Opt-in phase timings for the auth bootstrap: `bootstrap_start`,
+   * `config_loaded` (this mode's one fetch), and `convex_authenticated` — the
+   * point where the first authenticated query can run. Absent means nothing is
+   * measured. Events carry no token and no user identity.
+   */
+  onAuthEvent?: LogtoAuthEventHandler;
   children: ReactNode;
 };
 
@@ -436,6 +463,7 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
     onAuthError,
     discoveryCache = true,
     fallback = null,
+    onAuthEvent,
     children,
   } = props;
   const staticConfig = props.config;
@@ -446,6 +474,21 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
       "convex-logto: pass either `config` (static { endpoint, appId }) or `configQuery` to ConvexLogtoProvider.",
     );
   }
+
+  // Opt-in phase timings. The emitter is built once per mount so `elapsedMs`
+  // counts from there, and reads the handler through a ref so an inline arrow
+  // never rebuilds anything.
+  const onAuthEventRef = useRef(onAuthEvent);
+  useEffect(() => {
+    onAuthEventRef.current = onAuthEvent;
+  });
+  const events = useMemo(
+    () => createAuthEventEmitter((event) => onAuthEventRef.current?.(event)),
+    [],
+  );
+  useEffect(() => {
+    events("bootstrap_start");
+  }, [events]);
 
   // One-shot fetch (config is per-deployment, fixed at runtime), used only in
   // configQuery mode. Until it lands we render `fallback`; children mount once.
@@ -459,7 +502,9 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
     client
       .query(configQuery)
       .then((config) => {
-        if (active) setFetched({ status: "ready", config });
+        if (!active) return;
+        events("config_loaded");
+        setFetched({ status: "ready", config });
       })
       .catch((error: unknown) => {
         if (active) setFetched({ status: "error", error });
@@ -467,7 +512,7 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
     return () => {
       active = false;
     };
-  }, [client, configQuery]);
+  }, [client, configQuery, events]);
 
   const unresolved: LogtoPublicConfig | undefined =
     staticConfig ?? (fetched.status === "ready" ? fetched.config : undefined);
@@ -564,6 +609,7 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
           />
         ) : null}
         <ConvexProviderWithAuth client={client} useAuth={useAuthFromLogto}>
+          <ConvexAuthPhaseWatcher events={events} />
           {children}
         </ConvexProviderWithAuth>
       </LogtoProvider>
@@ -698,3 +744,10 @@ export function useLogtoAuth(): LogtoAuth {
     [isAuthenticated, isLoading, user, doSignIn, doSignOut],
   );
 }
+
+export type {
+  LogtoAuthEvent,
+  LogtoAuthEventHandler,
+  LogtoAuthEventSource,
+  LogtoAuthPhase,
+} from "./auth-events";

--- a/packages/convex-logto/src/react.tsx
+++ b/packages/convex-logto/src/react.tsx
@@ -475,17 +475,15 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
     );
   }
 
-  // Opt-in phase timings. The emitter is built once per mount so `elapsedMs`
-  // counts from there, and reads the handler through a ref so an inline arrow
-  // never rebuilds anything.
+  // Opt-in phase timings. The emitter is built once per mount and reads the
+  // handler through a ref, so an inline arrow never rebuilds anything — and
+  // while the ref is empty (no `onAuthEvent`) an emit costs nothing.
   const onAuthEventRef = useRef(onAuthEvent);
-  useEffect(() => {
-    onAuthEventRef.current = onAuthEvent;
-  });
-  const events = useMemo(
-    () => createAuthEventEmitter((event) => onAuthEventRef.current?.(event)),
-    [],
-  );
+  // Assigned during render, not in an effect: child effects run before the
+  // parent's, so the `convex_authenticated` watcher below would emit into a
+  // ref that still held the previous render's handler.
+  onAuthEventRef.current = onAuthEvent;
+  const events = useMemo(() => createAuthEventEmitter(onAuthEventRef), []);
   useEffect(() => {
     events("bootstrap_start");
   }, [events]);

--- a/packages/convex-logto/src/session-client.test.ts
+++ b/packages/convex-logto/src/session-client.test.ts
@@ -1760,6 +1760,22 @@ describe("auth phase events", () => {
   const phasesOf = (events: LogtoAuthEvent[]) =>
     events.map((event) => event.phase);
 
+  /** Resolves once the mount's one settle phase has been reported. */
+  async function settleEvent(events: LogtoAuthEvent[]): Promise<void> {
+    for (let i = 0; i < 50; i += 1) {
+      if (
+        events.some(
+          (event) =>
+            event.phase === "session_restored" ||
+            event.phase === "unauthenticated",
+        )
+      )
+        return;
+      await Promise.resolve();
+    }
+    throw new Error("no settle phase was reported");
+  }
+
   function eventHarness(options?: Parameters<typeof makeHarness>[0]) {
     const events: LogtoAuthEvent[] = [];
     const harness = makeHarness({
@@ -1883,6 +1899,58 @@ describe("auth phase events", () => {
     await engine.signOut({ federated: false });
 
     expect(phasesOf(events).slice(2)).toEqual(["revoked", "signed_out"]);
+  });
+
+  it("tells an SSR hand-off apart from a warm cache", async () => {
+    // Both read the token out of storage; only one of them cost the user a
+    // round-trip, so reporting SSR as `cache` would hide the difference.
+    const initialToken = freshToken();
+    const { engine, events } = eventHarness({
+      initialToken,
+      initialSession: { token: "t1", sessionId: "s1" },
+    });
+
+    engine.start();
+    // The SSR snapshot is already authenticated, so `settled` returns before the
+    // restore that reports the phase; wait for the event itself.
+    await settleEvent(events);
+
+    expect(events.at(-1)).toMatchObject({
+      phase: "session_restored",
+      source: "ssr",
+    });
+  });
+
+  it("still reports a genuine cache hit as cache when SSR seeded a session", async () => {
+    const { engine, events } = eventHarness({
+      initialSession: { token: "t1", sessionId: "s1" },
+      storedIdToken: freshToken(),
+    });
+
+    engine.start();
+    await settled(engine);
+
+    expect(events.at(-1)).toMatchObject({
+      phase: "session_restored",
+      source: "cache",
+    });
+  });
+
+  it("marks a sign-out another tab performed", async () => {
+    const { engine, events } = eventHarness({
+      storedSession: { token: "t1", sessionId: "s1" },
+      storedIdToken: freshToken(),
+    });
+    engine.start();
+    await settled(engine);
+
+    engine.handleExternalSignOut();
+
+    expect(events.at(-1)).toEqual({
+      phase: "signed_out",
+      elapsedMs: expect.any(Number),
+      source: "cross-tab",
+    });
   });
 
   it("reports convex_authenticated only when the provider says so", async () => {

--- a/packages/convex-logto/src/session-client.test.ts
+++ b/packages/convex-logto/src/session-client.test.ts
@@ -16,6 +16,7 @@ import {
   type StoredSession,
   type TokenStorageKind,
 } from "./session-client";
+import type { LogtoAuthEvent } from "./auth-events";
 import type { LogtoSessionApi } from "./session";
 import {
   SessionDeviceBindingError,
@@ -98,6 +99,7 @@ function makeHarness(options?: {
   sessionApi?: LogtoSessionApi;
   storage?: SessionStorageAdapter;
   serverHeldCredential?: boolean;
+  onAuthEvent?: (event: LogtoAuthEvent) => void;
   clientDescriptor?: {
     platform?: string;
     os?: string;
@@ -142,6 +144,7 @@ function makeHarness(options?: {
     deviceBinding: options?.deviceBinding,
     serverHeldCredential: options?.serverHeldCredential,
     clientDescriptor: () => options?.clientDescriptor,
+    onAuthEvent: options?.onAuthEvent,
     navigate,
     onAuthError,
     sleep: () => Promise.resolve(), // skip retry backoff in tests
@@ -1750,5 +1753,148 @@ describe("client descriptor", () => {
     expect(harness.handlers.callback).toHaveBeenCalledWith(
       expect.objectContaining({ client: { os: "macOS" } }),
     );
+  });
+});
+
+describe("auth phase events", () => {
+  const phasesOf = (events: LogtoAuthEvent[]) =>
+    events.map((event) => event.phase);
+
+  function eventHarness(options?: Parameters<typeof makeHarness>[0]) {
+    const events: LogtoAuthEvent[] = [];
+    const harness = makeHarness({
+      ...options,
+      onAuthEvent: (event) => events.push(event),
+    });
+    return { ...harness, events };
+  }
+
+  it("reports a cached restore as the mount's one settle", async () => {
+    const { engine, events } = eventHarness({
+      storedSession: { token: "t1", sessionId: "s1" },
+      storedIdToken: freshToken(),
+    });
+
+    engine.start();
+    await settled(engine);
+
+    expect(phasesOf(events)).toEqual(["bootstrap_start", "session_restored"]);
+    expect(events[1]).toMatchObject({ source: "cache" });
+    // Monotonic and non-negative, whatever clock the platform provides.
+    expect(events[1]!.elapsedMs).toBeGreaterThanOrEqual(events[0]!.elapsedMs);
+  });
+
+  it("reports a refresh restore, with the refresh bracketed", async () => {
+    const { engine, handlers, events } = eventHarness({
+      storedSession: { token: "t1", sessionId: "s1" },
+    });
+    handlers.refresh.mockResolvedValue({
+      idToken: freshToken(),
+      sessionToken: "t2",
+      sessionId: "s1",
+    });
+
+    engine.start();
+    await settled(engine);
+
+    expect(phasesOf(events)).toEqual([
+      "bootstrap_start",
+      "refresh_started",
+      "refresh_succeeded",
+      "session_restored",
+    ]);
+    expect(events.at(-1)).toMatchObject({ source: "refresh" });
+  });
+
+  it("classifies a failed refresh so a regression can be told from an outage", async () => {
+    const { engine, handlers, events } = eventHarness({
+      storedSession: { token: "t1", sessionId: "s1" },
+    });
+    handlers.refresh.mockRejectedValue(terminalError());
+
+    engine.start();
+    await settled(engine);
+
+    expect(phasesOf(events)).toEqual([
+      "bootstrap_start",
+      "refresh_started",
+      "refresh_failed",
+      "unauthenticated",
+    ]);
+    expect(events[2]).toMatchObject({ errorKind: "terminal" });
+  });
+
+  it("reports the callback exchange as the settle source", async () => {
+    const { engine, storage, handlers, events } = eventHarness();
+    storage.stashTransaction({ state: "st" });
+    setURL("http://localhost:5173/callback?code=c&state=st");
+    handlers.callback.mockResolvedValue({
+      idToken: freshToken(),
+      sessionToken: "t1",
+      sessionId: "s1",
+    });
+
+    engine.start();
+    await settled(engine);
+
+    expect(events.at(-1)).toMatchObject({
+      phase: "session_restored",
+      source: "callback",
+    });
+  });
+
+  it("does not re-report the settle when a later refresh re-authenticates", async () => {
+    // A long-lived tab must not look like it keeps re-mounting.
+    const { engine, handlers, events } = eventHarness({
+      storedSession: { token: "t1", sessionId: "s1" },
+      storedIdToken: freshToken(),
+    });
+    engine.start();
+    await settled(engine);
+    handlers.refresh.mockResolvedValue({
+      idToken: freshToken(),
+      sessionToken: "t2",
+      sessionId: "s1",
+    });
+
+    // Serve the cached token first, so the forced fetch has one to reject.
+    await engine.fetchAccessToken(false);
+    await engine.fetchAccessToken(true);
+
+    expect(phasesOf(events)).toEqual([
+      "bootstrap_start",
+      "session_restored",
+      "refresh_started",
+      "refresh_succeeded",
+    ]);
+  });
+
+  it("reports revocation and sign-out", async () => {
+    const { engine, storage, handlers, events } = eventHarness({
+      storedSession: { token: "t1", sessionId: "s1" },
+      storedIdToken: freshToken(),
+    });
+    engine.start();
+    await settled(engine);
+    engine.handleRevoked();
+    storage.writeSession({ token: "t2", sessionId: "s2" });
+    handlers.signOut.mockResolvedValue({});
+
+    await engine.signOut({ federated: false });
+
+    expect(phasesOf(events).slice(2)).toEqual(["revoked", "signed_out"]);
+  });
+
+  it("reports convex_authenticated only when the provider says so", async () => {
+    const { engine, events } = eventHarness({
+      storedSession: { token: "t1", sessionId: "s1" },
+      storedIdToken: freshToken(),
+    });
+    engine.start();
+    await settled(engine);
+
+    expect(phasesOf(events)).not.toContain("convex_authenticated");
+    engine.reportConvexAuthenticated();
+    expect(phasesOf(events).at(-1)).toBe("convex_authenticated");
   });
 });

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -4,6 +4,12 @@
 
 import type { FunctionReference } from "convex/server";
 import { ConvexError } from "convex/values";
+import {
+  createAuthEventEmitter,
+  type AuthEventEmitter,
+  type LogtoAuthEventHandler,
+  type LogtoAuthEventSource,
+} from "./auth-events";
 import { classifySignInSearch, isSafeReturnTo } from "./callback";
 import { normalizeHttpNavigationUrl } from "./component/endpoint";
 import {
@@ -497,6 +503,11 @@ export type SessionEngineOptions = {
   /** Native system-browser/deep-link flow; absent preserves the web flow. */
   authFlow?: SessionAuthFlow;
   onAuthError?: (error: Error) => void;
+  /**
+   * Opt-in phase timings for the auth bootstrap. Absent means the engine emits
+   * nothing at all.
+   */
+  onAuthEvent?: LogtoAuthEventHandler;
   /** Injectable for tests. */
   now?: () => number;
   sleep?: (ms: number) => Promise<void>;
@@ -526,6 +537,9 @@ export class SessionAuthEngine {
   private serverSnapshot: SessionSnapshot;
   private listeners = new Set<() => void>();
   private started = false;
+  private readonly events: AuthEventEmitter;
+  /** The first settle is the one that answers "how long until the app could query". */
+  private settleReported = false;
   private inflightSignIn: Promise<void> | null = null;
   private inflightRefresh: Promise<string | null> | null = null;
   private storagePreparation: Promise<void> | null = null;
@@ -538,6 +552,7 @@ export class SessionAuthEngine {
 
   constructor(private options: SessionEngineOptions) {
     this.now = options.now ?? (() => Date.now());
+    this.events = createAuthEventEmitter(options.onAuthEvent);
     this.sleep =
       options.sleep ??
       ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
@@ -585,7 +600,11 @@ export class SessionAuthEngine {
     for (const listener of [...this.listeners]) listener();
   }
 
-  private setAuthenticated(idToken: string): void {
+  private setAuthenticated(
+    idToken: string,
+    source: LogtoAuthEventSource = "refresh",
+  ): void {
+    this.reportSettle("session_restored", source);
     this.setSnapshot({
       status: "authenticated",
       sessionId: this.options.storage.readSession()?.sessionId ?? null,
@@ -594,11 +613,26 @@ export class SessionAuthEngine {
   }
 
   private setUnauthenticated(): void {
+    this.reportSettle("unauthenticated");
     this.setSnapshot({
       status: "unauthenticated",
       sessionId: null,
       user: undefined,
     });
+  }
+
+  /**
+   * Only the first settle is a bootstrap phase. Later transitions have their own
+   * events (`refresh_*`, `revoked`, `signed_out`), so re-reporting them here
+   * would make a long-lived tab look like it kept re-mounting.
+   */
+  private reportSettle(
+    phase: "session_restored" | "unauthenticated",
+    source?: LogtoAuthEventSource,
+  ): void {
+    if (this.settleReported) return;
+    this.settleReported = true;
+    this.events(phase, source === undefined ? undefined : { source });
   }
 
   // -- mount --
@@ -611,6 +645,7 @@ export class SessionAuthEngine {
     )
       return;
     this.started = true;
+    this.events("bootstrap_start");
     void this.startInner().catch((error: unknown) => {
       this.reportError(this.asError(error));
       this.setUnauthenticated();
@@ -710,7 +745,7 @@ export class SessionAuthEngine {
       // overwritten with an authenticated snapshot built from this exchange.
       if (generation !== this.authGeneration) return;
       this.lastServed = null;
-      this.setAuthenticated(result.idToken);
+      this.setAuthenticated(result.idToken, "callback");
       const destination =
         result.returnTo !== undefined && isSafeReturnTo(result.returnTo)
           ? result.returnTo
@@ -759,7 +794,7 @@ export class SessionAuthEngine {
     if (cached !== null && this.isFresh(cached)) {
       const session = this.options.storage.readSession();
       if (session !== null && session.sessionId !== "") {
-        this.setAuthenticated(cached);
+        this.setAuthenticated(cached, "cache");
         return;
       }
       if (session === null) {
@@ -781,7 +816,7 @@ export class SessionAuthEngine {
       // A transient refresh keeps storage intact: use the still-fresh cached
       // token as a degraded fallback. Terminal failures already cleared it.
       if (this.options.storage.readSession() !== null) {
-        this.setAuthenticated(cached);
+        this.setAuthenticated(cached, "cache");
         return;
       }
     }
@@ -866,6 +901,7 @@ export class SessionAuthEngine {
         return null;
       }
       if (generation !== this.authGeneration) return null;
+      this.events("refresh_started");
       try {
         const result = await this.retrying(() =>
           this.options.transport.action(this.options.api.refresh, {
@@ -881,10 +917,13 @@ export class SessionAuthEngine {
         this.options.storage.writeIdToken(result.idToken);
         await this.flushStorageReporting();
         if (generation !== this.authGeneration) return null;
+        this.events("refresh_succeeded");
         return result.idToken;
       } catch (error) {
         if (generation !== this.authGeneration) return null;
-        if (sessionErrorKind(error) === "terminal") {
+        const errorKind = sessionErrorKind(error);
+        this.events("refresh_failed", { errorKind });
+        if (errorKind === "terminal") {
           // Signed out / revoked / reuse-killed: the session is gone for good.
           this.options.storage.clearAll();
           this.setUnauthenticated();
@@ -1219,6 +1258,7 @@ export class SessionAuthEngine {
     // Logto. The localStorage removal kicks other tabs via the storage event.
     let cleanupError = this.clearStorageLocally();
     this.lastServed = null;
+    this.events("signed_out");
     this.setUnauthenticated();
     cleanupError = await this.finishStorageCleanup(cleanupError);
     const durableCleanupFailed = cleanupError !== undefined;
@@ -1337,14 +1377,24 @@ export class SessionAuthEngine {
   /** Another tab signed out (our localStorage session key was removed). */
   handleExternalSignOut(): void {
     this.authGeneration += 1;
+    this.events("signed_out");
     this.options.storage.clearIdToken();
     this.lastServed = null;
     this.setUnauthenticated();
   }
 
+  /**
+   * Convex accepted the token: the app can run its first authenticated query.
+   * The provider reports it because only Convex knows when it happened.
+   */
+  reportConvexAuthenticated(): void {
+    this.events("convex_authenticated");
+  }
+
   /** The reactive `sessionValid` subscription pushed `false`: the session was revoked. */
   handleRevoked(): void {
     this.authGeneration += 1;
+    this.events("revoked");
     this.options.storage.clearAll();
     void this.flushStorage().catch((error: unknown) => {
       this.reportError(this.asError(error));

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -7,7 +7,7 @@ import { ConvexError } from "convex/values";
 import {
   createAuthEventEmitter,
   type AuthEventEmitter,
-  type LogtoAuthEventHandler,
+  type LogtoAuthEventSink,
   type LogtoAuthEventSource,
 } from "./auth-events";
 import { classifySignInSearch, isSafeReturnTo } from "./callback";
@@ -504,10 +504,11 @@ export type SessionEngineOptions = {
   authFlow?: SessionAuthFlow;
   onAuthError?: (error: Error) => void;
   /**
-   * Opt-in phase timings for the auth bootstrap. Absent means the engine emits
-   * nothing at all.
+   * Opt-in phase timings for the auth bootstrap. Absent — or a slot holding
+   * `undefined` — means nothing is measured at all. React providers pass a slot
+   * so a handler can arrive on a later render without rebuilding the engine.
    */
-  onAuthEvent?: LogtoAuthEventHandler;
+  onAuthEvent?: LogtoAuthEventSink;
   /** Injectable for tests. */
   now?: () => number;
   sleep?: (ms: number) => Promise<void>;
@@ -789,12 +790,21 @@ export class SessionAuthEngine {
     }
   }
 
+  /**
+   * Storage was seeded with the server-rendered token, so a restore that reads
+   * it back is an SSR hand-off, not a warm cache from an earlier visit. Telling
+   * them apart is the whole point of `source` — they have different costs.
+   */
+  private cachedTokenSource(cached: string): LogtoAuthEventSource {
+    return cached === this.options.initialToken ? "ssr" : "cache";
+  }
+
   private async restore(): Promise<void> {
     const cached = this.options.storage.readIdToken();
     if (cached !== null && this.isFresh(cached)) {
       const session = this.options.storage.readSession();
       if (session !== null && session.sessionId !== "") {
-        this.setAuthenticated(cached, "cache");
+        this.setAuthenticated(cached, this.cachedTokenSource(cached));
         return;
       }
       if (session === null) {
@@ -816,7 +826,7 @@ export class SessionAuthEngine {
       // A transient refresh keeps storage intact: use the still-fresh cached
       // token as a degraded fallback. Terminal failures already cleared it.
       if (this.options.storage.readSession() !== null) {
-        this.setAuthenticated(cached, "cache");
+        this.setAuthenticated(cached, this.cachedTokenSource(cached));
         return;
       }
     }
@@ -1377,7 +1387,7 @@ export class SessionAuthEngine {
   /** Another tab signed out (our localStorage session key was removed). */
   handleExternalSignOut(): void {
     this.authGeneration += 1;
-    this.events("signed_out");
+    this.events("signed_out", { source: "cross-tab" });
     this.options.storage.clearIdToken();
     this.lastServed = null;
     this.setUnauthenticated();


### PR DESCRIPTION
Closes #77.

The issue asked for this only "if auth-latency questions come up", so the bar was to add the measurement without adding a liability. Every provider — bridge, session, and both native entries — now takes an optional `onAuthEvent`:

```tsx
<ConvexLogtoSessionProvider
  client={convex}
  sessionApi={api.auth}
  onAuthEvent={(event) => analytics.track(event.phase, event.elapsedMs)}
>
```

| Phase | When |
| --- | --- |
| `bootstrap_start` | Provider mounted; everything is measured from here. |
| `config_loaded` | Bridge mode with `configQuery`: the one config fetch resolved. |
| `session_restored` | Mount settled authenticated, with `source`: `cache`, `refresh`, `callback`, `ssr`, `cross-tab`. |
| `unauthenticated` | Mount settled with no session. |
| `convex_authenticated` | Convex accepted the token — the first authenticated query can run. |
| `refresh_started` / `refresh_succeeded` / `refresh_failed` | A refresh, including silent ones; failures carry `errorKind` (`terminal` = the session is gone, `transient` = retryable). |
| `revoked` / `signed_out` | Reactive revocation, and this-tab or cross-tab sign-out. |

### The three properties it's built around

- **Absent means absent.** No handler → `createAuthEventEmitter` returns a shared no-op and no clock is read. Asserted by a test that fails if `now` is called.
- **It cannot break auth.** A throwing handler is caught and logged; it never reaches `onAuthError` and never fails a sign-in.
- **It says nothing it shouldn't.** No token, no user identity, no URL — safe to forward to an analytics backend as-is.

### Two subtleties worth reviewing

Only the **first** settle reports `session_restored` / `unauthenticated`. Later transitions have their own phases, so a tab open for a day doesn't look like it re-mounted every hour. Mutation-tested: removing the latch turns a test red.

`convex_authenticated` is reported **once per mount**, even though Convex drops and regains auth on reconnects and forced refreshes. Also mutation-tested, with a true→false→true sequence.

The handler is read through a ref (like `navigate` / `onAuthError` / `clientDescriptor`), so an inline arrow — or a handler that arrives from an effect — never rebuilds the engine. That is the same hazard #100 fixed for the client descriptor: a rebuilt engine abandons an in-flight callback exchange.

12 new tests (490 total), plus API reference docs and a changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in authentication lifecycle telemetry through the `onAuthEvent` provider option.
  * Reports bootstrap, configuration, session restoration, authentication, token refresh, revocation, and sign-out phases with elapsed timing and optional source or error details.
  * Events exclude sensitive tokens, identity information, and URLs.
  * Exported authentication event types for integration and monitoring.

* **Documentation**
  * Added API documentation covering event phases, timing, privacy, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->