### PR TITLE
fix(webhooks): stop dropping a delivery over a field the library never reads

### DIFF
--- a/.changeset/webhook-payload-tolerance.md
+++ b/.changeset/webhook-payload-tolerance.md
@@ -1,0 +1,33 @@
+---
+"convex-logto": minor
+---
+
+Stop dropping a Logto webhook delivery over a field the library never reads.
+
+`isLogtoWebhookPayload` type-checked roughly fifteen advisory fields — `hookId`,
+`userAgent`, `ip`, `path`, `method`, `status`, `matchedRoute`, and most of the
+User entity — and one mismatch made the route answer 400 *before* it recorded
+the delivery or revoked sessions. Logto retries a 5xx, not a 4xx, so a single
+drifted field meant permanent, first-attempt loss of every `User.*` event for
+that user, taking the deletion and suspension revocation path with it. A
+`userAgent: null`, a missing `hookId`, an `identities: []` or a stringified
+`status` was enough.
+
+The predicate now accepts on exactly what the library consumes: a known `User.*`
+event, a string `createdAt` for the replay window, and a usable user id (with
+the existing rule that a `User.Deleted` carrying both `data.id` and
+`params.userId` must not contradict itself). A field that drifted out of its
+declared type is dropped from the entity handed to sync handlers rather than
+rejected, so a handler still receives the declared `LogtoUserEntity` shape while
+the raw value stays reachable on the payload it also receives. Fields Logto adds
+later pass through untouched, as before.
+
+One rejection is new, not relaxed: a `User.Deleted` whose entity carries an
+`id` that is not a string. That id is one the library *does* consume, and an
+unreadable one could be naming a different user than the route params — a
+destructive event must not run on a guess. A `User.Deleted` whose entity simply
+names no one (`data: {}`) is now accepted, since it carries the same
+information as the documented `data: null` shape.
+
+`LogtoWebhookPayload["hookId"]` is now optional, for the same reason as the
+rest: nothing reads it, so nothing should turn on it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ clean clone (`git clone --no-hardlinks . /tmp/x && cd /tmp/x && pnpm install
   - Every path that installs credentials in the browser re-checks `authGeneration` after each await, so a response issued before a sign-out cannot resurrect it.
   - Anything that reads or mutates a session takes its subject from the caller's presented token, never from an argument — and a row killed by a watermark is invisible to reads too, or a "where am I signed in" list would show sessions that are already dead.
   - A page filtered after the read must be filled by scanning, not by slicing: dead rows must never consume a slot and hide the live device behind them. Bound the scan instead, and report truncation when it stops early.
-  - Validate a webhook payload only as far as the fields the library consumes. Rejecting a signature-verified delivery turns Logto schema drift into silent, unretried event loss.
+  - Validate a webhook payload only as far as the fields the library consumes — the event, `createdAt`, and the user id. Rejecting a signature-verified delivery turns Logto schema drift into silent, unretried event loss (Logto retries a 5xx, not a 4xx), and the same handler revokes sessions for deleted and suspended users. A field that drifts out of its declared type is dropped from the entity handed to sync handlers, never rejected.
 
 ## Releasing
 

--- a/docs/content/docs/webhook-sync.mdx
+++ b/docs/content/docs/webhook-sync.mdx
@@ -175,10 +175,19 @@ synthetic payload, so read the status it gets back rather than expecting a `200`
 | Status | Meaning |
 | --- | --- |
 | `200` | Verified and dispatched to your `sync` mutation (or a deduplicated retry). |
-| `400` | Body wasn't valid JSON, wasn't a recognized `User.*` event, or its `createdAt` fell outside the freshness window. |
+| `400` | Body wasn't valid JSON, wasn't a recognized `User.*` event, named no user, or its `createdAt` fell outside the freshness window. |
 | `401` | Signature didn't match — wrong (or unset) `LOGTO_WEBHOOK_SIGNING_KEY`. |
 | `413` | Body over 1 MB. |
 | `500` | `LOGTO_WEBHOOK_SIGNING_KEY` isn't set on the deployment. |
+
+A verified delivery is never refused over a field the library doesn't read.
+Logto retries a `5xx` and not a `4xx`, so a `400` is permanent — and the same
+route revokes sessions for deleted and suspended users, which makes "reject the
+odd-looking delivery" the wrong default. Acceptance turns on the event, the
+`createdAt` freshness window and a usable user id; a field whose type drifts out
+of the published `LogtoUserEntity` shape is dropped from the `user` your handler
+receives, and the delivery still arrives verbatim as the third argument. Fields
+Logto adds later pass straight through.
 
 ## RBAC
 

--- a/examples/tanstack-router-spa/convex/rbac.test.ts
+++ b/examples/tanstack-router-spa/convex/rbac.test.ts
@@ -170,19 +170,35 @@ describe("RBAC example", () => {
     await expect(t.mutation(internal.logto.sync, hook("User.Deleted", null))).rejects.toThrow();
   });
 
-  test("a delete with stray data is rejected without tombstoning the user", async () => {
+  test("a delete whose entity id is unreadable is rejected without tombstoning the user", async () => {
     const t = makeT();
     const asAlice = t.withIdentity(ALICE);
     await asAlice.mutation(api.users.completeOnboarding, { role: "user" });
 
-    // A signature authenticates the sender, not the payload semantics. Never
-    // turn malformed entity data into a destructive delete.
+    // A signature authenticates the sender, not the payload semantics. An `id`
+    // that is present but not a string could be naming someone other than the
+    // route params, and a destructive event must not run on a guess.
     await expect(
       t.mutation(
         internal.logto.sync,
-        hook("User.Deleted", {}, { params: { userId: ALICE.subject } }),
+        hook("User.Deleted", { id: 42 }, { params: { userId: ALICE.subject } }),
       ),
     ).rejects.toThrow();
     expect((await rowFor(t, ALICE.subject))?.status).toBe("active");
+  });
+
+  test("a delete whose entity names no one still tombstones the route's user", async () => {
+    const t = makeT();
+    const asAlice = t.withIdentity(ALICE);
+    await asAlice.mutation(api.users.completeOnboarding, { role: "user" });
+
+    // `data: {}` carries no id, so it contradicts nothing — same information as
+    // the documented `data: null` shape. Refusing it would drop a
+    // signature-verified deletion, and Logto does not retry a 4xx.
+    await t.mutation(
+      internal.logto.sync,
+      hook("User.Deleted", {}, { params: { userId: ALICE.subject } }),
+    );
+    expect((await rowFor(t, ALICE.subject))?.status).toBe("deleted");
   });
 });

--- a/packages/convex-logto/src/webhooks.test.ts
+++ b/packages/convex-logto/src/webhooks.test.ts
@@ -193,16 +193,14 @@ describe("registerLogtoWebhook route", () => {
   });
 
   it.each([
-    ["missing hookId", { hookId: undefined }],
-    ["wrong profile field type", { data: { id: "u1", primaryEmail: 42 } }],
+    ["no entity at all", { data: null }],
+    ["a non-string entity id", { data: { id: 42 } }],
+    ["an entity that is not an object", { data: "user_abc" }],
     [
-      "wrong suspension flag type",
-      {
-        event: "User.SuspensionStatus.Updated",
-        data: { id: "u1", isSuspended: "true" },
-      },
+      "a User.Deleted with no id anywhere",
+      { event: "User.Deleted", data: null, params: {} },
     ],
-  ])("returns 400 on a malformed known payload (%s)", async (_name, patch) => {
+  ])("returns 400 when the user id is unusable (%s)", async (_name, patch) => {
     const handler = captureWebhookRoute({ signingKey });
     const malformed = JSON.stringify(freshPayload(patch));
     const runMutation = vi.fn();
@@ -445,6 +443,88 @@ describe("registerLogtoWebhook with sessions", () => {
     expect(response.status).toBe(200);
     expect(handlers.kill).toHaveBeenCalledWith({ subject: "u-current" });
     expect(calls.map((c) => c.fn)).toEqual(["record", "kill", "sync"]);
+  });
+
+  it.each([
+    ["a null envelope string", { userAgent: null }],
+    ["a missing hookId", { hookId: undefined }],
+    ["a stringified status", { status: "204" }],
+    [
+      "an entity field that changed type",
+      {
+        data: { id: "u-current", identities: [], lastSignInAt: "2026-01-01" },
+        params: { userId: "u-current" },
+      },
+    ],
+  ])(
+    "still revokes a deleted user's sessions despite %s",
+    async (_name, patch) => {
+      // The regression this guards: revocation used to hinge on the type of
+      // every advisory field. One drift and the delivery 400s — which Logto
+      // does not retry — so a deleted user's sessions stayed alive.
+      const { handler, runMutation, runAction, handlers, calls } =
+        sessionsHarness();
+      const deleted = JSON.stringify(
+        freshPayload({
+          event: "User.Deleted",
+          data: { id: "u-current" },
+          params: { userId: "u-current" },
+          ...patch,
+        }),
+      );
+
+      const response = await handler(
+        { runMutation, runAction },
+        post(sign(signingKey, deleted), deleted),
+      );
+
+      expect(response.status).toBe(200);
+      expect(handlers.kill).toHaveBeenCalledWith({ subject: "u-current" });
+      expect(calls.map((c) => c.fn)).toEqual(["record", "kill", "sync"]);
+    },
+  );
+
+  it("rejects User.Deleted when the entity id is present but unreadable", async () => {
+    // Not the same as "no entity": an id that is present and not a string could
+    // be naming someone other than the route params, and the destructive path
+    // must not run on a guess.
+    const { handler, runMutation, runAction, handlers } = sessionsHarness();
+    const unreadable = JSON.stringify(
+      freshPayload({
+        event: "User.Deleted",
+        data: { id: 42 },
+        params: { userId: "u-current" },
+      }),
+    );
+
+    const response = await handler(
+      { runMutation, runAction },
+      post(sign(signingKey, unreadable), unreadable),
+    );
+
+    expect(response.status).toBe(400);
+    expect(handlers.kill).not.toHaveBeenCalled();
+  });
+
+  it("accepts a User.Deleted whose entity names no one", async () => {
+    // `data: {}` carries the same information as the documented `data: null`
+    // shape — nothing to contradict the route params.
+    const { handler, runMutation, runAction, handlers } = sessionsHarness();
+    const empty = JSON.stringify(
+      freshPayload({
+        event: "User.Deleted",
+        data: {},
+        params: { userId: "u-current" },
+      }),
+    );
+
+    const response = await handler(
+      { runMutation, runAction },
+      post(sign(signingKey, empty), empty),
+    );
+
+    expect(response.status).toBe(200);
+    expect(handlers.kill).toHaveBeenCalledWith({ subject: "u-current" });
   });
 
   it("rejects User.Deleted when data.id and params.userId disagree", async () => {
@@ -694,7 +774,7 @@ describe("logtoSync dispatch", () => {
     ).rejects.toThrow(/known Logto User\.\* event/);
   });
 
-  it("throws before dispatching a known event with a malformed user", async () => {
+  it("throws before dispatching an event whose user has no id", async () => {
     const handler = vi.fn();
     const { sync } = logtoSync({ "User.Created": handler });
     await expect(
@@ -705,10 +785,51 @@ describe("logtoSync dispatch", () => {
           event: "User.Created",
           hookId: "h",
           createdAt: "t",
-          data: { id: "u1", primaryEmail: 42 },
+          data: { primaryEmail: "a@b.com" },
         },
       ),
     ).rejects.toThrow(/known Logto User\.\* event/);
     expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("drops a drifted advisory field instead of the delivery", async () => {
+    // Refusing a signature-verified delivery over a field this library never
+    // reads is how Logto schema drift becomes permanent event loss: Logto
+    // retries a 5xx, not a 4xx. The handler still gets a `LogtoUserEntity`
+    // that matches its declared type, and the raw value stays on `payload`.
+    const handler = vi.fn();
+    const { sync } = logtoSync({ "User.Created": handler });
+    await callSync(
+      sync,
+      { db: {} },
+      {
+        event: "User.Created",
+        hookId: 42,
+        ip: null,
+        status: "204",
+        createdAt: "t",
+        data: {
+          id: "u1",
+          primaryEmail: "a@b.com",
+          identities: [],
+          lastSignInAt: "2026-01-01T00:00:00.000Z",
+          newFieldLogtoAddedLater: { anything: true },
+        },
+      },
+    );
+    expect(handler).toHaveBeenCalledTimes(1);
+    const [, user, payload] = handler.mock.calls[0]!;
+    // Drifted fields are gone; a field this library has never heard of is not.
+    expect(user).toEqual({
+      id: "u1",
+      primaryEmail: "a@b.com",
+      newFieldLogtoAddedLater: { anything: true },
+    });
+    expect(payload.hookId).toBeUndefined();
+    expect(payload.ip).toBeUndefined();
+    expect(payload.status).toBeUndefined();
+    // Nothing is actually lost: the delivery is reachable verbatim.
+    expect(payload.data.identities).toEqual([]);
+    expect(payload.data.lastSignInAt).toBe("2026-01-01T00:00:00.000Z");
   });
 });

--- a/packages/convex-logto/src/webhooks.ts
+++ b/packages/convex-logto/src/webhooks.ts
@@ -44,18 +44,23 @@ export type LogtoWebhookPayload = {
    * Identifies the webhook **configuration** in Logto, not this delivery —
    * every delivery from the same hook carries the same `hookId`, so it is NOT
    * an idempotency key. Deliveries are deduplicated by raw-body hash instead
-   * (the `sessions` option of {@link registerLogtoWebhook}).
+   * (the `sessions` option of {@link registerLogtoWebhook}). Optional because
+   * nothing here reads it: a delivery is never refused over a field the
+   * library does not consume.
    */
-  hookId: string;
+  hookId?: string;
   event: LogtoUserEvent;
   /** ISO 8601 creation time of the event — bounds the accepted delivery age. */
   createdAt: string;
   userAgent?: string;
   ip?: string;
   /**
-   * The affected User entity. Current Logto versions include the pre-deletion
-   * entity for `User.Deleted`; older versions and Logto's documented payload
-   * shape use `null` and put the deleted id in Management API `params.userId`.
+   * The affected User entity, **verbatim as delivered**. Current Logto versions
+   * include the pre-deletion entity for `User.Deleted`; older versions and
+   * Logto's documented payload shape use `null` and put the deleted id in
+   * Management API `params.userId`. A sync handler's second argument is the
+   * normalized entity; this one is where the raw value of a field that drifted
+   * out of its declared type is still reachable.
    */
   data: LogtoUserEntity | null;
   /** Management API context, present for admin-triggered changes (e.g. deletion). */
@@ -73,37 +78,74 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-function isOptionalNullableString(value: unknown): boolean {
-  return value === undefined || value === null || typeof value === "string";
+function isNullableString(value: unknown): boolean {
+  return value === null || typeof value === "string";
 }
 
-function isOptionalNullableFiniteNumber(value: unknown): boolean {
+function isNullableFiniteNumber(value: unknown): boolean {
   return (
-    value === undefined ||
-    value === null ||
-    (typeof value === "number" && Number.isFinite(value))
+    value === null || (typeof value === "number" && Number.isFinite(value))
   );
 }
 
-function isLogtoUserEntity(value: unknown): value is LogtoUserEntity {
-  if (!isRecord(value) || typeof value.id !== "string") return false;
-  return (
-    isOptionalNullableString(value.username) &&
-    isOptionalNullableString(value.primaryEmail) &&
-    isOptionalNullableString(value.primaryPhone) &&
-    isOptionalNullableString(value.name) &&
-    isOptionalNullableString(value.avatar) &&
-    (value.customData === undefined || isRecord(value.customData)) &&
-    (value.identities === undefined || isRecord(value.identities)) &&
-    (value.isSuspended === undefined ||
-      typeof value.isSuspended === "boolean") &&
-    // `users.last_sign_in_at` is nullable in Logto: a user who has never signed
-    // in serialises as `null`. Rejecting that would drop a signature-verified
-    // delivery — including the `User.Deleted` one that revokes their sessions.
-    isOptionalNullableFiniteNumber(value.lastSignInAt) &&
-    isOptionalNullableFiniteNumber(value.createdAt) &&
-    isOptionalNullableString(value.applicationId)
-  );
+/**
+ * The fields this library never reads, each with the runtime type the published
+ * type declares for it.
+ *
+ * A delivery is never *refused* over one of these. Logto retries a 5xx and not
+ * a 4xx, so rejecting a signature-verified delivery turns one drifted field
+ * into permanent, first-attempt event loss — and because the same handler
+ * revokes sessions for deleted and suspended users, it would silently disable
+ * that too. A drifted field is dropped from the entity handed to sync handlers
+ * instead, which keeps the declared type honest while the raw value stays
+ * reachable on the payload those handlers also receive.
+ */
+const ADVISORY_PAYLOAD_FIELDS: Record<string, (value: unknown) => boolean> = {
+  hookId: (value) => typeof value === "string",
+  userAgent: (value) => typeof value === "string",
+  ip: (value) => typeof value === "string",
+  path: (value) => typeof value === "string",
+  method: (value) => typeof value === "string",
+  status: (value) => typeof value === "number" && Number.isFinite(value),
+  params: isRecord,
+  matchedRoute: (value) => typeof value === "string",
+};
+
+/** See {@link ADVISORY_PAYLOAD_FIELDS} — the same rule for the User entity. */
+const ADVISORY_ENTITY_FIELDS: Record<string, (value: unknown) => boolean> = {
+  username: isNullableString,
+  primaryEmail: isNullableString,
+  primaryPhone: isNullableString,
+  name: isNullableString,
+  avatar: isNullableString,
+  applicationId: isNullableString,
+  customData: isRecord,
+  identities: isRecord,
+  isSuspended: (value) => typeof value === "boolean",
+  // `users.last_sign_in_at` is nullable in Logto: a user who has never signed
+  // in serialises as `null`.
+  lastSignInAt: isNullableFiniteNumber,
+  createdAt: isNullableFiniteNumber,
+};
+
+/**
+ * Copy `raw` without the declared fields whose value drifted out of its type.
+ * Fields absent from `declared` — including ones Logto adds later — pass
+ * through untouched, and an undrifted payload is returned as-is.
+ */
+function withoutDriftedFields<Shape extends Record<string, unknown>>(
+  raw: Shape,
+  declared: Record<string, (value: unknown) => boolean>,
+): Shape {
+  let pruned: Shape | undefined;
+  for (const [field, matchesDeclaredType] of Object.entries(declared)) {
+    if (!Object.hasOwn(raw, field)) continue;
+    const value = raw[field];
+    if (value === undefined || matchesDeclaredType(value)) continue;
+    pruned ??= { ...raw };
+    delete pruned[field];
+  }
+  return pruned ?? raw;
 }
 
 function isLogtoUserEvent(value: unknown): value is LogtoUserEvent {
@@ -161,6 +203,20 @@ function entityId(payload: Record<string, unknown>): string | undefined {
   return undefined;
 }
 
+/**
+ * Did the entity bring an `id` this library cannot read? Distinct from "no
+ * entity": a `User.Deleted` naming no user in `data` is the documented 204
+ * shape and the route params are authoritative, but one whose id is present and
+ * unreadable could be naming a *different* user than the route params, and a
+ * destructive event must not be executed on a guess.
+ */
+function hasUnreadableEntityId(payload: Record<string, unknown>): boolean {
+  const data = payload.data;
+  return (
+    isRecord(data) && Object.hasOwn(data, "id") && typeof data.id !== "string"
+  );
+}
+
 /** The deleted user's id from the Management API route params (`DELETE /users/:userId`). */
 function paramsUserId(payload: Record<string, unknown>): string | undefined {
   const params = payload.params;
@@ -170,6 +226,13 @@ function paramsUserId(payload: Record<string, unknown>): string | undefined {
   return undefined;
 }
 
+/**
+ * Accept a delivery on exactly the fields this library consumes: the event it
+ * dispatches on, the `createdAt` it bounds the delivery age with, and the user
+ * id it revokes sessions by. Everything else is advisory — see
+ * {@link ADVISORY_PAYLOAD_FIELDS} for why widening this predicate is how schema
+ * drift becomes silent event loss.
+ */
 function isLogtoWebhookPayload(value: unknown): value is LogtoWebhookPayload {
   if (!isRecord(value)) return false;
   const candidate = value;
@@ -179,43 +242,35 @@ function isLogtoWebhookPayload(value: unknown): value is LogtoWebhookPayload {
   if (!isLogtoUserEvent(event)) {
     return false;
   }
-  if (
-    typeof candidate.hookId !== "string" ||
-    typeof candidate.createdAt !== "string" ||
-    (candidate.userAgent !== undefined &&
-      typeof candidate.userAgent !== "string") ||
-    (candidate.ip !== undefined && typeof candidate.ip !== "string") ||
-    (candidate.path !== undefined && typeof candidate.path !== "string") ||
-    (candidate.method !== undefined && typeof candidate.method !== "string") ||
-    (candidate.status !== undefined &&
-      (typeof candidate.status !== "number" ||
-        !Number.isFinite(candidate.status))) ||
-    (candidate.params !== undefined && !isRecord(candidate.params)) ||
-    (candidate.matchedRoute !== undefined &&
-      typeof candidate.matchedRoute !== "string")
-  ) {
-    return false;
-  }
+  // Read by the replay window below; `isFreshDelivery` parses it.
+  if (typeof candidate.createdAt !== "string") return false;
+  const dataUserId = entityId(candidate);
+  const routeUserId = paramsUserId(candidate);
   // Current Logto versions send the pre-deletion User; older/documented payloads
-  // send `data: null` with the id in route params. Accept both, but never accept
-  // malformed or contradictory entity/context data for a destructive event.
+  // send `data: null` with the id in route params (a 204 delete route serialises
+  // no `data` key at all). Accept both, but never accept contradictory ids for a
+  // destructive event.
   if (event === "User.Deleted") {
-    const dataUserId = entityId(candidate);
-    const routeUserId = paramsUserId(candidate);
     return (
-      // A 204 delete route serialises no `data` key at all, so `undefined` and
-      // `null` must both mean "no entity, use the route params".
-      (candidate.data == null || isLogtoUserEntity(candidate.data)) &&
+      !hasUnreadableEntityId(candidate) &&
       (dataUserId !== undefined || routeUserId !== undefined) &&
       (dataUserId === undefined ||
         routeUserId === undefined ||
         dataUserId === routeUserId)
     );
   }
-  return isLogtoUserEntity(candidate.data);
+  // Every other event hands a sync handler an entity, so it needs one.
+  return dataUserId !== undefined;
 }
 
-/** A per-event sync handler. Runs in a Convex mutation, so `ctx.db` is available. */
+/**
+ * A per-event sync handler. Runs in a Convex mutation, so `ctx.db` is available.
+ *
+ * `user` is normalized: a field whose type drifted out of the declared
+ * {@link LogtoUserEntity} shape is absent rather than surprising, and the raw
+ * delivery is still reachable on `payload`. See
+ * {@link ADVISORY_PAYLOAD_FIELDS}.
+ */
 export type LogtoSyncHandler<DataModel extends GenericDataModel> = (
   ctx: GenericMutationCtx<DataModel>,
   user: LogtoUserEntity,
@@ -280,13 +335,19 @@ export function logtoSync<
             "convex-logto: logtoSync received a payload that isn't a known Logto User.* event.",
           );
         }
-        const payload = args.payload;
+        const payload = withoutDriftedFields(
+          args.payload,
+          ADVISORY_PAYLOAD_FIELDS,
+        );
         const handler = handlers[payload.event];
         if (handler) {
           // Current Logto sends the pre-deletion entity; for the older/documented
           // `data: null` shape, synthesize the minimal entity from route params.
-          let user = payload.data;
-          if (user === null) {
+          const entity = payload.data;
+          let user: LogtoUserEntity;
+          if (isRecord(entity) && typeof entity.id === "string") {
+            user = withoutDriftedFields(entity, ADVISORY_ENTITY_FIELDS);
+          } else {
             const id = paramsUserId(payload);
             if (id === undefined) {
               throw new Error(


### PR DESCRIPTION
Closes #132.

`isLogtoWebhookPayload` type-checked roughly fifteen fields the library never reads. One mismatch and the route answered **400 before** `recordWebhookDelivery` and `killSubjectSessions` - and Logto retries a 5xx, not a 4xx, so the loss was permanent and first-attempt. Because the same handler revokes sessions for deleted and suspended users, an advisory field drifting would have silently disabled that security control along with the app's own sync handlers.

`AGENTS.md` has stated the invariant since the last time this bit (`f3cd827`, which fixed two such fields *days* after the validator was written, and whose message records that four event types "were silently lost for those users, taking the suspension/deletion revocation path with them"). The code had not caught up.

## What the predicate accepts on now

Exactly what the library consumes: a known `User.*` event, a string `createdAt` for the replay window, and a usable user id. The two deliberate rejections stay - an unknown event (which would 200 silently and hide a misconfigured hook) and a `User.Deleted` whose `data.id` and `params.userId` disagree.

## Drifted fields are dropped, not rejected

Rejecting nothing would have made the app-facing type lie: `LogtoSyncHandler` hands the app a typed `LogtoUserEntity`. So a field whose value drifted out of its declared type is removed from the entity the handler receives, while the raw delivery stays reachable on the `payload` argument. Fields Logto adds later still pass through untouched.

## One rejection is new

A `User.Deleted` whose entity carries a **non-string `id`** is now refused. That id is one the library does consume, and an unreadable one could be naming a different user than the route params - a destructive event must not run on a guess. Conversely a `User.Deleted` whose entity names no one (`data: {}`) is now accepted: it carries the same information as the documented `data: null` shape.

`LogtoWebhookPayload["hookId"]` becomes optional (hence a `minor`): nothing reads it, so nothing should turn on it.

## Tests

Five new tests fail on `main` and pass here, including four at the route level asserting that a deleted user's sessions are still revoked despite a null envelope string, a missing `hookId`, a stringified `status`, or an entity field that changed type. The example app's RBAC suite gained the mirror pair for the destructive path.

Verified with the full CI sequence (`lint`, `format:check`, `check-types`, `test`) over the whole workspace: 527 library tests, 10 example tests.
