### PR TITLE
fix(session): stop garbling non-ASCII claims and unwedge storage faults

### DIFF
--- a/.changeset/client-audit-fixes.md
+++ b/.changeset/client-audit-fixes.md
@@ -1,0 +1,28 @@
+---
+"convex-logto": patch
+---
+
+Fix three defects an adversarial audit of the client half confirmed.
+
+**Non-ASCII ID token claims were garbled in session mode.** The payload was
+decoded with bare `atob`, which yields one latin-1 character per byte, so a
+`name` of `王小明` arrived as mojibake and `José` as `JosÃ©`. It affected every
+snapshot path — cached restore, refresh, callback exchange, and the cookie
+transport's SSR seed — while bridge mode rendered the same name correctly, so
+migrating from bridge to session mode silently broke non-ASCII names. Both
+halves now share one UTF-8 segment decoder.
+
+**One failed durable credential removal wedged `signIn()` and refresh for the
+life of the page.** A sign-out that cannot delete a credential correctly fails
+loud, but the record of that failure also rejected the storage barrier every
+other transition awaits — including the two ways a user recovers. Signing in
+minted an authorize URL and then never navigated, and a completed refresh was
+reported as `refresh_failed` while the tab held live credentials. The barrier now
+waits for writes only; the surviving-credential assertion belongs to sign-out
+alone.
+
+**A refresh span could stay open.** When a sign-out, a revocation, or another
+tab's sign-out landed mid-refresh, the generation fence discarded the result
+without an end phase, so telemetry pairing `refresh_started` with an end event
+recorded a refresh that never finished. The new `refresh_abandoned` phase closes
+it: exactly one end phase now follows every `refresh_started`.

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -390,6 +390,7 @@ analytics backend as-is.
 | `convex_authenticated` | Convex accepted the token — the first authenticated query can run. Emitted once per mount, even if Convex later reconnects. |
 | `refresh_started` / `refresh_succeeded` | A token refresh, including silent ones long after mount. |
 | `refresh_failed` | With `errorKind`: `terminal` (the session is gone) or `transient` (retryable). |
+| `refresh_abandoned` | A sign-out or revocation landed while the refresh was in flight, so its result was discarded. Exactly one of the three end phases follows every `refresh_started`, so a paired span never stays open. |
 | `revoked` | The reactive `sessionValid` subscription reported the session dead. |
 | `signed_out` | This client signed out, or another tab did (`source: "cross-tab"`). |
 

--- a/packages/convex-logto/src/auth-events.ts
+++ b/packages/convex-logto/src/auth-events.ts
@@ -18,7 +18,9 @@
  *   marks "the first authenticated query can run"; everything before it is
  *   setup.
  * - the `refresh_*` phases bracket a token refresh, including the silent ones
- *   that happen long after mount.
+ *   that happen long after mount. Exactly one of `refresh_succeeded`,
+ *   `refresh_failed`, or `refresh_abandoned` follows every `refresh_started`,
+ *   so a consumer pairing them never records a span that stays open.
  */
 export type LogtoAuthPhase =
   | "bootstrap_start"
@@ -29,6 +31,8 @@ export type LogtoAuthPhase =
   | "refresh_started"
   | "refresh_succeeded"
   | "refresh_failed"
+  /** A sign-out or revocation landed mid-refresh, so its result was discarded. */
+  | "refresh_abandoned"
   | "revoked"
   | "signed_out";
 

