### PR TITLE
docs: list onAuthEvent in the three prop tables that missed it

### DIFF
--- a/.changeset/auth-phase-events.md
+++ b/.changeset/auth-phase-events.md
@@ -9,9 +9,9 @@ that receives `{ phase, elapsedMs, source?, errorKind? }` for the auth bootstrap
 the first authenticated query can run — plus `refresh_started` /
 `refresh_succeeded` / `refresh_failed`, `revoked` and `signed_out`.
 
-Bridge mode emits `bootstrap_start`, `config_loaded`, and `convex_authenticated`
-— the Logto SDK owns the credential lifecycle there, so the rest are session
-mode's.
+Bridge mode emits `bootstrap_start`, `convex_authenticated`, and — in
+`configQuery` mode, the only mode with a fetch to time — `config_loaded`. The
+Logto SDK owns the credential lifecycle there, so the rest are session mode's.
 
 `elapsedMs` counts from `bootstrap_start` on a monotonic clock. `source` tells a
 zero-round-trip cache restore apart from an SSR hand-off, a refresh, or a

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -263,6 +263,7 @@ to resolve it from the backend at runtime. Exactly one of the two.
 | `navigate` | — | Soft navigation (your router's `navigate`). Optional for plain Vite; **recommended for any router** (TanStack / Next) so post-sign-in is a soft navigation rather than a full-page reload that drops router state. Prefer a replace-style navigate. Falls back to a hard `location.replace`. |
 | `onAuthError` | — | Called on sign-in initiation failures (Logto unreachable, blocked storage, in-app browser restrictions) and recoverable callback failures (stale/replayed callback, setup errors like `invalid_scope`). Errors are also logged to the console. |
 | `discoveryCache` | — | Cache OIDC discovery + JWKS in sessionStorage. Default `true`. |
+| `onAuthEvent` | — | Opt-in phase timings (see [Auth phase events](#auth-phase-events)). Bridge mode emits `bootstrap_start`, `config_loaded`, and `convex_authenticated`. Absent means nothing is measured. |
 | `scopes` / `resources` | — | Extra OIDC scopes / API resources. `openid`, `profile`, `offline_access`, and `email` are always included. |
 
 Safe to render on the server: nothing touches `window` during render — no stub
@@ -429,6 +430,7 @@ device-binding option.
 | `redirectUri` | yes | Custom-scheme or universal-link callback registered as both a Redirect URI and Post sign-out redirect URI in Logto. |
 | `reactiveRevocation` | — | Subscribe to `sessionValid` and clear SecureStore immediately when revoked. Default `true`. |
 | `onAuthError` | — | Receives sign-in initiation failures plus recoverable OAuth, SecureStore, and system-browser failures; initiation failures are reported before `signIn()` rejects and all errors are logged. |
+| `onAuthEvent` | — | Opt-in phase timings (see [Auth phase events](#auth-phase-events)). Absent means nothing is measured. |
 
 `useLogtoAuth()` returns `{ isAuthenticated, isLoading, user, signIn,
 signOut, signOutEverywhere, listSessions, renameSession, revokeSession }`, with
@@ -481,6 +483,7 @@ and resolves when the deep link returns.
 | `redirectUri` | **yes** | Native callback URI — your `app.json` `scheme` plus a path (e.g. `io.logto://callback`), registered on the Logto app. The default for `signIn()`. |
 | `fallback` | — | Rendered while `configQuery` loads, before the Convex provider mounts. Default `null`. |
 | `scopes` / `resources` | — | Extra OIDC scopes / API resources. `openid`, `profile`, `offline_access`, and `email` are always included. |
+| `onAuthEvent` | — | Opt-in phase timings (see [Auth phase events](#auth-phase-events)): `bootstrap_start`, `config_loaded`, `convex_authenticated`. Absent means nothing is measured. |
 
 ### `useLogtoAuth()` (native)
 

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -263,7 +263,7 @@ to resolve it from the backend at runtime. Exactly one of the two.
 | `navigate` | — | Soft navigation (your router's `navigate`). Optional for plain Vite; **recommended for any router** (TanStack / Next) so post-sign-in is a soft navigation rather than a full-page reload that drops router state. Prefer a replace-style navigate. Falls back to a hard `location.replace`. |
 | `onAuthError` | — | Called on sign-in initiation failures (Logto unreachable, blocked storage, in-app browser restrictions) and recoverable callback failures (stale/replayed callback, setup errors like `invalid_scope`). Errors are also logged to the console. |
 | `discoveryCache` | — | Cache OIDC discovery + JWKS in sessionStorage. Default `true`. |
-| `onAuthEvent` | — | Opt-in phase timings (see [Auth phase events](#auth-phase-events)). Bridge mode emits `bootstrap_start`, `config_loaded`, and `convex_authenticated`. Absent means nothing is measured. |
+| `onAuthEvent` | — | Opt-in phase timings (see [Auth phase events](#auth-phase-events)). Bridge mode emits `bootstrap_start`, `convex_authenticated`, and — in `configQuery` mode only — `config_loaded`. Absent means nothing is measured. |
 | `scopes` / `resources` | — | Extra OIDC scopes / API resources. `openid`, `profile`, `offline_access`, and `email` are always included. |
 
 Safe to render on the server: nothing touches `window` during render — no stub
@@ -398,7 +398,8 @@ transitions have their own phases, so a long-lived tab never looks like it
 re-mounted. A handler that throws is caught and logged — telemetry can never fail
 an authentication.
 
-Bridge mode emits `bootstrap_start`, `config_loaded`, and `convex_authenticated`:
+Bridge mode emits `bootstrap_start`, `convex_authenticated`, and — only in
+`configQuery` mode, which is the only mode with a fetch to time — `config_loaded`:
 the Logto SDK owns the credential lifecycle there, so the settle and refresh
 phases are session mode's. Passing the handler on a later render is fine — it is
 read per event, so nothing is rebuilt — and it then reports from that point on
@@ -483,7 +484,7 @@ and resolves when the deep link returns.
 | `redirectUri` | **yes** | Native callback URI — your `app.json` `scheme` plus a path (e.g. `io.logto://callback`), registered on the Logto app. The default for `signIn()`. |
 | `fallback` | — | Rendered while `configQuery` loads, before the Convex provider mounts. Default `null`. |
 | `scopes` / `resources` | — | Extra OIDC scopes / API resources. `openid`, `profile`, `offline_access`, and `email` are always included. |
-| `onAuthEvent` | — | Opt-in phase timings (see [Auth phase events](#auth-phase-events)): `bootstrap_start`, `config_loaded`, `convex_authenticated`. Absent means nothing is measured. |
+| `onAuthEvent` | — | Opt-in phase timings (see [Auth phase events](#auth-phase-events)): `bootstrap_start`, `convex_authenticated`, plus `config_loaded` in `configQuery` mode. Absent means nothing is measured. |
 
 ### `useLogtoAuth()` (native)
 

--- a/packages/convex-logto/src/native.tsx
+++ b/packages/convex-logto/src/native.tsx
@@ -115,8 +115,8 @@ export type ConvexLogtoProviderProps = {
    * Opt-in phase timings for the auth bootstrap. Absent (the default), nothing
    * is measured or emitted. See [`LogtoAuthEvent`](./auth-events).
    *
-   * Native bridge mode emits `bootstrap_start`, `config_loaded` (with
-   * `configQuery`), and `convex_authenticated`: `@logto/rn` owns the credential
+   * Native bridge mode emits `bootstrap_start`, `convex_authenticated`, and —
+   * only with `configQuery` — `config_loaded`: `@logto/rn` owns the credential
    * lifecycle, so the settle and refresh phases belong to session mode.
    */
   onAuthEvent?: LogtoAuthEventHandler;

--- a/packages/convex-logto/src/react.tsx
+++ b/packages/convex-logto/src/react.tsx
@@ -400,9 +400,10 @@ type CommonProviderProps = {
   fallback?: ReactNode;
   /**
    * Opt-in phase timings for the auth bootstrap: `bootstrap_start`,
-   * `config_loaded` (this mode's one fetch), and `convex_authenticated` — the
-   * point where the first authenticated query can run. Absent means nothing is
-   * measured. Events carry no token and no user identity.
+   * `convex_authenticated` — the point where the first authenticated query can
+   * run — and, in `configQuery` mode only, `config_loaded` for that one fetch.
+   * Absent means nothing is measured. Events carry no token and no user
+   * identity.
    */
   onAuthEvent?: LogtoAuthEventHandler;
   children: ReactNode;


### PR DESCRIPTION
Follow-up to #109. The *Auth phase events* section states that every provider takes `onAuthEvent`, and after #109's review fix all four do — but only the web session provider's prop table listed it.

Adds the row to the web bridge, native bridge, and native session tables, each naming what that provider emits (bridge mode has three phases: `bootstrap_start`, `config_loaded`, `convex_authenticated` — the Logto SDK owns the credential lifecycle there).

Docs-only; `docs#check-types` passes.