### PR TITLE
fix(component): collect revocation watermarks once they can kill nothing

### DIFF
--- a/.changeset/collect-revocation-watermarks.md
+++ b/.changeset/collect-revocation-watermarks.md
@@ -1,0 +1,21 @@
+---
+"convex-logto": patch
+---
+
+Garbage-collect revocation watermarks.
+
+`subjectRevocations` and `sidRevocations` were never collected: `gc` swept every
+other table and skipped these two, and nothing else deleted from them. With
+back-channel logout enabled that is one permanent row per Logto OP session that
+ever ends — `markSidRevoked` inserts even when the logout matched no sessions,
+which the guide describes as a normal outcome — and the tables are
+component-private, so an app cannot prune them either.
+
+`gc` now collects a watermark, but only when it can no longer kill anything: no
+session it governs survives, and it is older than `SESSION_GC_AFTER_MS`. Both
+conditions are load-bearing. Deleting a marker while a row it killed is still
+waiting for a cleanup batch would hand that row's token its authority back, and
+a refresh can bind a `sid` to a session that did not carry one, so "nothing
+governed today" is not sufficient on its own. Two new `by_revokedAt` indexes let
+the sweep find candidates without scanning; the component takes care of building
+them on the next push, and no migration is required.

--- a/packages/convex-logto/src/component/core.ts
+++ b/packages/convex-logto/src/component/core.ts
@@ -169,6 +169,17 @@ export function normalizeClientDescriptor(
 export const SESSION_GC_AFTER_MS = 190 * 24 * 60 * 60 * 1000;
 
 /**
+ * GC horizon for a revocation watermark, measured from the moment it was
+ * written. A watermark is what makes a session created at or before it dead, so
+ * collecting one is only safe once nothing can still be governed by it: no
+ * session row it covers remains (the collector checks that directly), and no
+ * session can still *acquire* the marked `sid`, which a refresh can do long
+ * after sign-in. Past this horizon every session that could do either is itself
+ * unconditionally GC-dead, so the two conditions together leave no window.
+ */
+export const REVOCATION_MARKER_GC_AFTER_MS = SESSION_GC_AFTER_MS;
+
+/**
  * GC horizon for webhook-delivery dedupe hashes. Logto's delivery retries land
  * within seconds and the webhook route rejects deliveries older than minutes,
  * so a day of memory is far more than dedupe ever needs.

--- a/packages/convex-logto/src/component/lib.test.ts
+++ b/packages/convex-logto/src/component/lib.test.ts
@@ -19,6 +19,7 @@ import {
   signOut,
 } from "./lib";
 import {
+  REVOCATION_MARKER_GC_AFTER_MS,
   SESSION_LIST_LIMIT,
   SESSION_LIST_SCAN_BYTES,
   SESSION_LIST_SCAN_LIMIT,
@@ -1851,6 +1852,160 @@ describe("gc token generations", () => {
       "session-1",
       "orphan-generation",
     ]);
+  });
+});
+
+describe("gc revocation watermarks", () => {
+  type Row = Record<string, unknown> & { _id: string };
+
+  /**
+   * A small index-aware fake for the whole `gc` mutation: the watermark sweep
+   * needs a chained `eq(...).lte(...)`, which the refresh harness above does
+   * not model.
+   */
+  function gcHarness(tables: Record<string, Row[]>) {
+    const store: Record<string, Row[]> = {};
+    for (const [table, rows] of Object.entries(tables)) {
+      store[table] = rows.map((row) => ({ ...row }));
+    }
+    const db = {
+      query: (table: string) => ({
+        withIndex: (
+          _index: string,
+          configure?: (query: unknown) => unknown,
+        ) => {
+          const conditions: Array<(row: Row) => boolean> = [];
+          const compare =
+            (
+              field: string,
+              value: unknown,
+              ok: (a: number, b: number) => boolean,
+            ) =>
+            (row: Row) =>
+              typeof row[field] === "number" &&
+              typeof value === "number" &&
+              ok(row[field], value);
+          const builder = {
+            eq(field: string, value: unknown) {
+              conditions.push((row) => row[field] === value);
+              return this;
+            },
+            lt(field: string, value: unknown) {
+              conditions.push(compare(field, value, (a, b) => a < b));
+              return this;
+            },
+            lte(field: string, value: unknown) {
+              conditions.push(compare(field, value, (a, b) => a <= b));
+              return this;
+            },
+          };
+          configure?.(builder);
+          const matching = () =>
+            (store[table] ?? []).filter((row) =>
+              conditions.every((condition) => condition(row)),
+            );
+          const result = {
+            first: () => Promise.resolve(matching()[0] ?? null),
+            unique: () => Promise.resolve(matching()[0] ?? null),
+            collect: () => Promise.resolve(matching()),
+            take: (count: number) =>
+              Promise.resolve(matching().slice(0, count)),
+            order: () => result,
+          };
+          return result;
+        },
+      }),
+      delete: (id: string) => {
+        for (const rows of Object.values(store)) {
+          const index = rows.findIndex((row) => row._id === id);
+          if (index >= 0) rows.splice(index, 1);
+        }
+        return Promise.resolve();
+      },
+      get: (id: string) =>
+        Promise.resolve(
+          Object.values(store)
+            .flat()
+            .find((row) => row._id === id) ?? null,
+        ),
+    };
+    return {
+      db,
+      rows: (table: string) => (store[table] ?? []).map((row) => row._id),
+    };
+  }
+
+  const NOW = Date.now();
+  const ANCIENT = NOW - REVOCATION_MARKER_GC_AFTER_MS - 60_000;
+
+  it("collects a watermark once nothing it governs survives", async () => {
+    // Back-channel logout writes one row per OP session that ever ends,
+    // including logouts that matched nothing. Without this sweep they are
+    // permanent, and the app cannot reach a component-private table to prune.
+    const harness = gcHarness({
+      subjectRevocations: [
+        { _id: "subject-marker", subject: "u1", revokedAt: ANCIENT },
+      ],
+      sidRevocations: [{ _id: "sid-marker", sid: "s1", revokedAt: ANCIENT }],
+      sessions: [
+        // Created after the marker, so governed by neither, and refreshed
+        // recently enough that the dead-session sweep leaves it alone.
+        {
+          _id: "live",
+          subject: "u1",
+          sid: "s1",
+          createdAt: NOW,
+          lastRefreshedAt: NOW,
+        },
+      ],
+    });
+
+    await expect(gcHandler({ db: harness.db }, {})).resolves.toBeNull();
+    expect(harness.rows("subjectRevocations")).toEqual([]);
+    expect(harness.rows("sidRevocations")).toEqual([]);
+    expect(harness.rows("sessions")).toEqual(["live"]);
+  });
+
+  it("keeps a watermark while a row it killed is still waiting to be drained", async () => {
+    // The row is dead *because* of the marker. Dropping the marker first would
+    // hand its token back its authority.
+    const harness = gcHarness({
+      subjectRevocations: [
+        { _id: "subject-marker", subject: "u1", revokedAt: ANCIENT },
+      ],
+      sidRevocations: [{ _id: "sid-marker", sid: "s1", revokedAt: ANCIENT }],
+      sessions: [
+        {
+          _id: "stranded",
+          subject: "u1",
+          sid: "s1",
+          createdAt: ANCIENT - 1,
+          lastRefreshedAt: NOW,
+        },
+      ],
+    });
+
+    await expect(gcHandler({ db: harness.db }, {})).resolves.toBeNull();
+    expect(harness.rows("subjectRevocations")).toEqual(["subject-marker"]);
+    expect(harness.rows("sidRevocations")).toEqual(["sid-marker"]);
+  });
+
+  it("keeps a watermark inside the horizon even with nothing left to kill", async () => {
+    // A refresh can bind a `sid` to a session that did not have one, long after
+    // sign-in, so "no governed row today" is not enough on its own.
+    const harness = gcHarness({
+      subjectRevocations: [
+        { _id: "subject-marker", subject: "u1", revokedAt: NOW - 60_000 },
+      ],
+      sidRevocations: [
+        { _id: "sid-marker", sid: "s1", revokedAt: NOW - 60_000 },
+      ],
+      sessions: [],
+    });
+
+    await expect(gcHandler({ db: harness.db }, {})).resolves.toBeNull();
+    expect(harness.rows("subjectRevocations")).toEqual(["subject-marker"]);
+    expect(harness.rows("sidRevocations")).toEqual(["sid-marker"]);
   });
 });
 

