### PR TITLE
docs: fix the SSR seed snippet that could not compile, and three drifted JSDoc lists

### DIFF
--- a/docs/content/docs/session-mode.mdx
+++ b/docs/content/docs/session-mode.mdx
@@ -475,15 +475,15 @@ For example, a TanStack Start server function can seed the root loader:
 
 ```tsx
 import { createServerFn } from "@tanstack/react-start";
-import {
-  getRequest,
-  setResponseHeaders,
-} from "@tanstack/react-start/server";
+import { getRequest, setResponseHeader } from "@tanstack/react-start/server";
 import { logtoCookieHandler } from "~/server/logto-cookie";
 
 const seedSession = createServerFn().handler(async () => {
   const seed = await logtoCookieHandler.getInitialToken(getRequest());
-  setResponseHeaders(Object.fromEntries(seed.headers));
+  // Forward header by header. `setResponseHeaders` takes a `Headers`-like
+  // object, so handing it `Object.fromEntries(seed.headers)` does not
+  // typecheck.
+  for (const [name, value] of seed.headers) setResponseHeader(name, value);
   return {
     initialToken: seed.initialToken,
     initialSessionId: seed.initialSessionId,
@@ -528,6 +528,7 @@ too (an ID token stays cryptographically valid until it expires):
 ```ts title="convex/me.ts"
 import { assertSubjectHasActiveSession } from "convex-logto";
 import { components } from "./_generated/api";
+import { query } from "./_generated/server";
 
 export const sensitive = query({
   handler: async (ctx) => {

--- a/docs/content/docs/tanstack-start.mdx
+++ b/docs/content/docs/tanstack-start.mdx
@@ -89,7 +89,7 @@ it has a server on the same origin:
    ```tsx
    const seedSession = createServerFn().handler(async () => {
      const seed = await logtoCookieHandler.getInitialToken(getRequest());
-     setResponseHeaders(Object.fromEntries(seed.headers));
+     for (const [name, value] of seed.headers) setResponseHeader(name, value);
      return {
        initialToken: seed.initialToken,
        initialSessionId: seed.initialSessionId,

--- a/packages/convex-logto/src/react-session.tsx
+++ b/packages/convex-logto/src/react-session.tsx
@@ -60,7 +60,10 @@ export type ConvexLogtoSessionProviderProps = {
   /**
    * The module re-exporting `logtoSessionApi(...)`'s functions, e.g. `api.auth`.
    * The provider expects the exact names `signIn` / `callback` / `refresh` /
-   * `signOut` / `signOutEverywhere` / `sessionValid`.
+   * `signOut` / `signOutEverywhere` / `listSessions` / `renameSession` /
+   * `revokeSession` / `sessionValid`. Everything after `signOut` is
+   * feature-detected: omitting one disables that call with a message naming
+   * the export to add, so a rolling upgrade never breaks sign-in.
    */
   sessionApi: LogtoSessionApi;
   /**

--- a/packages/convex-logto/src/session-cookie.ts
+++ b/packages/convex-logto/src/session-cookie.ts
@@ -58,7 +58,10 @@ export type LogtoSessionCookieHandlerOptions = {
   action: LogtoSessionAction;
   /** Exact browser origins allowed to call the handler. Wildcards are rejected. */
   allowedOrigins: readonly string[];
-  /** Mount point containing `sign-in`, `callback`, `token`, and `sign-out`. */
+  /**
+   * Mount point containing `sign-in`, `callback`, `token`, `sign-out` and
+   * `sessions`.
+   */
   basePath?: string;
   /**
    * Mirror the session provider's device-binding flag so incompatible

--- a/packages/convex-logto/src/session.ts
+++ b/packages/convex-logto/src/session.ts
@@ -376,7 +376,8 @@ function readSessionConfig(options: LogtoSessionApiOptions): {
  * Build the public auth functions for session mode, backed by the Logto session
  * component. Reads `LOGTO_ENDPOINT`, `LOGTO_APP_ID` and `LOGTO_CLIENT_SECRET`
  * from the deployment's env (the secret never leaves the server). Re-export all
- * six — the frontend provider expects these exact names:
+ * nine — the frontend provider looks them up by these exact names, and a
+ * missing one disables that feature rather than failing the build:
  *
  * @example
  * // convex/auth.ts
@@ -389,6 +390,9 @@ function readSessionConfig(options: LogtoSessionApiOptions): {
  *   refresh,
  *   signOut,
  *   signOutEverywhere,
+ *   listSessions,
+ *   renameSession,
+ *   revokeSession,
  *   sessionValid,
  * } = logtoSessionApi(components.logto);
  */


### PR DESCRIPTION
Closes #129

Four documentation defects, all confirmed against the installed packages rather than by eye.

## The SSR seed snippet did not compile

`setResponseHeaders` is typed `(headers: TypedHeaders<ResponseHeaderMap>) => void`, and `TypedHeaders` is an interface extending `Headers` - so the documented `setResponseHeaders(Object.fromEntries(seed.headers))` is rejected:

```
error TS2345: Argument of type '{ [k: string]: string; }' is not assignable to parameter of
type 'TypedHeaders<ResponseHeaderMap>'. Type '{ [k: string]: string; }' is missing the
following properties: append, delete, get, getSetCookie, and 7 more.
```

(Reproduced with `@tanstack/react-start@1.168.46` as resolved in `examples/tanstack-start`, then the probe file removed.) The runtime implementation happens to iterate `Object.entries`, so the snippet would have *worked* had it compiled - which is exactly the kind of mismatch a reader cannot debug from the error message.

Forwarding header by header with `setResponseHeader` typechecks with no cast, because `ResponseHeaderName` is `keyof ResponseHeaderMap | AnyString`. Fixed in both `session-mode.mdx` and `tanstack-start.mdx`, since forwarding `seed.headers` is the step the guide calls "not optional" - it carries the rotated cookie.

## The subject-liveness snippet was missing an import

`convex/me.ts` used `query(...)` without importing it from `./_generated/server`.

## Three JSDoc comments had drifted

- `logtoSessionApi` returns **nine** functions; its `@example` destructured six, so a reader copying it silently loses `listSessions` / `renameSession` / `revokeSession` and later hits the upgrade error at runtime.
- `ConvexLogtoSessionProviderProps.sessionApi` named six of the nine, with no hint that the tail is feature-detected.
- `LogtoSessionCookieHandlerOptions.basePath` listed four of the handler's five routes (`sessions` was missing).

The `.mdx` guides and the README already listed all nine - only the shipped JSDoc was stale.

No changeset: comments and docs only, no behaviour change (same as #112).

Verified with the full CI sequence (`lint`, `format:check`, `check-types`, `test`) over the whole workspace.