### PR TITLE
fix: look up OAuth error hints in a Map, not on a prototype chain

### DIFF
--- a/.changeset/oauth-hint-lookup.md
+++ b/.changeset/oauth-hint-lookup.md
@@ -1,0 +1,12 @@
+---
+"convex-logto": patch
+---
+
+Stop resolving an OAuth error hint off `Object.prototype`.
+
+The sign-in error classifier looked its hint table up as a plain object, keyed
+by the `error` parameter taken straight from the callback URL. `?error=constructor`
+therefore found `Object`, and the message the app displays ended with
+`function Object() { [native code] }`; `?error=__proto__` appended
+`[object Object]`. The table is a `Map` now, so a lookup can only find a key the
+library put there.

--- a/packages/convex-logto/src/callback.test.ts
+++ b/packages/convex-logto/src/callback.test.ts
@@ -57,6 +57,24 @@ describe("classifySignInSearch", () => {
       expect(outcome.message).not.toContain("Single-page app");
     }
   });
+
+  it("does not find a hint on Object.prototype", () => {
+    // `error` comes straight off the query string. Looked up on a plain object,
+    // `constructor` resolves through the prototype chain and the message the
+    // app shows the user ends with a function's source.
+    for (const error of [
+      "constructor",
+      "toString",
+      "hasOwnProperty",
+      "__proto__",
+    ]) {
+      const outcome = classifySignInSearch(`?error=${error}&state=xyz`);
+      expect(outcome.kind).toBe("error");
+      if (outcome.kind === "error") {
+        expect(outcome.message).toBe(`Logto sign-in failed with "${error}".`);
+      }
+    }
+  });
 });
 
 describe("callbackResolved (#14: a /callback URL must never wait forever)", () => {

--- a/packages/convex-logto/src/callback.ts
+++ b/packages/convex-logto/src/callback.ts
@@ -2,11 +2,13 @@
 // carries a `state` param, so a stray `?error=`/`?code=` on an ordinary app route
 // is ignored rather than mistaken for a sign-in result.
 
-const OAUTH_ERROR_HINTS: Record<string, string> = {
-  invalid_scope:
+const OAUTH_ERROR_HINTS = new Map<string, string>([
+  [
+    "invalid_scope",
     "This usually means a requested scope isn't allowed — check any extra `scopes` " +
-    "you passed, and that LOGTO_APP_ID points at a Single-page app (not a Third-party app).",
-};
+      "you passed, and that LOGTO_APP_ID points at a Single-page app (not a Third-party app).",
+  ],
+]);
 
 // OAuth errors that just mean "no session" (e.g. the user cancelled): return to the app.
 const BENIGN_OAUTH_ERRORS = new Set([
@@ -30,7 +32,10 @@ export function classifySignInSearch(search: string): SignInOutcome {
   if (error) {
     if (BENIGN_OAUTH_ERRORS.has(error)) return { kind: "benign" };
     const description = params.get("error_description");
-    const hint = OAUTH_ERROR_HINTS[error];
+    // A Map, not an object: `error` is straight off the query string, and an
+    // object lookup would resolve `?error=constructor` through the prototype
+    // chain and splice a function's source into the message the app displays.
+    const hint = OAUTH_ERROR_HINTS.get(error);
     return {
       kind: "error",
       message:


### PR DESCRIPTION
Closes #130.

`classifySignInSearch` keyed its hint table - a plain object - with the `error` parameter taken straight off the callback URL, so any inherited property answered the lookup:

```
?error=constructor  ->  Logto sign-in failed with "constructor". function Object() { [native code] }
?error=__proto__    ->  Logto sign-in failed with "__proto__". [object Object]
```

The declared `Record<string, string>` also lied - `hint` is a function at runtime.

The table is a `Map` now. A `Map` cannot resolve a key nobody put in it, which is the property this lookup needs; `Object.hasOwn` would have worked too but leaves the next person free to reintroduce the bare index.

Impact is low - the value lands in a message the provider logs and the app renders, and the classifier ignores any URL without `state` - but it is wrong output from attacker-supplied input on the sign-in path, which is not a place to leave a sharp edge.

The regression test drives all four inherited keys and asserts the exact message; it fails on `main`.

Verified with the full CI sequence (`lint`, `format:check`, `check-types`, `test`) over the whole workspace.
