### PR TITLE
fix(react): report sign-out failures, and give native an error surface

### DIFF
--- a/.changeset/sign-out-error-surface.md
+++ b/.changeset/sign-out-error-surface.md
@@ -17,6 +17,9 @@ reported and rethrown.
 The native bridge had no error surface at all: `@logto/rn` rejects rather than
 storing the error, and the documented pattern is `void signIn()` in an
 `onPress`, so a dismissed system browser or an offline sign-out became an
-unhandled rejection and nothing else. The native `<ConvexLogtoProvider>` now
+unhandled rejection and *nothing else*. The native `<ConvexLogtoProvider>` now
 takes `onAuthError`, matching the web provider and native session mode, and both
-`signIn()` and `signOut()` report through it before rejecting.
+`signIn()` and `signOut()` report through it before rejecting. Reporting is not
+handling: a promise that rejects still does, so a fire-and-forget caller wants
+`.catch(() => {})` alongside `onAuthError` — the docs now say so instead of
+calling `void signIn()` safe.

--- a/.changeset/sign-out-error-surface.md
+++ b/.changeset/sign-out-error-surface.md
@@ -1,0 +1,22 @@
+---
+"convex-logto": minor
+---
+
+Surface sign-out failures instead of swallowing them, on web and native.
+
+A failed sign-out is not cosmetic: `@logto/client` reaches OIDC discovery
+**before** it clears tokens, so an unreachable Logto leaves the user signed in
+with a live ID token while the button looks like it worked.
+
+On the web, `@logto/react` caught that failure into its own state and resolved
+the promise, and the bridge only registered sign-*in* attempts — so nothing
+reported it and `onAuthError` never fired. Sign-out now registers an attempt the
+same way, so the swallowed error is reported once, and a direct rejection is
+reported and rethrown.
+
+The native bridge had no error surface at all: `@logto/rn` rejects rather than
+storing the error, and the documented pattern is `void signIn()` in an
+`onPress`, so a dismissed system browser or an offline sign-out became an
+unhandled rejection and nothing else. The native `<ConvexLogtoProvider>` now
+takes `onAuthError`, matching the web provider and native session mode, and both
+`signIn()` and `signOut()` report through it before rejecting.

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -261,7 +261,7 @@ to resolve it from the backend at runtime. Exactly one of the two.
 | `callbackPath` | — | The route that finishes the OIDC redirect. Default `/callback`. Must match a registered Redirect URI's path; only this exact path runs callback handling. |
 | `afterSignIn` | — | Where to go once sign-in completes. Default `/`. `signIn({ returnTo })` overrides it. |
 | `navigate` | — | Soft navigation (your router's `navigate`). Optional for plain Vite; **recommended for any router** (TanStack / Next) so post-sign-in is a soft navigation rather than a full-page reload that drops router state. Prefer a replace-style navigate. Falls back to a hard `location.replace`. |
-| `onAuthError` | — | Called on sign-in initiation failures (Logto unreachable, blocked storage, in-app browser restrictions) and recoverable callback failures (stale/replayed callback, setup errors like `invalid_scope`). Errors are also logged to the console. |
+| `onAuthError` | — | Called on sign-in initiation failures (Logto unreachable, blocked storage, in-app browser restrictions), recoverable callback failures (stale/replayed callback, setup errors like `invalid_scope`), and **sign-out failures** — `@logto/react` catches those into its own state and resolves the promise, leaving the user signed in with the tokens still in place. Errors are also logged to the console. |
 | `discoveryCache` | — | Cache OIDC discovery + JWKS in sessionStorage. Default `true`. |
 | `onAuthEvent` | — | Opt-in phase timings (see [Auth phase events](#auth-phase-events)). Bridge mode emits `bootstrap_start`, `convex_authenticated`, and — in `configQuery` mode only — `config_loaded`. Absent means nothing is measured. |
 | `scopes` / `resources` | — | Extra OIDC scopes / API resources. `openid`, `profile`, `offline_access`, and `email` are always included. |
@@ -286,8 +286,10 @@ completes — a same-origin path starting with `/` (anything else is rejected, t
 prevent open redirects). Without `returnTo`, the provider's `afterSignIn` is
 used. `signIn(redirectUri: string)` is **deprecated**: set `callbackPath` on the
 provider instead if your callback route isn't `/callback`. Event handlers may
-continue to use `void signIn()`: initiation failures are logged and delivered
-to `onAuthError` even though `@logto/react` catches them into SDK state.
+continue to use `void signIn()` and `void signOut()`: failures are logged and
+delivered to `onAuthError` even though `@logto/react` catches them into SDK
+state. A failed sign-out is worth handling — the SDK reaches OIDC discovery
+before it clears tokens, so an unreachable Logto leaves the user signed in.
 
 ## Session mode (`convex-logto/react-session`)
 
@@ -489,12 +491,15 @@ and resolves when the deep link returns.
 | `fallback` | — | Rendered while `configQuery` loads, before the Convex provider mounts. Default `null`. |
 | `scopes` / `resources` | — | Extra OIDC scopes / API resources. `openid`, `profile`, `offline_access`, and `email` are always included. |
 | `onAuthEvent` | — | Opt-in phase timings (see [Auth phase events](#auth-phase-events)): `bootstrap_start`, `convex_authenticated`, plus `config_loaded` in `configQuery` mode. Absent means nothing is measured. |
+| `onAuthError` | — | Called when sign-in or sign-out fails (Logto unreachable, the user dismissing the system browser, an expired session). `@logto/rn` rejects rather than storing the error, so without this a `void signIn()` in an `onPress` is an unhandled rejection and nothing else. Errors are also logged to the console. |
 
 ### `useLogtoAuth()` (native)
 
 Returns `{ isAuthenticated, isLoading, user, signIn, signOut }`. `signIn(redirectUri?)`
 defaults to the provider's `redirectUri`; **`signOut()` takes no argument** — on native
 it revokes the tokens and clears local storage (no browser / federated sign-out).
+Both report a failure to the provider's `onAuthError` before rejecting, so a
+`void signIn()` in an `onPress` is observable rather than an unhandled rejection.
 
 ```tsx
 const { isAuthenticated, user, signIn, signOut } = useLogtoAuth();

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -285,11 +285,13 @@ const { isAuthenticated, isLoading, user, signIn, signOut } = useLogtoAuth();
 completes — a same-origin path starting with `/` (anything else is rejected, to
 prevent open redirects). Without `returnTo`, the provider's `afterSignIn` is
 used. `signIn(redirectUri: string)` is **deprecated**: set `callbackPath` on the
-provider instead if your callback route isn't `/callback`. Event handlers may
-continue to use `void signIn()` and `void signOut()`: failures are logged and
-delivered to `onAuthError` even though `@logto/react` catches them into SDK
-state. A failed sign-out is worth handling — the SDK reaches OIDC discovery
-before it clears tokens, so an unreachable Logto leaves the user signed in.
+provider instead if your callback route isn't `/callback`. Failures reach
+`onAuthError` and the console either way — including the ones `@logto/react`
+catches into SDK state and never rejects with. The ones it does reject with are
+reported first and then rethrown, so a fire-and-forget call wants a handler:
+`void signOut().catch(() => {})`. A failed sign-out is worth acting on — the SDK
+reaches OIDC discovery before it clears tokens, so an unreachable Logto leaves
+the user signed in.
 
 ## Session mode (`convex-logto/react-session`)
 
@@ -491,15 +493,17 @@ and resolves when the deep link returns.
 | `fallback` | — | Rendered while `configQuery` loads, before the Convex provider mounts. Default `null`. |
 | `scopes` / `resources` | — | Extra OIDC scopes / API resources. `openid`, `profile`, `offline_access`, and `email` are always included. |
 | `onAuthEvent` | — | Opt-in phase timings (see [Auth phase events](#auth-phase-events)): `bootstrap_start`, `convex_authenticated`, plus `config_loaded` in `configQuery` mode. Absent means nothing is measured. |
-| `onAuthError` | — | Called when sign-in or sign-out fails (Logto unreachable, the user dismissing the system browser, an expired session). `@logto/rn` rejects rather than storing the error, so without this a `void signIn()` in an `onPress` is an unhandled rejection and nothing else. Errors are also logged to the console. |
+| `onAuthError` | — | Called when sign-in or sign-out fails (Logto unreachable, the user dismissing the system browser, an expired session). `@logto/rn` rejects rather than storing the error, so without this a `void signIn()` in an `onPress` is an unhandled rejection and *nothing else*. Reported before the promise rejects; also logged to the console. |
 
 ### `useLogtoAuth()` (native)
 
 Returns `{ isAuthenticated, isLoading, user, signIn, signOut }`. `signIn(redirectUri?)`
 defaults to the provider's `redirectUri`; **`signOut()` takes no argument** — on native
 it revokes the tokens and clears local storage (no browser / federated sign-out).
-Both report a failure to the provider's `onAuthError` before rejecting, so a
-`void signIn()` in an `onPress` is observable rather than an unhandled rejection.
+Both report a failure to the provider's `onAuthError`, and to the console,
+**before** rejecting — so a failure in an `onPress` is observable rather than
+silent. The promise still rejects: `void signIn().catch(() => {})` if you do not
+want an unhandled rejection alongside the report.
 
 ```tsx
 const { isAuthenticated, user, signIn, signOut } = useLogtoAuth();

--- a/packages/convex-logto/.oxlintrc.json
+++ b/packages/convex-logto/.oxlintrc.json
@@ -75,6 +75,7 @@
     },
     {
       "files": [
+        "src/native.bridge.test.tsx",
         "src/react.bridge.test.tsx",
         "src/react.config-loading.test.tsx",
         "src/react-session.provider.test.tsx"

--- a/packages/convex-logto/src/native.bridge.test.tsx
+++ b/packages/convex-logto/src/native.bridge.test.tsx
@@ -2,7 +2,9 @@
 //
 // `@logto/rn` does not proxy its errors the way the web SDK does — `signIn` and
 // `signOut` reject — and the documented pattern is `void signIn()` in an
-// `onPress`. These cover what an app can observe when either one fails.
+// `onPress`. These cover what an app can observe when either one fails: the
+// failure reaches `onAuthError` and the console *before* the promise rejects,
+// which it still does.
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
@@ -75,7 +77,7 @@ afterEach(async () => {
   capturedApi = null;
 });
 
-it("reports a dismissed sign-in instead of leaving an unhandled rejection", async () => {
+it("reports a dismissed sign-in before rejecting", async () => {
   const failure = new Error("auth_session_failed");
   mockLogto.signIn.mockRejectedValue(failure);
   const onAuthError = vi.fn<(error: Error) => void>();

--- a/packages/convex-logto/src/native.bridge.test.tsx
+++ b/packages/convex-logto/src/native.bridge.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment happy-dom
+//
+// `@logto/rn` does not proxy its errors the way the web SDK does — `signIn` and
+// `signOut` reject — and the documented pattern is `void signIn()` in an
+// `onPress`. These cover what an app can observe when either one fails.
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { ConvexLogtoProvider, useLogtoAuth } from "./native";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mockLogto = {
+  isAuthenticated: false,
+  isInitialized: true,
+  getIdToken: vi.fn<() => Promise<string | undefined>>(async () => undefined),
+  getAccessToken: vi.fn<() => Promise<string | undefined>>(
+    async () => undefined,
+  ),
+  getIdTokenClaims: vi.fn<() => Promise<undefined>>(async () => undefined),
+  signIn: vi.fn<(redirectUri: string) => Promise<void>>(async () => {}),
+  signOut: vi.fn<() => Promise<void>>(async () => {}),
+  client: { clearAccessToken: vi.fn<() => Promise<void>>(async () => {}) },
+};
+
+vi.mock("@logto/rn", () => ({
+  LogtoProvider: ({ children }: { children: unknown }) => children,
+  useLogto: () => mockLogto,
+  UserScope: { Email: "email" },
+}));
+vi.mock("convex/react", () => ({
+  ConvexProviderWithAuth: ({ children }: { children: unknown }) => children,
+  useConvexAuth: () => ({ isLoading: false, isAuthenticated: false }),
+}));
+
+type AuthApi = ReturnType<typeof useLogtoAuth>;
+let capturedApi: AuthApi | null = null;
+function ApiProbe() {
+  capturedApi = useLogtoAuth();
+  return null;
+}
+
+let root: Root | null = null;
+async function renderProvider(onAuthError?: (error: Error) => void) {
+  root = createRoot(document.createElement("div"));
+  await act(async () => {
+    root!.render(
+      <ConvexLogtoProvider
+        client={{} as never}
+        config={{ endpoint: "https://example.logto.app", appId: "app123" }}
+        redirectUri="io.logto://callback"
+        {...(onAuthError ? { onAuthError } : {})}
+      >
+        <ApiProbe />
+      </ConvexLogtoProvider>,
+    );
+  });
+}
+
+beforeEach(() => {
+  mockLogto.signIn.mockReset().mockResolvedValue(undefined);
+  mockLogto.signOut.mockReset().mockResolvedValue(undefined);
+});
+
+afterEach(async () => {
+  if (root) {
+    const r = root;
+    root = null;
+    await act(async () => {
+      r.unmount();
+    });
+  }
+  capturedApi = null;
+});
+
+it("reports a dismissed sign-in instead of leaving an unhandled rejection", async () => {
+  const failure = new Error("auth_session_failed");
+  mockLogto.signIn.mockRejectedValue(failure);
+  const onAuthError = vi.fn<(error: Error) => void>();
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    await renderProvider(onAuthError);
+
+    await expect(capturedApi!.signIn()).rejects.toBe(failure);
+    expect(onAuthError).toHaveBeenCalledTimes(1);
+    expect(onAuthError).toHaveBeenCalledWith(failure);
+    expect(consoleError).toHaveBeenCalledTimes(1);
+  } finally {
+    consoleError.mockRestore();
+  }
+});
+
+it("reports a sign-out that left the user signed in", async () => {
+  // `@logto/client` reaches OIDC discovery before it clears tokens, so an
+  // offline sign-out throws with the session fully intact.
+  const failure = new Error("failed to fetch openid-configuration");
+  mockLogto.signOut.mockRejectedValue(failure);
+  const onAuthError = vi.fn<(error: Error) => void>();
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    await renderProvider(onAuthError);
+
+    await expect(capturedApi!.signOut()).rejects.toBe(failure);
+    expect(onAuthError).toHaveBeenCalledTimes(1);
+    expect(onAuthError).toHaveBeenCalledWith(failure);
+  } finally {
+    consoleError.mockRestore();
+  }
+});
+
+it("still logs when no onAuthError is provided", async () => {
+  mockLogto.signOut.mockRejectedValue(new Error("offline"));
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  try {
+    await renderProvider();
+
+    await expect(capturedApi!.signOut()).rejects.toThrow("offline");
+    expect(consoleError).toHaveBeenCalledTimes(1);
+  } finally {
+    consoleError.mockRestore();
+  }
+});

--- a/packages/convex-logto/src/native.tsx
+++ b/packages/convex-logto/src/native.tsx
@@ -90,6 +90,32 @@ type ConfigState =
 // `useLogtoAuth().signIn()` can default to it without every caller repeating it.
 const RedirectUriContext = createContext<string | undefined>(undefined);
 
+// `@logto/rn` does not proxy its errors the way the web SDK does: `signIn` and
+// `signOut` reject. The shipped pattern is `void signIn()` in an onPress, so
+// without somewhere to report them a dismissed browser sheet or an offline
+// sign-out becomes an unhandled rejection and nothing else.
+const AuthErrorContext = createContext<((error: Error) => void) | undefined>(
+  undefined,
+);
+
+/** Reports a recoverable auth error: loud in the console, surfaced to `onAuthError`. */
+function reportAuthError(
+  onAuthError: ((error: Error) => void) | undefined,
+  error: Error,
+): void {
+  console.error(`convex-logto: ${error.message}`, error);
+  try {
+    onAuthError?.(error);
+  } catch {
+    // An app's own handler must not break sign-in or sign-out.
+  }
+}
+
+function asAuthError(caught: unknown, fallbackMessage: string): Error {
+  if (caught instanceof Error) return caught;
+  return new Error(fallbackMessage, { cause: caught });
+}
+
 export type ConvexLogtoProviderProps = {
   /** Your `ConvexReactClient`. */
   client: ConvexReactClient;
@@ -120,6 +146,15 @@ export type ConvexLogtoProviderProps = {
    * lifecycle, so the settle and refresh phases belong to session mode.
    */
   onAuthEvent?: LogtoAuthEventHandler;
+  /**
+   * Called when sign-in or sign-out fails recoverably (Logto unreachable, the
+   * user dismissing the system browser, an expired session). `@logto/rn`
+   * rejects rather than storing the error, so without this a `void signIn()` in
+   * an `onPress` — the documented pattern — is an unhandled rejection and
+   * nothing else. A failed sign-out matters as much: the SDK reaches Logto
+   * before clearing tokens, so the user stays signed in.
+   */
+  onAuthError?: (error: Error) => void;
   children: ReactNode;
 } & (
   | {
@@ -169,6 +204,7 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
     resources,
     fallback = null,
     onAuthEvent,
+    onAuthError,
     children,
   } = props;
   const staticConfig = props.config;
@@ -254,12 +290,14 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
 
   return (
     <RedirectUriContext.Provider value={redirectUri}>
-      <LogtoProvider config={logtoConfig}>
-        <ConvexProviderWithAuth client={client} useAuth={useAuthFromLogto}>
-          <ConvexAuthPhaseWatcher events={events} />
-          {children}
-        </ConvexProviderWithAuth>
-      </LogtoProvider>
+      <AuthErrorContext.Provider value={onAuthError}>
+        <LogtoProvider config={logtoConfig}>
+          <ConvexProviderWithAuth client={client} useAuth={useAuthFromLogto}>
+            <ConvexAuthPhaseWatcher events={events} />
+            {children}
+          </ConvexProviderWithAuth>
+        </LogtoProvider>
+      </AuthErrorContext.Provider>
     </RedirectUriContext.Provider>
   );
 }
@@ -310,6 +348,7 @@ export function useLogtoAuth(): LogtoAuth {
   const { isAuthenticated, isLoading } = useConvexAuth();
   const { signIn, signOut, getIdTokenClaims } = useLogto();
   const defaultRedirectUri = useContext(RedirectUriContext);
+  const onAuthError = useContext(AuthErrorContext);
   const [user, setUser] = useState<IdTokenClaims>();
 
   useEffect(() => {
@@ -332,20 +371,45 @@ export function useLogtoAuth(): LogtoAuth {
   }, [isAuthenticated, getIdTokenClaims]);
 
   const doSignIn = useCallback(
-    (redirectUri?: string) => {
+    async (redirectUri?: string) => {
       const uri = redirectUri ?? defaultRedirectUri;
-      if (!uri) {
-        throw new Error(
-          "convex-logto: signIn needs a redirect URI on native — pass one to " +
-            "signIn() or set `redirectUri` on <ConvexLogtoProvider> (e.g. " +
-            '"io.logto://callback").',
+      try {
+        if (!uri) {
+          throw new Error(
+            "convex-logto: signIn needs a redirect URI on native — pass one to " +
+              "signIn() or set `redirectUri` on <ConvexLogtoProvider> (e.g. " +
+              '"io.logto://callback").',
+          );
+        }
+        await signIn(uri);
+      } catch (caught) {
+        // Dismissing the system browser rejects with `auth_session_failed`.
+        // Report it so an app's "signing in…" state has something to clear on.
+        const failure = asAuthError(
+          caught,
+          "convex-logto: starting Logto sign-in failed.",
         );
+        reportAuthError(onAuthError, failure);
+        throw failure;
       }
-      return signIn(uri);
     },
-    [signIn, defaultRedirectUri],
+    [signIn, defaultRedirectUri, onAuthError],
   );
-  const doSignOut = useCallback(() => signOut(), [signOut]);
+  const doSignOut = useCallback(async () => {
+    try {
+      await signOut();
+    } catch (caught) {
+      // `@logto/client` reaches OIDC discovery before it clears tokens, so an
+      // unreachable Logto leaves the user signed in with a live ID token while
+      // the button looks like it worked.
+      const failure = asAuthError(
+        caught,
+        "convex-logto: Logto sign-out failed.",
+      );
+      reportAuthError(onAuthError, failure);
+      throw failure;
+    }
+  }, [signOut, onAuthError]);
 
   return useMemo(
     () => ({

--- a/packages/convex-logto/src/react.bridge.test.tsx
+++ b/packages/convex-logto/src/react.bridge.test.tsx
@@ -312,6 +312,36 @@ it("stops holding isLoading once a callback resolves without authenticating", as
   }
 });
 
+it("reports a sign-out that @logto/react swallowed", async () => {
+  // The SDK reaches OIDC discovery before it clears tokens, then catches the
+  // failure into its own state and resolves the promise — so the user is still
+  // signed in with a live token while the button looks like it worked.
+  const failure = new Error("failed to fetch openid-configuration");
+  const onAuthError = vi.fn<(error: Error) => void>();
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  mockLogto.signOut.mockImplementation(async () => {
+    mockLogto.error = failure;
+  });
+  try {
+    await renderProvider({ probe: true, onAuthError });
+    await act(async () => {
+      void capturedApi!.signOut();
+      await Promise.resolve();
+    });
+
+    // The SDK context update is what exposes the swallowed failure.
+    await rerenderProvider({ probe: true, onAuthError });
+    expect(onAuthError).toHaveBeenCalledTimes(1);
+    expect(onAuthError).toHaveBeenCalledWith(failure);
+
+    // And it is reported once, not on every later render.
+    await rerenderProvider({ probe: true, onAuthError });
+    expect(onAuthError).toHaveBeenCalledTimes(1);
+  } finally {
+    consoleError.mockRestore();
+  }
+});
+
 it("mounts the sign-in error observer once the callback has resolved", async () => {
   // A router's `navigate` is asynchronous, so a provider re-render right after
   // the callback resolves can still see /callback in the URL. Gating the
@@ -337,6 +367,22 @@ it("mounts the sign-in error observer once the callback has resolved", async () 
     });
     await rerenderProvider({ probe: true, onAuthError, navigate });
 
+    expect(onAuthError).toHaveBeenCalledTimes(1);
+    expect(onAuthError).toHaveBeenCalledWith(failure);
+  } finally {
+    consoleError.mockRestore();
+  }
+});
+
+it("rethrows a sign-out that rejects outright", async () => {
+  const failure = new Error("network down");
+  const onAuthError = vi.fn<(error: Error) => void>();
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  mockLogto.signOut.mockRejectedValue(failure);
+  try {
+    await renderProvider({ probe: true, onAuthError });
+
+    await expect(capturedApi!.signOut()).rejects.toBe(failure);
     expect(onAuthError).toHaveBeenCalledTimes(1);
     expect(onAuthError).toHaveBeenCalledWith(failure);
   } finally {

--- a/packages/convex-logto/src/react.tsx
+++ b/packages/convex-logto/src/react.tsx
@@ -427,11 +427,13 @@ type CommonProviderProps = {
   /**
    * Called when starting or finishing sign-in — or signing out — fails
    * recoverably (Logto unreachable, blocked storage, a stale/replayed callback,
-   * or a setup error like `invalid_scope`). This makes `void signIn()` and
-   * `void signOut()` safe for event handlers: failures are observable here and
-   * are also logged to the console. A failed sign-out matters as much as a
-   * failed sign-in — the SDK leaves the tokens in place, so the user is still
-   * signed in.
+   * or a setup error like `invalid_scope`). Failures are reported here and
+   * logged to the console; the ones `@logto/react` swallows into its own state
+   * would otherwise be invisible, and the ones it doesn't are reported *before*
+   * the promise rejects, so a fire-and-forget caller still wants a
+   * `.catch(() => {})` to avoid an unhandled rejection. A failed sign-out
+   * matters as much as a failed sign-in — the SDK leaves the tokens in place,
+   * so the user is still signed in.
    */
   onAuthError?: (error: Error) => void;
   /**

--- a/packages/convex-logto/src/react.tsx
+++ b/packages/convex-logto/src/react.tsx
@@ -47,18 +47,22 @@ const STALE_CALLBACK_TIMEOUT_MS = 10_000;
 
 // Provider-level settings the bridge hooks need but can't take as props, since
 // `ConvexProviderWithAuth` owns the `useAuth` call site.
-type BridgeSignInAttempt = {
+/**
+ * One `signIn()`/`signOut()` call, tracked so the failure `@logto/react`
+ * swallows into its own state can still be reported exactly once.
+ */
+type BridgeAuthAttempt = {
   baselineError: Error | undefined;
   handled: boolean;
 };
 
-type BridgeSignInErrors = {
-  begin: (baselineError: Error | undefined) => BridgeSignInAttempt;
-  fail: (attempt: BridgeSignInAttempt, error: Error) => void;
+type BridgeAuthErrors = {
+  begin: (baselineError: Error | undefined) => BridgeAuthAttempt;
+  fail: (attempt: BridgeAuthAttempt, error: Error) => void;
   observe: (error: Error | undefined) => void;
 };
 
-const NOOP_SIGN_IN_ERRORS: BridgeSignInErrors = {
+const NOOP_AUTH_ERRORS: BridgeAuthErrors = {
   begin: (baselineError) => ({ baselineError, handled: false }),
   fail: () => {},
   observe: () => {},
@@ -66,7 +70,7 @@ const NOOP_SIGN_IN_ERRORS: BridgeSignInErrors = {
 
 const BridgeContext = createContext<{
   callbackPath: string;
-  signInErrors: BridgeSignInErrors;
+  authErrors: BridgeAuthErrors;
   /**
    * Is this document still finishing an OIDC redirect? React state, not a read
    * of `window.location`: the location is not a reactive source, and a provider
@@ -78,7 +82,7 @@ const BridgeContext = createContext<{
   callbackActive: boolean;
 }>({
   callbackPath: DEFAULT_CALLBACK_PATH,
-  signInErrors: NOOP_SIGN_IN_ERRORS,
+  authErrors: NOOP_AUTH_ERRORS,
   callbackActive: false,
 });
 
@@ -228,16 +232,16 @@ function ConvexAuthPhaseWatcher({ events }: { events: AuthEventEmitter }) {
   return null;
 }
 
-/** Observes initiation failures that @logto/react catches into its error state. */
-function LogtoSignInErrorObserver({
-  signInErrors,
+/** Observes the failures @logto/react catches into its error state instead of rejecting. */
+function LogtoAuthErrorObserver({
+  authErrors,
 }: {
-  signInErrors: BridgeSignInErrors;
+  authErrors: BridgeAuthErrors;
 }) {
   const { error } = useLogto();
   useEffect(() => {
-    signInErrors.observe(error);
-  }, [error, signInErrors]);
+    authErrors.observe(error);
+  }, [error, authErrors]);
   return null;
 }
 
@@ -421,10 +425,13 @@ type CommonProviderProps = {
    */
   callbackPath?: string;
   /**
-   * Called when starting or finishing sign-in fails recoverably (Logto
-   * unreachable, blocked storage, a stale/replayed callback, or a setup error
-   * like `invalid_scope`). This makes `void signIn()` safe for event handlers:
-   * failures are observable here and are also logged to the console.
+   * Called when starting or finishing sign-in — or signing out — fails
+   * recoverably (Logto unreachable, blocked storage, a stale/replayed callback,
+   * or a setup error like `invalid_scope`). This makes `void signIn()` and
+   * `void signOut()` safe for event handlers: failures are observable here and
+   * are also logged to the console. A failed sign-out matters as much as a
+   * failed sign-in — the SDK leaves the tokens in place, so the user is still
+   * signed in.
    */
   onAuthError?: (error: Error) => void;
   /**
@@ -582,9 +589,9 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
     onAuthErrorRef.current = onAuthError;
   }, [onAuthError]);
   const signInErrorState = useRef<{
-    latestAttempt: BridgeSignInAttempt | undefined;
+    latestAttempt: BridgeAuthAttempt | undefined;
   }>({ latestAttempt: undefined });
-  const signInErrors = useMemo<BridgeSignInErrors>(() => {
+  const authErrors = useMemo<BridgeAuthErrors>(() => {
     return {
       begin: (baselineError) => {
         const attempt = { baselineError, handled: false };
@@ -620,8 +627,8 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
   );
   const endCallbackFlow = useCallback(() => setCallbackActive(false), []);
   const bridgeValue = useMemo(
-    () => ({ callbackPath, signInErrors, callbackActive }),
-    [callbackPath, signInErrors, callbackActive],
+    () => ({ callbackPath, authErrors, callbackActive }),
+    [callbackPath, authErrors, callbackActive],
   );
 
   if (configQuery && fetched.status === "error") {
@@ -643,7 +650,7 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
             public promise. Observe that state only on the initiating page;
             callback errors are already handled by LogtoCallback below. */}
         {!callbackActive ? (
-          <LogtoSignInErrorObserver signInErrors={signInErrors} />
+          <LogtoAuthErrorObserver authErrors={authErrors} />
         ) : null}
         {/* Callback handling is gated to the exact callback route: a real OIDC
             redirect always lands as a full-page load, so mount == landing. */}
@@ -703,7 +710,7 @@ export type LogtoAuth = {
 export function useLogtoAuth(): LogtoAuth {
   const { isAuthenticated, isLoading } = useConvexAuth();
   const { signIn, signOut, getIdTokenClaims, error } = useLogto();
-  const { callbackPath, signInErrors } = useContext(BridgeContext);
+  const { callbackPath, authErrors } = useContext(BridgeContext);
   const [user, setUser] = useState<IdTokenClaims>();
 
   useEffect(() => {
@@ -728,7 +735,7 @@ export function useLogtoAuth(): LogtoAuth {
 
   const doSignIn = useCallback(
     async (redirectUriOrOptions?: string | { returnTo?: string }) => {
-      const attempt = signInErrors.begin(error);
+      const attempt = authErrors.begin(error);
       try {
         // Deprecated escape hatch: a full redirect URI. Kept working for 0.3.x
         // callers, but callback handling only runs on `callbackPath` — warn loudly
@@ -766,18 +773,35 @@ export function useLogtoAuth(): LogtoAuth {
           caught,
           "convex-logto: starting Logto sign-in failed.",
         );
-        signInErrors.fail(attempt, failure);
+        authErrors.fail(attempt, failure);
         throw failure;
       }
     },
-    [signIn, callbackPath, error, signInErrors],
+    [signIn, callbackPath, error, authErrors],
   );
   // Federated sign-out: ends the SSO session (so the next sign-in isn't silent),
   // then returns to origin — which must be a registered Post sign-out redirect URI.
   const doSignOut = useCallback(
-    (postLogoutRedirectUri?: string) =>
-      signOut(postLogoutRedirectUri ?? window.location.origin),
-    [signOut],
+    async (postLogoutRedirectUri?: string) => {
+      // Sign-out is swallowed the same way sign-in is: `@logto/react` catches
+      // the failure into its own state and resolves this promise. Worse, the
+      // SDK reaches OIDC discovery *before* clearing tokens, so an unreachable
+      // Logto leaves the user signed in with a live token while the button
+      // appears to have worked. Register the attempt so the observer reports
+      // whatever the SDK stored.
+      const attempt = authErrors.begin(error);
+      try {
+        await signOut(postLogoutRedirectUri ?? window.location.origin);
+      } catch (caught) {
+        const failure = asAuthError(
+          caught,
+          "convex-logto: Logto sign-out failed.",
+        );
+        authErrors.fail(attempt, failure);
+        throw failure;
+      }
+    },
+    [signOut, error, authErrors],
   );
 
   return useMemo(


### PR DESCRIPTION
Closes #143, closes #144.

A failed sign-out is not cosmetic. `@logto/client` reaches OIDC discovery **before** it clears tokens, so an unreachable Logto throws with the session fully intact: the user believes they signed out, and the app still holds a live ID token.

## Web (#144)

`@logto/react` catches that failure into its own state and **resolves** the promise, and the bridge only registered sign-*in* attempts — `signInErrors.observe` returns early when there is no attempt, so nothing was ever reported. `onAuthError` never fired, no navigation happened, and the UI stayed signed in; the only trace was the SDK's own `console.error`.

`signOut()` now registers an attempt the same way `signIn()` does, so the swallowed error is reported exactly once, and a direct rejection is reported and rethrown. The internal machinery is renamed from `signInErrors` to `authErrors` accordingly — it is no longer sign-in only.

## Native (#143)

The native bridge had no error surface at all: no `onAuthError` prop, and `signIn`/`signOut` returned unwrapped. Unlike the web SDK, `@logto/rn` does not proxy or catch — those promises reject — and the shipped example calls both with `void`. So a user swiping away the system browser (`auth_session_failed`) or signing out while offline produced an unhandled rejection and nothing else: no toast, no way to clear an app-level "signing in…" state, and in the sign-out case a user who is still signed in.

The native `<ConvexLogtoProvider>` now takes `onAuthError`, matching the web provider and native session mode, and both actions report through it before rejecting.

## Tests

A new `native.bridge.test.tsx` covers a dismissed sign-in, an offline sign-out, and the no-handler case (still logged); `react.bridge.test.tsx` gains the swallowed sign-out and the outright rejection. All five fail on `main`.

Docs: the `onAuthError` rows in both provider tables and the two `useLogtoAuth()` sections now say what they cover.

Verified with the full CI sequence (`lint`, `format:check`, `check-types`, `test`) over the whole workspace: 541 library tests, 10 example tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error handling for sign-in and sign-out across web and native integrations.
  * Sign-out failures are now reported consistently through the authentication error callback.
  * Errors are logged and rethrown when appropriate, preventing failures from being silently ignored.
  * Added support for authentication error callbacks in the native provider.

* **Documentation**
  * Updated authentication reference documentation with sign-out error behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->