--- a/packages/convex-logto/src/component/core.test.ts
+++ b/packages/convex-logto/src/component/core.test.ts
@@ -11,6 +11,7 @@ import {
   classifyTokenEndpointFailure,
   decideRefresh,
   decodeIdToken,
+  decodeJwtSegment,
   generatePkce,
   generateToken,
   hashToken,
@@ -213,15 +214,34 @@ it("URL builders reject an endpoint that bypassed public config validation", () 
 // --- ID token decoding -------------------------------------------------------
 
 function fakeIdToken(payload: Record<string, unknown>): string {
-  const enc = (o: unknown) =>
-    btoa(JSON.stringify(o))
+  const enc = (o: unknown) => {
+    // A real payload is base64url over UTF-8 bytes; `btoa` alone cannot even
+    // represent a non-ASCII claim.
+    let binary = "";
+    for (const byte of new TextEncoder().encode(JSON.stringify(o)))
+      binary += String.fromCharCode(byte);
+    return btoa(binary)
       .replace(/\+/g, "-")
       .replace(/\//g, "_")
       .replace(/=+$/, "");
+  };
   return `${enc({ alg: "ES384" })}.${enc(payload)}.sig`;
 }
 
 const expected = { endpoint: "https://auth.example.com", appId: "app1" };
+
+it("decodeJwtSegment reads a segment as UTF-8, not one char per byte", () => {
+  // `atob` alone turns a `name` of 王小明 into ç\u008e\u008bå°\u008fæ\u0098\u008e.
+  const claims = { name: "王小明", family_name: "Müller", emoji: "🔐" };
+  const segment = fakeIdToken(claims).split(".")[1]!;
+
+  expect(decodeJwtSegment(segment)).toEqual(claims);
+});
+
+it("decodeJwtSegment refuses a segment it cannot decode", () => {
+  expect(decodeJwtSegment("not base64url!")).toBeUndefined();
+  expect(decodeJwtSegment("bm90IGpzb24")).toBeUndefined();
+});
 
 it("decodeIdToken extracts sub and exp (ms)", () => {
   const token = fakeIdToken({

--- a/packages/convex-logto/src/component/core.ts
+++ b/packages/convex-logto/src/component/core.ts
@@ -186,6 +186,27 @@ export type DevicePublicKey = {
   y: string;
 };
 
+/**
+ * A JWT segment is base64url over **UTF-8 bytes**. `atob` alone yields one
+ * latin-1 character per byte, which silently mojibakes every multi-byte claim —
+ * a `name` of `王小明` decodes as `ç\u008e\u008bå°\u008fæ\u0098\u008e` — so the bytes
+ * have to go through a UTF-8 decode. Returns `undefined` rather than a partial
+ * result: nothing downstream can act on half-decoded claims.
+ */
+export function decodeJwtSegment(segment: string): unknown {
+  const bytes = fromBase64Url(segment);
+  if (bytes === null) return undefined;
+  try {
+    return JSON.parse(jwtSegmentDecoder.decode(bytes));
+  } catch {
+    return undefined;
+  }
+}
+
+const jwtSegmentDecoder = /* @__PURE__ */ new TextDecoder("utf-8", {
+  fatal: true,
+});
+
 function fromBase64Url(value: string): Uint8Array<ArrayBuffer> | null {
   if (!/^[A-Za-z0-9_-]+$/.test(value)) return null;
   const base64 = value.replace(/-/g, "+").replace(/_/g, "/");
@@ -345,13 +366,7 @@ export function decodeIdToken(
   if (payloadSegment === undefined) {
     throw terminal("invalid_id_token", "Logto returned a malformed ID token.");
   }
-  let payload: unknown;
-  try {
-    const base64 = payloadSegment.replace(/-/g, "+").replace(/_/g, "/");
-    payload = JSON.parse(atob(base64));
-  } catch {
-    throw terminal("invalid_id_token", "Logto returned a malformed ID token.");
-  }
+  const payload = decodeJwtSegment(payloadSegment);
   if (!isRecord(payload)) {
     throw terminal("invalid_id_token", "Logto returned a malformed ID token.");
   }

--- a/packages/convex-logto/src/native-session.tsx
+++ b/packages/convex-logto/src/native-session.tsx
@@ -184,7 +184,8 @@ function useAuthFromSession() {
 /**
  * `convex_authenticated` is the phase an app actually cares about — the first
  * moment an authenticated query can run — and only Convex knows when it
- * happens. Mounted only when the app opted into events.
+ * happens. Always mounted: whether anything is measured is decided per event by
+ * the handler slot, so an `onAuthEvent` passed on a later render still works.
  */
 function ConvexAuthPhaseWatcher({ engine }: { engine: SessionAuthEngine }) {
   const { isAuthenticated } = useConvexAuth();
@@ -197,6 +198,12 @@ function ConvexAuthPhaseWatcher({ engine }: { engine: SessionAuthEngine }) {
   return null;
 }
 
+/**
+ * Reactive revocation: subscribe to the session's liveness; the moment the
+ * server deletes the session row (sign-out elsewhere, reuse detection, a
+ * webhook revocation), Convex pushes `false`, SecureStore is cleared, and auth
+ * drops in real time.
+ */
 function RevocationWatcher() {
   const { engine, sessionApi } = useSessionContext("RevocationWatcher");
   const snapshot = useSyncExternalStore(

--- a/packages/convex-logto/src/react-session.tsx
+++ b/packages/convex-logto/src/react-session.tsx
@@ -321,14 +321,10 @@ function useAuthFromSession() {
 }
 
 /**
- * Reactive revocation: subscribe to the session's liveness; the moment the
- * server deletes the session row (sign-out elsewhere, reuse detection, a
- * webhook revocation), Convex pushes `false` and auth drops in real time.
- */
-/**
  * `convex_authenticated` is the phase an app actually cares about — the first
  * moment an authenticated query can run — and only Convex knows when it
- * happens. Mounted only when the app opted into events.
+ * happens. Always mounted: whether anything is measured is decided per event by
+ * the handler slot, so an `onAuthEvent` passed on a later render still works.
  */
 function ConvexAuthPhaseWatcher({ engine }: { engine: SessionAuthEngine }) {
   const { isAuthenticated } = useConvexAuth();
@@ -341,6 +337,11 @@ function ConvexAuthPhaseWatcher({ engine }: { engine: SessionAuthEngine }) {
   return null;
 }
 
+/**
+ * Reactive revocation: subscribe to the session's liveness; the moment the
+ * server deletes the session row (sign-out elsewhere, reuse detection, a
+ * webhook revocation), Convex pushes `false` and auth drops in real time.
+ */
 function RevocationWatcher() {
   const { engine, sessionApi } = useSessionContext("RevocationWatcher");
   const snapshot = useSyncExternalStore(

--- a/packages/convex-logto/src/session-client.test.ts
+++ b/packages/convex-logto/src/session-client.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   SessionAuthEngine,
   SessionStorageArea,
+  decodeJwtPayload,
   type SessionSnapshot,
   type SessionStorageAdapter,
   type SessionTransport,
@@ -37,11 +38,17 @@ function setURL(url: string): void {
 }
 
 function fakeIdToken(payload: Record<string, unknown>): string {
-  const enc = (o: unknown) =>
-    btoa(JSON.stringify(o))
+  const enc = (o: unknown) => {
+    // A real payload is base64url over UTF-8 bytes; `btoa` alone cannot even
+    // represent a non-ASCII claim.
+    let binary = "";
+    for (const byte of new TextEncoder().encode(JSON.stringify(o)))
+      binary += String.fromCharCode(byte);
+    return btoa(binary)
       .replace(/\+/g, "-")
       .replace(/\//g, "_")
       .replace(/=+$/, "");
+  };
   return `${enc({ alg: "ES384" })}.${enc(payload)}.sig`;
 }
 
@@ -245,6 +252,39 @@ afterEach(() => {
 
 // --- storage -----------------------------------------------------------------
 
+describe("ID token claims", () => {
+  it("decodes a non-ASCII claim the way the Logto SDK does", () => {
+    // Bridge mode renders `王小明` correctly (`@logto/js` UTF-8-decodes), so an
+    // app migrating to session mode must not start garbling the same name.
+    const token = fakeIdToken({
+      sub: "u1",
+      name: "王小明",
+      family_name: "Müller",
+    });
+
+    expect(decodeJwtPayload(token)).toMatchObject({
+      name: "王小明",
+      family_name: "Müller",
+    });
+  });
+
+  it("carries the decoded claims into the snapshot the app reads", async () => {
+    const { engine } = makeHarness({
+      storedSession: { token: "t1", sessionId: "s1" },
+      storedIdToken: fakeIdToken({
+        sub: "u1",
+        name: "José Müller",
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      }),
+    });
+
+    engine.start();
+    await settled(engine);
+
+    expect(engine.getSnapshot().user?.name).toBe("José Müller");
+  });
+});
+
 describe("SessionStorageArea", () => {
   it("keeps the session in localStorage and the ID token in the chosen area", () => {
     const store = new SessionStorageArea("ns", "session");
@@ -312,11 +352,15 @@ describe("SessionStorageArea", () => {
 
     expect(store.readSession()).toBeNull();
     expect(removeAttempts).toBe(1);
-    await expect(store.flush()).rejects.toThrow(/durably remove/);
+    // The barrier stays clean — only sign-out may fail over a survivor.
+    await expect(store.flush()).resolves.toBeUndefined();
+    await expect(store.assertCredentialsRemoved()).rejects.toThrow(
+      /durably remove/,
+    );
 
     removalFails = false;
     store.clearAll();
-    await expect(store.flush()).resolves.toBeUndefined();
+    await expect(store.assertCredentialsRemoved()).resolves.toBeUndefined();
     expect(values.get("convex-logto:ns:session")).toBeUndefined();
     expect(removeAttempts).toBe(2);
   });
@@ -1157,6 +1201,67 @@ describe("signOut", () => {
     expect(coldHandlers.refresh).not.toHaveBeenCalled();
   });
 
+  it("lets the user sign in again after a durable removal failure", async () => {
+    // Signing in is how a user recovers from a storage fault. Before the
+    // barrier was split, the sign-out-era failure rejected sign-in's own flush
+    // forever: the authorize URL was minted, a server transaction row was
+    // spent, and the browser never left for Logto.
+    const sessionKey = "convex-logto:test:session";
+    const local = persistentStorageStub(
+      [[sessionKey, JSON.stringify({ token: "t1", sessionId: "s1" })]],
+      Number.POSITIVE_INFINITY,
+    );
+    const session = persistentStorageStub([], Number.POSITIVE_INFINITY);
+    vi.stubGlobal("localStorage", local.storage);
+    vi.stubGlobal("sessionStorage", session.storage);
+    const { engine, handlers } = makeHarness();
+    handlers.signOut.mockResolvedValue({});
+    await expect(engine.signOut({ federated: false })).rejects.toMatchObject({
+      name: "SessionSignOutError",
+    });
+    handlers.signIn.mockResolvedValue({
+      url: "https://auth.example.com/oidc/auth?state=st",
+    });
+
+    await engine.signIn();
+
+    expect(window.location.assign).toHaveBeenCalledWith(
+      "https://auth.example.com/oidc/auth?state=st",
+    );
+  });
+
+  it("keeps a completed refresh completed when a removal failed earlier", async () => {
+    // The rotation was consumed and the new credentials are stored. Reporting
+    // that as a failure would leave the tab unauthenticated while holding live
+    // credentials — on every refresh, for the life of the page.
+    const sessionKey = "convex-logto:test:session";
+    const local = persistentStorageStub(
+      [[sessionKey, JSON.stringify({ token: "t1", sessionId: "s1" })]],
+      Number.POSITIVE_INFINITY,
+    );
+    const session = persistentStorageStub([], Number.POSITIVE_INFINITY);
+    vi.stubGlobal("localStorage", local.storage);
+    vi.stubGlobal("sessionStorage", session.storage);
+    const { engine, storage, handlers } = makeHarness();
+    handlers.signOut.mockResolvedValue({});
+    await expect(engine.signOut({ federated: false })).rejects.toMatchObject({
+      name: "SessionSignOutError",
+    });
+    // Same engine, same poisoned storage area: sign in again and refresh.
+    storage.writeSession({ token: "t2", sessionId: "s1" });
+    const rotated = freshToken();
+    handlers.refresh.mockResolvedValue({
+      idToken: rotated,
+      sessionToken: "t3",
+      sessionId: "s1",
+    });
+
+    const served = await engine.fetchAccessToken(false);
+
+    expect(served).toBe(rotated);
+    expect(engine.getSnapshot().status).toBe("authenticated");
+  });
+
   it("prioritizes durable browser cleanup failure after successful revocation", async () => {
     const sessionKey = "convex-logto:test:session";
     const idTokenKey = "convex-logto:test:idToken";
@@ -1951,6 +2056,39 @@ describe("auth phase events", () => {
       elapsedMs: expect.any(Number),
       source: "cross-tab",
     });
+  });
+
+  it("closes the refresh span when a sign-out lands mid-refresh", async () => {
+    // A consumer pairing refresh_started with an end phase must never be left
+    // holding an open span because the generation fence discarded the result.
+    const refresh = deferred<{
+      idToken: string;
+      sessionToken: string;
+      sessionId: string;
+    }>();
+    const { engine, handlers, events } = eventHarness({
+      storedSession: { token: "t1", sessionId: "s1" },
+    });
+    handlers.refresh.mockReturnValue(refresh.promise);
+    handlers.signOut.mockResolvedValue({});
+    engine.start();
+    await vi.waitFor(() => expect(handlers.refresh).toHaveBeenCalled());
+
+    await engine.signOut({ federated: false });
+    refresh.resolve({
+      idToken: freshToken(),
+      sessionToken: "t2",
+      sessionId: "s1",
+    });
+    await vi.waitFor(() =>
+      expect(phasesOf(events)).toContain("refresh_abandoned"),
+    );
+
+    const refreshPhases = phasesOf(events).filter((phase) =>
+      phase.startsWith("refresh_"),
+    );
+    expect(refreshPhases).toEqual(["refresh_started", "refresh_abandoned"]);
+    expect(engine.getSnapshot().status).toBe("unauthenticated");
   });
 
   it("reports convex_authenticated only when the provider says so", async () => {

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -11,6 +11,7 @@ import {
   type LogtoAuthEventSource,
 } from "./auth-events";
 import { classifySignInSearch, isSafeReturnTo } from "./callback";
+import { decodeJwtSegment } from "./component/core";
 import { normalizeHttpNavigationUrl } from "./component/endpoint";
 import {
   SessionDeviceBindingError,
@@ -53,8 +54,19 @@ export type SessionTransport = {
 export type SessionStorageAdapter = {
   /** Async stores hydrate their synchronous cache here before the engine reads it. */
   prepare?(): Promise<void>;
-  /** Wait for queued writes or surface a failed durable credential removal. */
+  /** Durability barrier: wait for queued writes. Every engine transition awaits it. */
   flush?(): Promise<void>;
+  /**
+   * Sign-out only: reject when a credential this area was asked to delete is
+   * still in the browser.
+   *
+   * Deliberately not part of `flush()`. A surviving credential must fail the
+   * sign-out that left it behind — and nothing else. Signing in again and
+   * refreshing are the two ways a user recovers from a storage fault, and both
+   * await the barrier, so folding the check into it locks the page out of its
+   * own recovery paths for as long as it lives.
+   */
+  assertCredentialsRemoved?(): Promise<void>;
   readonly sessionEventKey: string;
   readSession(): StoredSession | null;
   writeSession(session: StoredSession): void;
@@ -185,13 +197,11 @@ export function decodeJwtPayload(
   if (parts.length !== 3) return null;
   const payload = parts[1];
   if (payload === undefined) return null;
-  try {
-    const base64 = payload.replace(/-/g, "+").replace(/_/g, "/");
-    const decoded: unknown = JSON.parse(atob(base64));
-    return isRecord(decoded) ? decoded : null;
-  } catch {
-    return null;
-  }
+  // Shared with the component's own ID-token decode so both halves read a
+  // non-ASCII claim the same way — and the same way the Logto SDK does, or
+  // migrating from bridge mode would start garbling names.
+  const decoded = decodeJwtSegment(payload);
+  return isRecord(decoded) ? decoded : null;
 }
 
 function idTokenExpMs(token: string): number {
@@ -389,7 +399,12 @@ export class SessionStorageArea {
     }
   }
 
+  /** Browser writes are synchronous, so there is nothing queued to wait for. */
   flush(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  assertCredentialsRemoved(): Promise<void> {
     if (this.pendingRemovals.size === 0) return Promise.resolve();
     return Promise.reject(
       new BrowserSessionStorageError(
@@ -912,6 +927,13 @@ export class SessionAuthEngine {
       }
       if (generation !== this.authGeneration) return null;
       this.events("refresh_started");
+      // Every fenced exit below closes the span it just opened: a consumer that
+      // pairs `refresh_started` with an end phase must never be left holding an
+      // open one because a sign-out raced the refresh.
+      const abandoned = (): null => {
+        this.events("refresh_abandoned");
+        return null;
+      };
       try {
         const result = await this.retrying(() =>
           this.options.transport.action(this.options.api.refresh, {
@@ -919,18 +941,18 @@ export class SessionAuthEngine {
             ...(deviceProof === undefined ? {} : { deviceProof }),
           }),
         );
-        if (generation !== this.authGeneration) return null;
+        if (generation !== this.authGeneration) return abandoned();
         this.options.storage.writeSession({
           token: result.sessionToken,
           sessionId: result.sessionId,
         });
         this.options.storage.writeIdToken(result.idToken);
         await this.flushStorageReporting();
-        if (generation !== this.authGeneration) return null;
+        if (generation !== this.authGeneration) return abandoned();
         this.events("refresh_succeeded");
         return result.idToken;
       } catch (error) {
-        if (generation !== this.authGeneration) return null;
+        if (generation !== this.authGeneration) return abandoned();
         const errorKind = sessionErrorKind(error);
         this.events("refresh_failed", { errorKind });
         if (errorKind === "terminal") {
@@ -1445,6 +1467,9 @@ export class SessionAuthEngine {
   ): Promise<Error | undefined> {
     try {
       await this.flushStorage();
+      // Sign-out is the one caller that must also fail over a credential that
+      // survived removal — see `assertCredentialsRemoved`.
+      await this.options.storage.assertCredentialsRemoved?.();
       return clearError;
     } catch (error) {
       const flushError = this.asError(error);


### PR DESCRIPTION
Three defects an adversarial audit of the client half confirmed, each with a regression test. Closes #114, #118, #119.

## 1. Non-ASCII ID token claims were garbled in session mode (#114)

`decodeJwtPayload` decoded the payload with bare `atob`, which yields one latin-1 character per byte. A JWT payload is base64url over **UTF-8 bytes**, so a user named `王小明` reached the app as mojibake and `José Müller` as `JosÃ© MÃ¼ller`. Every snapshot path was affected: the zero-round-trip cached restore, a refresh, the callback exchange, and the cookie transport's SSR seed.

Bridge mode was fine — `@logto/js` UTF-8-decodes — so an app migrating from bridge to session mode silently started garbling names it used to render correctly. Both halves now share one decoder (`decodeJwtSegment` in the component's core, next to the existing base64url helper); the component's own `decodeIdToken` uses it too.

Note the two test helpers that built fake tokens with `btoa(JSON.stringify(...))`: `btoa` throws on any character above U+00FF, so the tests *could not have represented* a non-ASCII claim. They encode UTF-8 now, which is what let the regression tests exist.

## 2. One failed durable credential removal wedged `signIn()` and refresh (#118)

`pendingRemovals` exists for a good reason: a sign-out must not report success while a credential is still in the browser. But `flush()` rejected over it, and `flush()` is awaited by *every* engine transition — including the two ways a user recovers from a storage fault:

- **Sign in again:** the action ran (a server-side transaction row spent, an authorize URL minted), the OIDC `state` was stashed, then the flush rejected and `location.assign` was never reached. Every click repeated it; only a full reload escaped.
- **Refresh:** `flushStorageReporting()` sits inside the `try` *after* the rotation was consumed and the new credentials written, so a completed refresh was reported as `refresh_failed` and returned `null` — the tab reported itself unauthenticated while holding live credentials.

Split the two concerns: `flush()` is the write barrier and nothing else, and a new `assertCredentialsRemoved()` carries the surviving-credential check, called only from the sign-out cleanup path.

One part of the original diagnosis turned out not to apply: retiring the record when a later write overwrites the key is unreachable, because a failed removal trips the same circuit breaker that sends subsequent writes to memory — so the credential really does survive and the record should stand. I dropped that half rather than ship dead code.

## 3. A refresh span could stay open (#119)

The `authGeneration` fences after `refresh_started` returned without an end phase, so when a sign-out, a revocation, or another tab's sign-out landed mid-refresh, a consumer pairing start/end events recorded a refresh that never finished. New `refresh_abandoned` phase; exactly one end phase now follows every `refresh_started`, and the docs table says so.

## Also

`RevocationWatcher`'s doc comment had drifted above `ConvexAuthPhaseWatcher`, leaving one function undocumented and the other described as "mounted only when the app opted into events" — it always mounts, and the handler slot decides per event.

Tests 498 → 505. Verified locally in CI order: `lint`, `format:check`, `check-types`, `test`, `build`.