### PR TITLE
fix(session): three cookie-transport and device-binding defects

### DIFF
--- a/.changeset/cookie-and-device-audit.md
+++ b/.changeset/cookie-and-device-audit.md
@@ -1,0 +1,31 @@
+---
+"convex-logto": patch
+---
+
+Fix three defects an adversarial audit of the cookie transport and device
+binding confirmed.
+
+**A Logto outage turned SSR seeding into a 500 for every signed-in visitor.**
+`getInitialToken` rethrew any error it could not classify, and an unreachable
+Logto is exactly that class — the component rethrows a raw `fetch` failure
+unclassified on purpose, so that an outage does not force a reauthentication.
+With the documented root-loader seeding path, the loader threw and the whole
+document failed. The browser `/token` route had always treated the same failure
+as transient and kept the session; the seed now matches both it and the
+documented contract, "every failed seed returns empty without changing the
+cookie".
+
+**"Sign out everywhere" with no cookie answered a body the client rejects.** The
+route parsed the `everywhere` flag and then returned a bare `{}` when the cookie
+was already gone. The client validates that call on `count`, so it retried twice
+and threw — a hard error for what is a clean no-op. It now answers
+`{ count: 0 }`.
+
+**A device key could be reported as persisted when its transaction aborted.**
+`add()` resolved from the IndexedDB *request*, but a commit-time failure
+(`QuotaExceededError`) arrives on the *transaction*, after that request has
+already succeeded. The binding then lived only in the tab's memory: the next
+reload generated a different key, every device proof was rejected, and the
+component deleted the session — a sign-in loop that survived one page load at a
+time. `add()` now settles on the transaction, so the failure reaches the loud
+path the module promises instead of falling back silently.

--- a/packages/convex-logto/src/session-cookie.test.ts
+++ b/packages/convex-logto/src/session-cookie.test.ts
@@ -397,6 +397,26 @@ describe("cookie session flows", () => {
     });
   });
 
