### PR TITLE
chore(deps): keep @types/node on the Node major CI actually runs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,6 +60,13 @@ updates:
       - dependency-name: typescript
         update-types:
           - version-update:semver-major
+      # @types/node describes the Node major this workspace actually runs on —
+      # 22, in `ci.yml` and `release.yml`. A newer major types APIs the runtime
+      # does not have, so a script could typecheck green here and throw on the
+      # runner. Bump it deliberately when the workflows move to a new Node.
+      - dependency-name: "@types/node"
+        update-types:
+          - version-update:semver-major
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Dependabot opened #115 to take `@types/node` from 22 to **26**. Both `ci.yml` and `release.yml` pin `node-version: 22`, and the only consumer is `examples/nextjs`, so a newer major would describe APIs the runtime does not have — a script could typecheck green here and throw on the runner. CI cannot catch that, which is exactly the criterion the existing `typescript` and Expo ignores use.

Adds a major-version ignore with the reason inline, so the next reader knows what unblocks it: moving the workflows to a new Node.

Supersedes #115.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated dependency updates now skip major-version upgrades for Node.js type definitions to maintain compatibility with the project’s supported Node.js version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->