### PR TITLE
fix(session): stop treating a long device name as a dead session

### DIFF
--- a/.changeset/label-length-locally.md
+++ b/.changeset/label-length-locally.md
@@ -1,0 +1,10 @@
+---
+"convex-logto": patch
+---
+
+Reject an over-long session label in the browser instead of as a terminal
+session error. The component classifies a label past 64 characters as terminal,
+and terminal is defined as "this session is gone for good" — so an app following
+that taxonomy would sign a user out for typing a long device name.
+`renameSession` now checks the length before the round-trip and fails with a
+plain error; the component keeps its guard for callers reaching it directly.

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -352,7 +352,8 @@ signOutEverywhere, listSessions, renameSession, revokeSession }`.
   authenticates with rotates) of the caller's own sessions, `{ sessions,
   truncated }`, newest first. Call it again after a rename or revoke.
 - `renameSession(sessionId, label)` — name one of the caller's own sessions;
-  `undefined` (or a blank string) clears it. Rejects with terminal
+  `undefined` (or a blank string) clears it. A label over 64 characters is
+  rejected locally, before any round-trip. Rejects with terminal
   `session_not_found` for an id that is not the caller's or is already revoked —
   the component will not confirm that another subject's session exists.
 - `revokeSession(sessionId)` — sign that device out; rejects the same way for an

--- a/packages/convex-logto/src/component/core.ts
+++ b/packages/convex-logto/src/component/core.ts
@@ -578,6 +578,12 @@ export function audienceMatches(value: unknown, appId: string): boolean {
 // Terminal: the session/transaction is gone for good — the client clears its
 // state and transitions to unauthenticated. Transient: network/5xx/contention —
 // the client retries with backoff and NEVER treats it as a sign-out.
+//
+// One class of terminal error is about the *input*, not the session: a rejected
+// session label means "do not retry this value", and nothing about the session
+// died. The client validates label length before the round-trip so an app never
+// has to tell the two apart, and this guard stays as defence in depth for a
+// caller reaching the component directly.
 
 export type SessionErrorData = {
   kind: "terminal" | "transient";

--- a/packages/convex-logto/src/component/core.ts
+++ b/packages/convex-logto/src/component/core.ts
@@ -109,6 +109,19 @@ function normalizeDisplayText(raw: string): string {
 }
 
 /**
+ * Would this label be rejected for its length? Exported so the browser half can
+ * pre-empt the round-trip against *exactly* the rule the component applies:
+ * normalization first, then a code-point count. Measuring the raw string
+ * instead would reject a label the component would have accepted, because
+ * normalization collapses whitespace and drops invisible characters.
+ */
+export function sessionLabelTooLong(raw: string): boolean {
+  return (
+    Array.from(normalizeDisplayText(raw)).length > SESSION_LABEL_MAX_LENGTH
+  );
+}
+
+/**
  * Normalize a user-chosen session label. Rejects rather than truncates: a
  * silently shortened label is worse than a clear error, because the user is
  * naming a device they need to recognise later.
@@ -119,7 +132,7 @@ export function normalizeSessionLabel(
   if (raw === undefined) return undefined;
   const label = normalizeDisplayText(raw);
   if (label === "") return undefined;
-  if (Array.from(label).length > SESSION_LABEL_MAX_LENGTH) {
+  if (sessionLabelTooLong(label)) {
     throw terminal(
       "session_label_too_long",
       `A session label may be at most ${SESSION_LABEL_MAX_LENGTH} characters.`,

--- a/packages/convex-logto/src/session-client.test.ts
+++ b/packages/convex-logto/src/session-client.test.ts
@@ -1722,6 +1722,12 @@ describe("session management", () => {
     await expect(
       engine.renameSession("s2", "🔐".repeat(64)),
     ).resolves.toBeUndefined();
+    // The local check measures what the component would store, not the raw
+    // input: whitespace collapses and invisible characters drop out first, so
+    // a label the component accepts is never refused here.
+    await expect(
+      engine.renameSession("s2", "x  ".repeat(32)),
+    ).resolves.toBeUndefined();
   });
 
   it("revokes another session without touching this client's credentials", async () => {

--- a/packages/convex-logto/src/session-client.test.ts
+++ b/packages/convex-logto/src/session-client.test.ts
@@ -1702,6 +1702,28 @@ describe("session management", () => {
     });
   });
 
+  it("rejects an over-long label locally instead of as a session death", async () => {
+    // The component classifies an over-long label as a *terminal* session
+    // error, and terminal means "this session is gone" — so an app following
+    // that taxonomy would sign the user out over a long device name.
+    const { engine, storage, handlers } = makeHarness();
+    storage.writeSession({ token: "t1", sessionId: "s1" });
+
+    await expect(engine.renameSession("s2", "x".repeat(65))).rejects.toThrow(
+      /at most 64 characters/,
+    );
+
+    expect(handlers.renameSession).not.toHaveBeenCalled();
+    // 64 is fine, and so is a 64-code-point label built from surrogate pairs.
+    handlers.renameSession.mockResolvedValue(true);
+    await expect(
+      engine.renameSession("s2", "x".repeat(64)),
+    ).resolves.toBeUndefined();
+    await expect(
+      engine.renameSession("s2", "🔐".repeat(64)),
+    ).resolves.toBeUndefined();
+  });
+
   it("revokes another session without touching this client's credentials", async () => {
     const { engine, storage, handlers } = makeHarness();
     storage.writeSession({ token: "t1", sessionId: "s1" });

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -11,7 +11,11 @@ import {
   type LogtoAuthEventSource,
 } from "./auth-events";
 import { classifySignInSearch, isSafeReturnTo } from "./callback";
-import { SESSION_LABEL_MAX_LENGTH, decodeJwtSegment } from "./component/core";
+import {
+  SESSION_LABEL_MAX_LENGTH,
+  decodeJwtSegment,
+  sessionLabelTooLong,
+} from "./component/core";
 import { normalizeHttpNavigationUrl } from "./component/endpoint";
 import {
   SessionDeviceBindingError,
@@ -1157,10 +1161,7 @@ export class SessionAuthEngine {
     // defined as "this session is gone" — an app that follows that taxonomy
     // would sign the user out for typing a long device name. Failing locally
     // also saves a round-trip on an input the user can simply shorten.
-    if (
-      label !== undefined &&
-      Array.from(label).length > SESSION_LABEL_MAX_LENGTH
-    ) {
+    if (label !== undefined && sessionLabelTooLong(label)) {
       throw new Error(
         `convex-logto: a session label may be at most ${SESSION_LABEL_MAX_LENGTH} characters.`,
       );

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -11,7 +11,7 @@ import {
   type LogtoAuthEventSource,
 } from "./auth-events";
 import { classifySignInSearch, isSafeReturnTo } from "./callback";
-import { decodeJwtSegment } from "./component/core";
+import { SESSION_LABEL_MAX_LENGTH, decodeJwtSegment } from "./component/core";
 import { normalizeHttpNavigationUrl } from "./component/endpoint";
 import {
   SessionDeviceBindingError,
@@ -1152,6 +1152,19 @@ export class SessionAuthEngine {
   ): Promise<void> {
     const action = this.options.api.renameSession;
     if (action === undefined) throw sessionApiUpgradeError("renameSession");
+    // Check the length here rather than learn it from the server. The component
+    // reports an over-long label as a *terminal* session error, and terminal is
+    // defined as "this session is gone" — an app that follows that taxonomy
+    // would sign the user out for typing a long device name. Failing locally
+    // also saves a round-trip on an input the user can simply shorten.
+    if (
+      label !== undefined &&
+      Array.from(label).length > SESSION_LABEL_MAX_LENGTH
+    ) {
+      throw new Error(
+        `convex-logto: a session label may be at most ${SESSION_LABEL_MAX_LENGTH} characters.`,
+      );
+    }
     const credential = await this.sessionCallCredential("renameSession");
     await this.callSessionAction("renameSession", () =>
       this.options.transport.action(action, {


### PR DESCRIPTION
Closes #122.

`normalizeSessionLabel` raises a **terminal** error for a label past 64 characters, and the taxonomy comment right below it defines terminal as *"the session/transaction is gone for good - the client clears its state and transitions to unauthenticated"*. Renaming a device with a 65-character name is not that. An app that follows the documented contract signs the user out over ordinary form input.

## The fix

The browser half checks the length before the round-trip and throws a plain `Error` naming the limit, so the terminal classification is never reached by a normal rename. The component's guard stays as defence in depth for a caller that reaches it directly, and the taxonomy comment now records that one class of terminal error is about the *input* ("do not retry this value") rather than the session.

Both halves measure the **same** string: `sessionLabelTooLong()` is exported from the component's pure core and normalizes first - collapsing whitespace, dropping invisible characters - then counts code points. Counting the raw input instead would refuse a label the component would have happily stored (a 96-character string of doubled spaces normalizes to 63).

## Tests

`session-client.test.ts` covers the local rejection without a round-trip, the exact-limit label, a 64-code-point label built from surrogate pairs, and the normalization case above; `core.test.ts` keeps the component-side guard covered.

Verified with the full CI sequence (`lint`, `format:check`, `check-types`, `test`) over the whole workspace.