+  it("answers a cookieless sign-out in the shape the caller asked for", async () => {
+    // The cookie can leave the jar while a tab lives (privacy extension, ITP
+    // eviction, another tab clearing cookies). Signing out is then a no-op —
+    // but a bare `{}` fails the client's `count` check, so it would retry twice
+    // and then throw, turning a clean no-op into a hard error.
+    const { handler, handlers } = makeHarness();
+    const everywhere = await handler(
+      request("sign-out", { body: { everywhere: true } }),
+    );
+    expect(everywhere.status).toBe(200);
+    await expect(everywhere.json()).resolves.toEqual({ count: 0 });
+
+    const local = await handler(request("sign-out", {}));
+    expect(local.status).toBe(200);
+    await expect(local.json()).resolves.toEqual({});
+
+    expect(handlers.signOut).not.toHaveBeenCalled();
+    expect(handlers.signOutEverywhere).not.toHaveBeenCalled();
+  });
+
   it("translates a legacy app module's missing sign-out-everywhere action", async () => {
     const { handler, handlers } = makeHarness();
     handlers.signOutEverywhere.mockRejectedValue(
@@ -546,6 +566,23 @@ describe("SSR seed", () => {
     const seed = await handler.getInitialToken(
       new Request(`${APP_ORIGIN}/dashboard`, {
         headers: { Cookie: cookie("spent") },
+      }),
+    );
+    expect(seed.initialToken).toBeNull();
+    expect(seed.initialSessionId).toBeNull();
+    expect(seed.headers.get("set-cookie")).toBeNull();
+  });
+
+  it("leaves the cookie intact and returns an empty seed after an unclassifiable error", async () => {
+    // What an unreachable Logto looks like: the component rethrows a raw fetch
+    // failure unclassified on purpose. Rethrowing here would turn that outage
+    // into a 500 document for every signed-in visitor, while the browser
+    // `/token` route treats the same failure as transient and keeps going.
+    const { handler, handlers } = makeHarness();
+    handlers.refresh.mockRejectedValueOnce(new Error("fetch failed"));
+    const seed = await handler.getInitialToken(
+      new Request(`${APP_ORIGIN}/dashboard`, {
+        headers: { Cookie: cookie("still-valid") },
       }),
     );
     expect(seed.initialToken).toBeNull();

--- a/packages/convex-logto/src/session-cookie.ts
+++ b/packages/convex-logto/src/session-cookie.ts
@@ -571,8 +571,16 @@ export function createLogtoSessionCookieHandler(
           );
           const everywhere = optionalBoolean(body, "everywhere") ?? false;
           const sessionToken = readCookie(request);
+          // Nothing to sign out of, but the answer still has to match the call:
+          // the client validates `signOutEverywhere` responses on `count`, and
+          // a bare `{}` fails that check, retries twice and then throws — a
+          // hard error for what is a clean no-op.
           if (sessionToken === null)
-            return jsonResponse({}, { headers }, origin);
+            return jsonResponse(
+              everywhere ? { count: 0 } : {},
+              { headers },
+              origin,
+            );
           try {
             const signOutEverywhere = options.sessionApi.signOutEverywhere;
             if (everywhere && signOutEverywhere === undefined) {
@@ -813,8 +821,16 @@ export function createLogtoSessionCookieHandler(
           initialSessionId: result.sessionId,
           headers,
         };
-      } catch (error) {
-        if (errorData(error) === null) throw error;
+      } catch {
+        // Every failed seed returns empty without changing the cookie —
+        // including an error this transport cannot classify, which is what an
+        // unreachable Logto looks like (the component rethrows a raw `fetch`
+        // failure unclassified on purpose, so that an outage does not force a
+        // reauthentication). Rethrowing would turn that outage into a 500
+        // document for every signed-in visitor, while the browser `/token`
+        // route — the authoritative one — treats the same failure as transient
+        // and keeps the session. A genuine misconfiguration still surfaces
+        // there, loudly, on the first request after hydration.
         return {
           initialToken: null,
           initialSessionId: null,

--- a/packages/convex-logto/src/session-device.test.ts
+++ b/packages/convex-logto/src/session-device.test.ts
@@ -25,6 +25,71 @@ function memoryRepository(): SessionDeviceKeyRepository & {
   };
 }
 
+/**
+ * The narrowest IndexedDB that can model a commit-time abort: a request that
+ * succeeds, followed by a transaction that does not.
+ */
+function fakeIndexedDb(options: {
+  abortCommitWith?: string;
+  occupied?: boolean;
+}): IDBFactory {
+  const stored = new Map<string, unknown>();
+  if (options.occupied) stored.set("device-key", { winner: true });
+  const fire = (handler: unknown, event: unknown) => {
+    if (typeof handler === "function") handler(event);
+  };
+  const database = {
+    objectStoreNames: { contains: () => true },
+    close: () => undefined,
+    transaction: (_store: string, mode: string) => {
+      const transaction: Record<string, unknown> = { error: null };
+      transaction["objectStore"] = () => ({
+        get: (key: string) => {
+          const request: Record<string, unknown> = { result: stored.get(key) };
+          queueMicrotask(() => fire(request["onsuccess"], { target: request }));
+          return request;
+        },
+        add: (value: unknown, key: string) => {
+          const request: Record<string, unknown> = { error: null };
+          queueMicrotask(() => {
+            if (stored.has(key)) {
+              request["error"] = { name: "ConstraintError" };
+              fire(request["onerror"], {
+                preventDefault: () => undefined,
+                stopPropagation: () => undefined,
+              });
+            } else {
+              stored.set(key, value);
+              fire(request["onsuccess"], { target: request });
+            }
+            queueMicrotask(() => {
+              if (
+                options.abortCommitWith !== undefined &&
+                mode === "readwrite"
+              ) {
+                stored.delete(key);
+                transaction["error"] = { name: options.abortCommitWith };
+                fire(transaction["onabort"], {});
+                return;
+              }
+              fire(transaction["oncomplete"], {});
+            });
+          });
+          return request;
+        },
+      });
+      return transaction;
+    },
+  };
+  return {
+    open: () => {
+      const request: Record<string, unknown> = { result: database };
+      queueMicrotask(() => fire(request["onsuccess"], { target: request }));
+      return request;
+    },
+  } as unknown as IDBFactory;
+}
+
 describe("WebCryptoSessionDeviceBinding", () => {
   it("persists a non-extractable P-256 key and signs a verifiable token proof", async () => {
     const repository = memoryRepository();
@@ -50,6 +115,32 @@ describe("WebCryptoSessionDeviceBinding", () => {
     // A fresh binding instance (another tab/reload) adopts the persisted key.
     const reloaded = new WebCryptoSessionDeviceBinding(repository);
     await expect(reloaded.getPublicKey()).resolves.toEqual(publicKey);
+  });
+
+  it("fails loudly when the key's transaction aborts at commit", async () => {
+    // IndexedDB reports a quota failure on the transaction, after the `add`
+    // request has already succeeded. Believing the request would leave the key
+    // in this tab's memory only: the next reload generates a different one,
+    // every device proof is rejected, and the component deletes the session.
+    const binding = createSessionDeviceBinding(
+      "deployment",
+      fakeIndexedDb({ abortCommitWith: "QuotaExceededError" }),
+    );
+
+    await expect(binding.prepare()).rejects.toBeInstanceOf(
+      SessionDeviceBindingError,
+    );
+  });
+
+  it("adopts another tab's key when the add loses the race", async () => {
+    // A ConstraintError is swallowed so the transaction still commits, and the
+    // caller re-reads the winner instead of failing.
+    const binding = createSessionDeviceBinding(
+      "deployment",
+      fakeIndexedDb({ occupied: true }),
+    );
+
+    await expect(binding.prepare()).resolves.toBeUndefined();
   });
 
   it("defers an unavailable IndexedDB failure until preparation", async () => {

--- a/packages/convex-logto/src/session-device.ts
+++ b/packages/convex-logto/src/session-device.ts
@@ -178,20 +178,30 @@ class IndexedDbDeviceKeyRepository implements SessionDeviceKeyRepository {
     const database = await this.open();
     try {
       return await new Promise((resolve, reject) => {
-        const request = database
-          .transaction(DEVICE_KEY_STORE, "readwrite")
+        const transaction = database.transaction(DEVICE_KEY_STORE, "readwrite");
+        const request = transaction
           .objectStore(DEVICE_KEY_STORE)
           .add(keyPair, DEVICE_KEY_ID);
-        request.onsuccess = () => resolve(true);
+        let alreadyStored = false;
         request.onerror = (event) => {
-          if (request.error?.name === "ConstraintError") {
-            event.preventDefault();
-            event.stopPropagation();
-            resolve(false);
-          } else {
-            reject(request.error ?? unavailable());
-          }
+          // A key is already stored — another tab won the race. Swallow the
+          // error so the transaction still commits, and report the loss;
+          // anything else must abort and be raised.
+          if (request.error?.name !== "ConstraintError") return;
+          event.preventDefault();
+          event.stopPropagation();
+          alreadyStored = true;
         };
+        // Settle on the *transaction*, not the request: a successful `add` is
+        // still undone by a commit-time abort (`QuotaExceededError`), which
+        // IndexedDB reports here and not on the request. Reporting the key as
+        // persisted when it is not degrades the binding to this tab's memory —
+        // the next reload generates a different key, every proof is rejected,
+        // and the component deletes the session on sight. Failing instead
+        // reaches the module's stated contract: no silent fallback.
+        transaction.oncomplete = () => resolve(!alreadyStored);
+        transaction.onabort = () => reject(transaction.error ?? unavailable());
+        transaction.onerror = () => reject(transaction.error ?? unavailable());
       });
     } finally {
       database.close();


### PR DESCRIPTION
Closes #136, closes #137, closes #138. Three defects an adversarial audit of the cookie transport and device binding confirmed, each with a regression test that fails on `main`.

## 1. A Logto outage turned SSR seeding into a 500 for every signed-in visitor

`getInitialToken` rethrew any error it could not classify:

```ts
if (errorData(error) === null) throw error;
```

An unreachable Logto is exactly that class - `component/lib.ts` rethrows a raw `fetch` failure unclassified *on purpose*, so an outage does not force a full reauthentication. With the documented root-loader seeding path the loader therefore threw, and every signed-in visitor got a 500 document for the duration of the outage.

The browser `/token` route had always classified the identical failure the other way (`500 {kind: "transient"}` -> engine keeps the session), and the docs state the transport's contract as "every failed seed returns empty without changing the cookie". The seed now matches both. A genuine misconfiguration still surfaces loudly on the first `/token` request after hydration, which is where it was always going to surface anyway.

## 2. "Sign out everywhere" with no cookie answered a body the client rejects

The route read the `everywhere` flag, then returned a bare `{}` on the no-cookie path. `parseSignOutEverywhereResponse` requires a numeric `count`, so the client retried twice and then threw "session cookie handler returned an invalid response" - a hard error and a console error for what is a clean no-op. Plain `signOut()` was fine on the same path, so the two differed only by the flag the route had already parsed. It now answers `{ count: 0 }`.

Trigger: a tab whose engine holds a session marker while the `__Host-` cookie has left the jar (privacy extension, ITP eviction, cookies cleared in another tab).

## 3. A device key could be reported as persisted when its transaction aborted

`add()` resolved `true` from `request.onsuccess`. IndexedDB fires that on the request; a `QuotaExceededError` aborts the **transaction** afterwards, and `database.close()` in the `finally` made the abort unobservable. The binding then existed only in the tab's memory: the next reload generated a different key, `sign()` produced a proof under the wrong key, and the component threw terminal `device_proof_invalid` - deleting the session. Every subsequent sign-in repeated it, working until reload and then dying.

`add()` now settles on the transaction (`oncomplete` / `onabort`), so the failure reaches the loud path the module already promises: "device binding requires working IndexedDB to persist its non-extractable key ... silent fallback is not allowed." The `ConstraintError` race is unchanged in effect - it is swallowed so the transaction still commits, and the caller adopts the other tab's winner.

## Tests

The device tests gain the narrowest fake `IDBFactory` that can model a commit-time abort (a request that succeeds followed by a transaction that does not), covering both the abort and the lost-race path. The cookie tests gain an unclassifiable seed rejection and a cookieless sign-out in both shapes.

Verified with the full CI sequence (`lint`, `format:check`, `check-types`, `test`) over the whole workspace.
