### PR TITLE
fix(react): make the callback flow reactive instead of reading the URL

### DIFF
--- a/.changeset/bridge-callback-reactivity.md
+++ b/.changeset/bridge-callback-reactivity.md
@@ -1,0 +1,29 @@
+---
+"convex-logto": patch
+---
+
+Fix three bridge-mode defects that all trace to reading `window.location` during
+render.
+
+**A callback that resolved without authenticating could pin Convex at
+`isLoading` forever.** The loading veto was derived from the URL, which is not a
+reactive source, and it has absolute priority over the settle latch. In the
+layout every SPA example ships — provider mounted above the router — the soft
+navigation out of `/callback` re-renders only the router subtree, so the veto
+stayed frozen at "still on /callback" for the rest of the page session. A spent
+or replayed code, a lost sign-in session, a state mismatch, or the documented
+10-second stale-callback timeout would leave the app showing a loading state
+with no Sign in button, recoverable only by reloading. The callback flow is now
+provider state that ends when the callback resolves, whatever the outcome.
+
+**The sign-in error observer never mounted for a page session that began on the
+callback route.** Same frozen read, so a later sign-in whose failure
+`@logto/react` swallows into its own state — the case `onAuthError` exists for —
+went unreported and the button appeared to do nothing.
+
+**A cancelled sign-in could lose its `returnTo`.** The benign/error branch had no
+idempotence guard, so React's StrictMode double-invoke (every shipped example
+wraps the provider in it) ran it twice: the first pass consumed the destructive
+`returnTo` stash and navigated correctly, the second found it empty and
+redirected to `afterSignIn` instead. A setup error was reported twice for the
+same reason.

--- a/packages/convex-logto/src/react.bridge.test.tsx
+++ b/packages/convex-logto/src/react.bridge.test.tsx
@@ -5,7 +5,7 @@
 // the 0.4 tightening), the `signIn({ returnTo })` contract, and the
 // fetchAccessToken in-flight merge. `@logto/react` and `convex/react` are
 // mocked at the module boundary so every input is controllable.
-import { act } from "react";
+import { StrictMode, act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import type { ConvexLogtoProviderProps } from "./react";
@@ -269,6 +269,80 @@ it.each(["//evil.example.com", "https://evil.example.com", "back\\slash"])(
     }
   },
 );