--- a/packages/convex-logto/src/component/lib.ts
+++ b/packages/convex-logto/src/component/lib.ts
@@ -13,6 +13,7 @@ import { internal } from "./_generated/api.js";
 import type { DataModel, Doc, Id } from "./_generated/dataModel.js";
 import {
   DEFAULT_REUSE_WINDOW_MS,
+  REVOCATION_MARKER_GC_AFTER_MS,
   SESSION_GC_AFTER_MS,
   SESSION_TOKEN_GENERATION_LIMIT,
   TRANSACTION_TTL_MS,
@@ -116,6 +117,9 @@ const MAX_REVOCATION_BATCHES = 512;
 // so reserve four of the 16 MiB read/write budget for transaction documents.
 const GC_TRANSACTION_BATCH_SIZE = 4;
 const GC_SMALL_DOCUMENT_BATCH_SIZE = 500;
+// Each watermark costs one indexed session lookup on top of its own row, so
+// this batch buys two document reads per unit rather than one.
+const GC_MARKER_BATCH_SIZE = 100;
 
 type SessionTokenMatch =
   | { source: "current"; session: Doc<"sessions"> }
@@ -1786,6 +1790,56 @@ export const forgetWebhookDelivery = mutation({
 
 // --- GC ---------------------------------------------------------------------
 
+/**
+ * Delete revocation watermarks that can no longer kill anything: no session the
+ * marker covers survives, and it is old enough that none can appear. Returns
+ * how many rows were deleted so `gc` knows whether to continue.
+ *
+ * A marker that still governs a surviving row is skipped, not deleted — that
+ * row is logically dead *because* of the marker, and dropping it early would
+ * hand its token back its authority. Skipped markers are the oldest, so they
+ * hold up younger ones until the session sweep in the same mutation removes
+ * what they govern; that is the safe direction to be stuck in.
+ */
+async function collectRevocationMarkers(
+  db: DatabaseWriter,
+  now: number,
+): Promise<number> {
+  const horizon = now - REVOCATION_MARKER_GC_AFTER_MS;
+  let deleted = 0;
+  const subjectMarkers = await db
+    .query("subjectRevocations")
+    .withIndex("by_revokedAt", (q) => q.lt("revokedAt", horizon))
+    .take(GC_MARKER_BATCH_SIZE);
+  for (const marker of subjectMarkers) {
+    const governed = await db
+      .query("sessions")
+      .withIndex("by_subject_createdAt", (q) =>
+        q.eq("subject", marker.subject).lte("createdAt", marker.revokedAt),
+      )
+      .first();
+    if (governed !== null) continue;
+    await db.delete(marker._id);
+    deleted += 1;
+  }
+  const sidMarkers = await db
+    .query("sidRevocations")
+    .withIndex("by_revokedAt", (q) => q.lt("revokedAt", horizon))
+    .take(GC_MARKER_BATCH_SIZE);
+  for (const marker of sidMarkers) {
+    const governed = await db
+      .query("sessions")
+      .withIndex("by_sid_createdAt", (q) =>
+        q.eq("sid", marker.sid).lte("createdAt", marker.revokedAt),
+      )
+      .first();
+    if (governed !== null) continue;
+    await db.delete(marker._id);
+    deleted += 1;
+  }
+  return deleted;
+}
+
 export const gc = internalMutation({
   args: {},
   returns: v.null(),
@@ -1823,13 +1877,21 @@ export const gc = internalMutation({
       )
       .take(GC_SMALL_DOCUMENT_BATCH_SIZE);
     for (const d of staleDeliveries) await ctx.db.delete(d._id);
+    // Revocation watermarks outlive the rows they killed on purpose, but not
+    // forever: back-channel logout writes one per OP session that ever ends,
+    // including logouts that matched nothing, and nothing else ever deletes
+    // them. Collect only a marker that governs no surviving session — deleting
+    // one that still does would make a logically dead row start validating
+    // again — and only past the horizon where a session could still bind it.
+    const collectedMarkers = await collectRevocationMarkers(ctx.db, now);
     // A full batch might have more rows behind it. Continue durably instead of
     // reducing a daily cron to four abandoned sign-ins or eight dead sessions.
     if (
       expiredTransactions.length === GC_TRANSACTION_BATCH_SIZE ||
       deadSessions.length === REVOCATION_BATCH_SIZE ||
       expiredGenerations.length === GC_SMALL_DOCUMENT_BATCH_SIZE ||
-      staleDeliveries.length === GC_SMALL_DOCUMENT_BATCH_SIZE
+      staleDeliveries.length === GC_SMALL_DOCUMENT_BATCH_SIZE ||
+      collectedMarkers === GC_MARKER_BATCH_SIZE
     ) {
       await ctx.scheduler.runAfter(0, internal.lib.gc, {});
     }

--- a/packages/convex-logto/src/component/schema.ts
+++ b/packages/convex-logto/src/component/schema.ts
@@ -101,16 +101,24 @@ export default defineSchema({
   // or before the marker is dead even while its row is waiting for a bounded
   // cleanup batch; a later sign-in receives a strictly newer `createdAt`.
   // Watermarks remain after cleanup so a delayed create mutation can never
-  // reuse an older timestamp and accidentally reactivate revoked state.
+  // reuse an older timestamp and accidentally reactivate revoked state. GC
+  // collects one only once it governs no surviving session and is older than
+  // any session that could still bind it — `by_revokedAt` is how it finds
+  // candidates without scanning, since back-channel logout writes one row per
+  // OP session that ever ends.
   subjectRevocations: defineTable({
     subject: v.string(),
     revokedAt: v.number(),
-  }).index("by_subject", ["subject"]),
+  })
+    .index("by_subject", ["subject"])
+    .index("by_revokedAt", ["revokedAt"]),
 
   sidRevocations: defineTable({
     sid: v.string(),
     revokedAt: v.number(),
-  }).index("by_sid", ["sid"]),
+  })
+    .index("by_sid", ["sid"])
+    .index("by_revokedAt", ["revokedAt"]),
 
   // Bounded, indexed grace history for responses that arrive out of order.
   // `prevTokenHash` remains on sessions as a legacy adapter for rows created


### PR DESCRIPTION
Closes #134.

`subjectRevocations` and `sidRevocations` grew forever. `gc` sweeps `transactions`, `sessions`, `sessionTokenGenerations` and `webhookDeliveries` and skipped exactly these two; there is no other `db.delete` against them anywhere in the package.

With back-channel logout enabled that is **one permanent row per Logto OP session that ever ends** — `markSidRevoked` inserts unconditionally, including when the logout matched zero sessions, which `backchannel-logout.mdx` describes as a normal outcome. `signOutEverywhere` does the same for subjects. The tables are component-private, so an app cannot read or prune them either.

## The collection rule

A watermark is what makes a session created at or before it dead. So `gc` deletes one only when **both** hold:

1. **No session it governs survives.** Deleting a marker while a row it killed is still waiting for a bounded cleanup batch would make that row start validating again — every liveness check goes through `sessionIsLogicallyRevoked`. A marker that still governs a row is skipped rather than deleted; skipped markers are the oldest, so they hold up younger ones until the session sweep in the same mutation removes what they govern, which is the safe direction to be stuck in.
2. **It is older than `SESSION_GC_AFTER_MS`.** `completeRefresh` can bind a `sid` to a session that did not carry one, long after sign-in, so "nothing governed today" is not sufficient by itself. Past that horizon any session that could still bind the `sid` is itself unconditionally GC-dead.

The schema comment explaining why watermarks outlive cleanup is still true and now says where that reasoning stops.

## Schema

Two new `by_revokedAt` indexes, so the sweep finds candidates without scanning. Adding an index needs no migration and no codegen — `_generated/dataModel.ts` derives from `schema.ts`, and no function signature changed.

## Tests

Three, all against a small index-aware fake of the whole `gc` mutation (the existing refresh harness cannot model the chained `eq(...).lte(...)` the sweep needs): collection when nothing is governed, retention while a stranded row is still waiting to be drained, and retention inside the horizon. The first fails on `main`.

Verified with the full CI sequence (`lint`, `format:check`, `check-types`, `test`) over the whole workspace.