+
+it("resolves a cancelled sign-in once, even under StrictMode", async () => {
+  // Every shipped example wraps the provider in StrictMode, where React
+  // double-invokes effects. `takeReturnTo()` is destructive, so a second pass
+  // finds the stash empty and sends the user to `afterSignIn` instead of the
+  // page they were signing in to reach.
+  setUrl("http://localhost:3000/callback?state=xyz&error=access_denied");
+  sessionStorage.setItem("convex-logto:returnTo", "/post/123");
+  const navigate = vi.fn();
+
+  root = createRoot(document.createElement("div"));
+  await act(async () => {
+    root!.render(<StrictMode>{providerTree({ navigate })}</StrictMode>);
+  });
+
+  expect(navigate).toHaveBeenCalledTimes(1);
+  expect(navigate).toHaveBeenCalledWith("/post/123");
+});
+
+it("stops holding isLoading once a callback resolves without authenticating", async () => {
+  // The provider is mounted above the router in every SPA example, so the soft
+  // navigation out of /callback re-renders only the router subtree. Anything the
+  // loading veto reads from `window.location` would stay frozen at "still on
+  // /callback", and Convex would sit at isLoading forever — the app never shows
+  // a Sign in button again, and only a page reload recovers.
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    setUrl("http://localhost:3000/callback?code=abc&state=xyz");
+    mockLogto.error = new Error("state mismatch");
+    const navigate = vi.fn((to: string) => {
+      setUrl(`http://localhost:3000${to}`);
+    });
+
+    await renderProvider({ navigate });
+
+    expect(navigate).toHaveBeenCalledWith("/");
+    expect(capturedAuth?.isLoading).toBe(false);
+    expect(capturedAuth?.isAuthenticated).toBe(false);
+  } finally {
+    consoleError.mockRestore();
+  }
+});
+
+it("mounts the sign-in error observer once the callback has resolved", async () => {
+  // A router's `navigate` is asynchronous, so a provider re-render right after
+  // the callback resolves can still see /callback in the URL. Gating the
+  // observer on the URL leaves it unmounted for the rest of the page session,
+  // and the swallowed sign-in failure #53 exists to surface is lost again.
+  const failure = new Error("OIDC discovery unreachable");
+  const onAuthError = vi.fn<(error: Error) => void>();
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    setUrl("http://localhost:3000/callback?code=abc&state=xyz");
+    mockLogto.isAuthenticated = true;
+    const navigate = vi.fn();
+
+    await renderProvider({ probe: true, onAuthError, navigate });
+    expect(navigate).toHaveBeenCalledWith("/");
+
+    mockLogto.signIn.mockImplementation(async () => {
+      mockLogto.error = failure;
+    });
+    await act(async () => {
+      void capturedApi!.signIn();
+      await Promise.resolve();
+    });
+    await rerenderProvider({ probe: true, onAuthError, navigate });
+
+    expect(onAuthError).toHaveBeenCalledTimes(1);
+    expect(onAuthError).toHaveBeenCalledWith(failure);
+  } finally {
+    consoleError.mockRestore();
+  }
+});
 
 it("reports an SDK-stored initiation error once when signIn() is discarded", async () => {
   const failure = new Error("OIDC discovery unreachable");

--- a/packages/convex-logto/src/react.tsx
+++ b/packages/convex-logto/src/react.tsx
@@ -67,9 +67,19 @@ const NOOP_SIGN_IN_ERRORS: BridgeSignInErrors = {
 const BridgeContext = createContext<{
   callbackPath: string;
   signInErrors: BridgeSignInErrors;
+  /**
+   * Is this document still finishing an OIDC redirect? React state, not a read
+   * of `window.location`: the location is not a reactive source, and a provider
+   * mounted *above* the router — the layout every SPA example ships — never
+   * re-renders when the callback soft-navigates away. A value derived from the
+   * URL during render would then stay frozen at "still on /callback" for the
+   * rest of the page session.
+   */
+  callbackActive: boolean;
 }>({
   callbackPath: DEFAULT_CALLBACK_PATH,
   signInErrors: NOOP_SIGN_IN_ERRORS,
+  callbackActive: false,
 });
 
 /** True only when the current document is on the provider's callback route. */
@@ -106,7 +116,7 @@ function takeReturnTo(): string | undefined {
 
 /** Bridges Logto's ID token into the `useAuth` shape `ConvexProviderWithAuth` expects. */
 function useAuthFromLogto() {
-  const { callbackPath } = useContext(BridgeContext);
+  const { callbackActive } = useContext(BridgeContext);
   const {
     isAuthenticated,
     isLoading,
@@ -120,9 +130,15 @@ function useAuthFromLogto() {
   // transient logged-out tick that route guards mistake for a sign-out (#11).
   // Gated to the exact callback route: a stray `?code=&state=` on any other page
   // is not a sign-in transaction and must not pin the app into a loading state.
+  //
+  // `callbackActive` ends when the callback resolves — including when it
+  // resolves *without* authenticating (spent code, lost sign-in session, the
+  // stale-callback timeout). It has veto over `isLoading`, so reading it from
+  // the URL instead would leave an app whose provider never re-renders pinned
+  // at `isLoading: true` forever, with no way back short of a page reload.
   const authFlowPending =
     !isAuthenticated &&
-    onCallbackRoute(callbackPath) &&
+    callbackActive &&
     classifySignInSearch(window.location.search).kind === "pending";
 
   // `@logto/react` toggles `isLoading` around every SDK call; forwarding that to
@@ -230,10 +246,13 @@ function LogtoCallback({
   afterSignIn,
   navigate,
   onAuthError,
+  onResolved,
 }: {
   afterSignIn: string;
   navigate?: (to: string) => void;
   onAuthError?: (error: Error) => void;
+  /** Ends the provider's callback flow, whatever the outcome. */
+  onResolved: () => void;
 }) {
   const goAfterSignIn = useCallback(() => {
     // `returnTo` (validated same-origin path) wins over the static default.
@@ -258,28 +277,50 @@ function LogtoCallback({
   // alive over a spent code if this component re-renders before navigation.
   const [done, setDone] = useState(false);
 
+  // Resolve at most once. StrictMode double-invokes this effect, and in
+  // production it re-runs whenever an inline `navigate`/`onAuthError` arrow —
+  // the documented pattern — changes identity. `takeReturnTo()` is destructive,
+  // so a second pass finds the stash empty and sends the user to `afterSignIn`
+  // instead of where they were headed; an error would also be reported twice.
+  const resolved = useRef(false);
   useEffect(() => {
+    if (resolved.current) return;
+    // On the callback route with no sign-in result to finish. Nothing to do,
+    // but the flow still has to end or it would gate the provider forever.
+    if (outcome.kind === "none") {
+      resolved.current = true;
+      onResolved();
+      return;
+    }
     // The user cancelled / there was no session — just return to the app.
     if (outcome.kind === "benign") {
+      resolved.current = true;
       setDone(true);
+      onResolved();
       goAfterSignIn();
+      return;
     }
     // A setup error (e.g. invalid_scope): recoverable, not fatal. Report and
     // return to the app logged out, instead of throwing during render — a throw
     // would blank any tree without an error boundary above the provider.
     if (outcome.kind === "error") {
+      resolved.current = true;
       setDone(true);
       reportAuthError(onAuthError, new Error(outcome.message));
+      onResolved();
       goAfterSignIn();
     }
-  }, [outcome, goAfterSignIn, onAuthError]);
+  }, [outcome, goAfterSignIn, onAuthError, onResolved]);
 
   // Only a real `?code=` callback runs the token exchange; benign/error redirects
   // never touch the SDK, so a cancelled sign-in can't poison the next one.
   if (outcome.kind === "pending" && !done)
     return (
       <CodeExchange
-        onDone={() => setDone(true)}
+        onDone={() => {
+          setDone(true);
+          onResolved();
+        }}
         goAfterSignIn={goAfterSignIn}
         onAuthError={onAuthError}
       />
@@ -570,9 +611,17 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
       },
     };
   }, []);
+  // Captured once, at mount: a real OIDC redirect always lands as a full-page
+  // load, so mount == landing. Ending it is a state change, which is what makes
+  // both the loading veto and the error observer below react to the callback
+  // finishing even in an app whose provider never re-renders on navigation.
+  const [callbackActive, setCallbackActive] = useState(() =>
+    onCallbackRoute(callbackPath),
+  );
+  const endCallbackFlow = useCallback(() => setCallbackActive(false), []);
   const bridgeValue = useMemo(
-    () => ({ callbackPath, signInErrors }),
-    [callbackPath, signInErrors],
+    () => ({ callbackPath, signInErrors, callbackActive }),
+    [callbackPath, signInErrors, callbackActive],
   );
 
   if (configQuery && fetched.status === "error") {
@@ -587,24 +636,23 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
 
   if (!resolved) return <>{fallback}</>;
 
-  const callbackRoute = onCallbackRoute(callbackPath);
-
   return (
     <BridgeContext.Provider value={bridgeValue}>
       <LogtoProvider config={logtoConfig} unstable_enableCache={discoveryCache}>
         {/* @logto/react catches signIn failures into context and resolves its
             public promise. Observe that state only on the initiating page;
             callback errors are already handled by LogtoCallback below. */}
-        {!callbackRoute ? (
+        {!callbackActive ? (
           <LogtoSignInErrorObserver signInErrors={signInErrors} />
         ) : null}
         {/* Callback handling is gated to the exact callback route: a real OIDC
             redirect always lands as a full-page load, so mount == landing. */}
-        {callbackRoute ? (
+        {callbackActive ? (
           <LogtoCallback
             afterSignIn={afterSignIn}
             navigate={navigate}
             onAuthError={onAuthError}
+            onResolved={endCallbackFlow}
           />
         ) : null}
         <ConvexProviderWithAuth client={client} useAuth={useAuthFromLogto}>


### PR DESCRIPTION
Closes #141, closes #142, closes #145. Three bridge-mode defects with one root cause: `window.location` read during render, in a component that an SPA never re-renders.

## 1. A failed callback could pin Convex at `isLoading` forever (#141, high)

`authFlowPending` was derived from the URL and has absolute veto over the loading state (`isLoading: !settled || authFlowPending`), while `settled` cannot latch while it is true. The location is not a reactive source, so the bridge only un-pinned if `useAuthFromLogto` re-rendered *after* the URL stopped looking pending - and in the layout `examples/tanstack-router-spa` ships, with the provider mounted **above** the router, nothing produces that render. `CodeExchange` resolving calls `setDone` on a sibling of `ConvexProviderWithAuth`; the provider itself never re-renders.

So a spent or replayed code, a lost sign-in session, a state mismatch, or simply the documented 10s `STALE_CALLBACK_TIMEOUT_MS` path left `useConvexAuth()` reporting `{ isLoading: true, isAuthenticated: false }` for the rest of the page session. In the example app the user lands on `/` showing "Auth loading…" and `AuthButton` does not even render a Sign in button. Only a reload recovers.

The comment on the timeout said it exists "so the page can't spin indefinitely" - it changed the URL but did not stop the spin.

## 2. The sign-in error observer never mounted after landing on /callback (#142, medium)

Same frozen read: `callbackRoute` gated `<LogtoSignInErrorObserver>`, so a page session that *began* on the callback route never mounted it. Hours later, when the refresh token dies and the app offers Sign in again without a reload, `@logto/react` swallows the initiation failure into its own state and resolves the public promise - so neither `fail` nor `observe` fires, `onAuthError` is never called, and the button silently does nothing. That is exactly the swallow #53 was written to close.

## 3. A cancelled sign-in could lose its `returnTo` (#145, low)

The benign/error branch had no idempotence guard (`CodeExchange`'s sibling path has had one). Under StrictMode - which every shipped example enables - the double-invoke ran it twice: the first pass consumed the destructive `takeReturnTo()` stash and navigated to `/post/123`, the second found it empty and redirected to `afterSignIn`. A setup error was reported to `onAuthError` twice for the same reason. It is also reachable in production whenever the provider re-renders on the callback route with the documented inline `navigate`/`onAuthError` arrows.

## The fix

The callback flow is now provider state, captured once at mount (a real OIDC redirect always lands as a full-page load, so mount == landing) and ended when the callback resolves - success, benign cancel, setup error, failed exchange, timeout, or "on the callback route with nothing to finish". Ending it is a state change, which is what makes both the loading veto and the observer gate react in a provider that never re-renders on navigation. The resolve path is guarded by a ref so it runs at most once.

## Tests

Three, all failing on `main`: the loading state after a callback that resolves without authenticating; the observer reporting a swallowed initiation failure after the callback resolved (with the URL still on `/callback`, since a router's `navigate` is asynchronous); and a StrictMode cancel keeping its `returnTo`.

Verified with the full CI sequence (`lint`, `format:check`, `check-types`, `test`) over the whole workspace.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sign-in loading now ends reliably after callback processing, including navigation and error scenarios.
  * Sign-in errors are now detected when a session starts on the callback route and remain observable afterward.
  * Cancelled sign-ins preserve the intended return location and avoid duplicate error reporting.
  * Improved callback handling under React StrictMode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->