### PR TITLE
fix(backchannel): record completion, not just a claim

### DIFF
--- a/.changeset/backchannel-completion-record.md
+++ b/.changeset/backchannel-completion-record.md
@@ -1,0 +1,25 @@
+---
+"convex-logto": patch
+---
+
+Stop back-channel logout from answering 200 for a revocation that never
+committed.
+
+The endpoint claimed the logout token's `jti` *before* dispatching the
+revocation, and a claim only proves that a delivery started. If the first
+delivery failed after claiming and its release also failed — the release is
+best-effort, since there is nothing left to do about it — every Logto retry for
+the next 24 hours was answered 200 without revoking anything, and the user
+stayed signed in through a completed OIDC back-channel logout.
+
+Delivery records now carry a completion marker. A replay is answered without
+work only once some delivery got as far as recording completion; an unfinished
+claim is redone, which is safe because revocation is idempotent — the watermark
+takes the max of what it already holds, and the drain deletes rows that are
+already dead. Suppressing *completed* replays still matters and is unchanged: a
+`sub`-only logout token revokes whatever the subject has at the moment it runs,
+so replaying one after the user signs in again would sign them out a second
+time.
+
+The webhook route keeps answering a claimed delivery without redoing it, since
+an app's sync handlers write to its own tables and are not idempotent.

--- a/.changeset/backchannel-completion-record.md
+++ b/.changeset/backchannel-completion-record.md
@@ -21,5 +21,10 @@ already dead. Suppressing *completed* replays still matters and is unchanged: a
 so replaying one after the user signs in again would sign them out a second
 time.
 
+Releasing a claim after a failure no longer deletes a *completed* record: a
+retry can take over an abandoned claim and finish while the original owner is
+still failing, and deleting the row then would erase the only proof the work
+happened.
+
 The webhook route keeps answering a claimed delivery without redoing it, since
 an app's sync handlers write to its own tables and are not idempotent.

--- a/packages/convex-logto/src/backchannel-logout.test.ts
+++ b/packages/convex-logto/src/backchannel-logout.test.ts
@@ -121,6 +121,7 @@ async function logoutToken(options: {
 
 const refs = {
   record: { fn: "record" },
+  complete: { fn: "complete" },
   forget: { fn: "forget" },
   killSid: { fn: "killSid" },
   killSubject: { fn: "killSubject" },
@@ -129,6 +130,7 @@ const refs = {
 const sessions = {
   lib: {
     recordWebhookDelivery: refs.record,
+    completeWebhookDelivery: refs.complete,
     forgetWebhookDelivery: refs.forget,
     killSessionsBySid: refs.killSid,
     killSubjectSessions: refs.killSubject,
@@ -144,7 +146,8 @@ type RouteHandler = (
 ) => Promise<Response>;
 
 function harness(options?: {
-  record?: boolean;
+  /** What `recordWebhookDelivery` reports: a fresh claim by default. */
+  delivery?: { claimed: boolean; completed: boolean };
   killSidError?: Error;
   customPath?: string;
 }) {
@@ -160,7 +163,12 @@ function harness(options?: {
     );
   vi.stubGlobal("fetch", fetchMock);
   const handlers: Record<string, ReturnType<typeof vi.fn>> = {
-    record: vi.fn().mockResolvedValue(options?.record ?? true),
+    record: vi
+      .fn()
+      .mockResolvedValue(
+        options?.delivery ?? { claimed: true, completed: false },
+      ),
+    complete: vi.fn().mockResolvedValue(null),
     forget: vi.fn().mockResolvedValue(null),
     killSid: options?.killSidError
       ? vi.fn().mockRejectedValue(options.killSidError)
@@ -258,7 +266,11 @@ describe("Logto back-channel logout", () => {
       sid: "logto-session-1",
     });
     expect(handlers.killSubject).not.toHaveBeenCalled();
-    expect(calls.map((call) => call.fn)).toEqual(["record", "killSid"]);
+    expect(calls.map((call) => call.fn)).toEqual([
+      "record",
+      "killSid",
+      "complete",
+    ]);
   });
 
   it("kills every subject session when sid is absent", async () => {
@@ -312,11 +324,9 @@ describe("Logto back-channel logout", () => {
     expect(handlers.killSid).toHaveBeenCalledTimes(1);
   });
 
-  it("answers 200 and performs no revocation for a replayed jti", async () => {
+  it("answers 200 and performs no revocation for a completed replay", async () => {
     const { endpoint, handler, handlers, calls, runMutation, runAction } =
-      harness({
-        record: false,
-      });
+      harness({ delivery: { claimed: false, completed: true } });
     const token = await logoutToken({ endpoint });
 
     const response = await handler(
@@ -328,6 +338,46 @@ describe("Logto back-channel logout", () => {
     expect(handlers.killSid).not.toHaveBeenCalled();
     expect(handlers.killSubject).not.toHaveBeenCalled();
     expect(calls.map((call) => call.fn)).toEqual(["record"]);
+  });
+
+  it("redoes the revocation for a claim that never completed", async () => {
+    // A claim proves a delivery started. If its revocation never committed —
+    // the mutation failed and the release failed too — answering 200 would
+    // leave the user signed in through a completed OIDC logout for the whole
+    // dedupe window. Revocation is idempotent, so redo it.
+    const { endpoint, handler, handlers, calls, runMutation, runAction } =
+      harness({ delivery: { claimed: false, completed: false } });
+    const token = await logoutToken({ endpoint });
+
+    const response = await handler(
+      { runMutation, runAction },
+      logoutRequest(token),
+    );
+
+    expect(response.status).toBe(200);
+    expect(handlers.killSid).toHaveBeenCalledTimes(1);
+    expect(calls.map((call) => call.fn)).toEqual([
+      "record",
+      "killSid",
+      "complete",
+    ]);
+  });
+
+  it("records completion only after the revocation committed", async () => {
+    const { endpoint, handler, calls, runMutation, runAction } = harness();
+    const token = await logoutToken({ endpoint });
+
+    const response = await handler(
+      { runMutation, runAction },
+      logoutRequest(token),
+    );
+
+    expect(response.status).toBe(200);
+    expect(calls.map((call) => call.fn)).toEqual([
+      "record",
+      "killSid",
+      "complete",
+    ]);
   });
 
   it.each([

--- a/packages/convex-logto/src/backchannel-logout.ts
+++ b/packages/convex-logto/src/backchannel-logout.ts
@@ -468,13 +468,21 @@ export function createLogtoBackchannelLogoutHandler(
     const bodyHash = await deliveryKey(claims);
     let claimed = false;
     try {
-      claimed = await ctx.runMutation(
+      const delivery = await ctx.runMutation(
         options.sessions.lib.recordWebhookDelivery,
         { bodyHash, now: Date.now() },
       );
-      // A valid replay is already fully handled. Always return the same 200 as
-      // a first delivery so neither jti nor session existence leaks.
-      if (!claimed) return successResponse();
+      claimed = delivery.claimed;
+      // A *completed* replay is already fully handled. Always return the same
+      // 200 as a first delivery so neither jti nor session existence leaks.
+      //
+      // A claim that has not completed is not the same thing: the revocation
+      // may never have committed, and a release that itself failed keeps the
+      // claim for the whole dedupe window. Redo the work instead — revocation
+      // is idempotent (the marker takes the max of what it already holds, and
+      // the drain deletes rows that are already dead), so the worst case for
+      // two deliveries racing inside that window is doing it twice.
+      if (!claimed && delivery.completed) return successResponse();
       if (claims.sid !== undefined) {
         await ctx.runAction(options.sessions.lib.killSessionsBySid, {
           sid: claims.sid,
@@ -486,6 +494,14 @@ export function createLogtoBackchannelLogoutHandler(
       } else {
         throw new Error("Verified logout token has no subject or sid.");
       }
+      // Only now is a later replay safe to answer without working. Suppressing
+      // replays still matters: a `sub`-only logout token revokes everything the
+      // subject has *at the time it runs*, so a replay after the user signs in
+      // again would sign them out a second time.
+      await ctx.runMutation(options.sessions.lib.completeWebhookDelivery, {
+        bodyHash,
+        now: Date.now(),
+      });
       return successResponse();
     } catch {
       if (claimed) {

--- a/packages/convex-logto/src/component/_generated/component.ts
+++ b/packages/convex-logto/src/component/_generated/component.ts
@@ -24,6 +24,13 @@ import type { FunctionReference } from "convex/server";
 export type ComponentApi<Name extends string | undefined = string | undefined> =
   {
     lib: {
+      completeWebhookDelivery: FunctionReference<
+        "mutation",
+        "internal",
+        { bodyHash: string; now: number },
+        null,
+        Name
+      >;
       createSignInUrl: FunctionReference<
         "action",
         "internal",
@@ -128,7 +135,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         "mutation",
         "internal",
         { bodyHash: string; now: number },
-        boolean,
+        { claimed: boolean; completed: boolean },
         Name
       >;
       refresh: FunctionReference<

--- a/packages/convex-logto/src/component/lib.test.ts
+++ b/packages/convex-logto/src/component/lib.test.ts
@@ -4,14 +4,17 @@ import {
   beginRefresh,
   beginSubjectRevocationByToken,
   completeRefresh,
+  completeWebhookDelivery,
   consumeSessionForSignOut,
   devicePublicKeyForToken,
   exchange,
+  forgetWebhookDelivery,
   gc,
   killSession,
   killSubjectSessionsByToken,
   deleteOwnedSession,
   listSubjectSessions,
+  recordWebhookDelivery,
   refresh,
   releaseClaim,
   resolveCallerSession,
@@ -2006,6 +2009,104 @@ describe("gc revocation watermarks", () => {
     await expect(gcHandler({ db: harness.db }, {})).resolves.toBeNull();
     expect(harness.rows("subjectRevocations")).toEqual(["subject-marker"]);
     expect(harness.rows("sidRevocations")).toEqual(["sid-marker"]);
+  });
+});
+
+describe("webhook delivery dedupe", () => {
+  type DeliveryRow = {
+    _id: string;
+    bodyHash: string;
+    seenAt: number;
+    completedAt?: number;
+  };
+
+  function deliveryHarness(initial: DeliveryRow[]) {
+    let rows = initial.map((row) => ({ ...row }));
+    const db = {
+      query: () => ({
+        withIndex: (_index: string, configure: (query: unknown) => unknown) => {
+          let hash = "";
+          configure({
+            eq(_field: string, value: string) {
+              hash = value;
+              return this;
+            },
+          });
+          return {
+            unique: () =>
+              Promise.resolve(
+                rows.find((row) => row.bodyHash === hash) ?? null,
+              ),
+          };
+        },
+      }),
+      insert: (_table: string, value: Omit<DeliveryRow, "_id">) => {
+        rows.push({ _id: `delivery-${rows.length + 1}`, ...value });
+        return Promise.resolve("delivery");
+      },
+      patch: (id: string, patch: Partial<DeliveryRow>) => {
+        rows = rows.map((row) => (row._id === id ? { ...row, ...patch } : row));
+        return Promise.resolve();
+      },
+      delete: (id: string) => {
+        rows = rows.filter((row) => row._id !== id);
+        return Promise.resolve();
+      },
+    };
+    return { db, rows: () => rows };
+  }
+
+  const record = internalHandler<{ bodyHash: string; now: number }, unknown>(
+    recordWebhookDelivery,
+  );
+  const complete = internalHandler<{ bodyHash: string; now: number }, null>(
+    completeWebhookDelivery,
+  );
+  const forget = internalHandler<{ bodyHash: string }, null>(
+    forgetWebhookDelivery,
+  );
+
+  it("reports a claim and a completion separately", async () => {
+    const harness = deliveryHarness([]);
+    await expect(
+      record({ db: harness.db }, { bodyHash: "h", now: 1 }),
+    ).resolves.toEqual({ claimed: true, completed: false });
+    // A claim proves a delivery started, not that its work committed.
+    await expect(
+      record({ db: harness.db }, { bodyHash: "h", now: 2 }),
+    ).resolves.toEqual({ claimed: false, completed: false });
+
+    await complete({ db: harness.db }, { bodyHash: "h", now: 3 });
+    await expect(
+      record({ db: harness.db }, { bodyHash: "h", now: 4 }),
+    ).resolves.toEqual({ claimed: false, completed: true });
+  });
+
+  it("records completion even after the claim was released", async () => {
+    const harness = deliveryHarness([]);
+    await record({ db: harness.db }, { bodyHash: "h", now: 1 });
+    await forget({ db: harness.db }, { bodyHash: "h" });
+
+    await complete({ db: harness.db }, { bodyHash: "h", now: 2 });
+    await expect(
+      record({ db: harness.db }, { bodyHash: "h", now: 3 }),
+    ).resolves.toEqual({ claimed: false, completed: true });
+  });
+
+  it("never releases a delivery that completed", async () => {
+    // A retry can take over an abandoned claim and finish while the original
+    // owner is still failing. Deleting the row then would erase the only proof
+    // the work happened, re-arming a replay.
+    const harness = deliveryHarness([]);
+    await record({ db: harness.db }, { bodyHash: "h", now: 1 });
+    await complete({ db: harness.db }, { bodyHash: "h", now: 2 });
+
+    await forget({ db: harness.db }, { bodyHash: "h" });
+
+    expect(harness.rows()).toHaveLength(1);
+    await expect(
+      record({ db: harness.db }, { bodyHash: "h", now: 3 }),
+    ).resolves.toEqual({ claimed: false, completed: true });
   });
 });
 

--- a/packages/convex-logto/src/component/lib.ts
+++ b/packages/convex-logto/src/component/lib.ts
@@ -1752,22 +1752,56 @@ export const deleteSidSessionsBatch = internalMutation({
 
 /**
  * Claim a verified Logto delivery by a SHA-256 key (webhook body or issuer+jti).
- * Returns `true` the first time; `false` on a retry whose original 200 was lost.
+ *
+ * `claimed` is true only for the caller that created the row — the first
+ * delivery, or the first retry after a released claim. `completed` reports
+ * whether some caller got as far as {@link completeWebhookDelivery}: a claim on
+ * its own proves a delivery *started*, not that its work committed, so a caller
+ * whose work is idempotent should redo an unfinished one rather than answer for
+ * it.
  */
 export const recordWebhookDelivery = mutation({
   args: { bodyHash: v.string(), now: v.number() },
-  returns: v.boolean(),
+  returns: v.object({ claimed: v.boolean(), completed: v.boolean() }),
   handler: async (ctx, args) => {
     const existing = await ctx.db
       .query("webhookDeliveries")
       .withIndex("by_bodyHash", (q) => q.eq("bodyHash", args.bodyHash))
       .unique();
-    if (existing) return false;
+    if (existing) {
+      return { claimed: false, completed: existing.completedAt !== undefined };
+    }
     await ctx.db.insert("webhookDeliveries", {
       bodyHash: args.bodyHash,
       seenAt: args.now,
     });
-    return true;
+    return { claimed: true, completed: false };
+  },
+});
+
+/**
+ * Record that a delivery's work committed. Inserts when the row is gone, so a
+ * caller that took over an abandoned claim — one whose owner failed and
+ * released it — still leaves proof behind for the next retry.
+ */
+export const completeWebhookDelivery = mutation({
+  args: { bodyHash: v.string(), now: v.number() },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("webhookDeliveries")
+      .withIndex("by_bodyHash", (q) => q.eq("bodyHash", args.bodyHash))
+      .unique();
+    if (existing === null) {
+      await ctx.db.insert("webhookDeliveries", {
+        bodyHash: args.bodyHash,
+        seenAt: args.now,
+        completedAt: args.now,
+      });
+    } else if (existing.completedAt === undefined) {
+      await ctx.db.patch(existing._id, { completedAt: args.now });
+    }
+    return null;
   },
 });
 

--- a/packages/convex-logto/src/component/lib.ts
+++ b/packages/convex-logto/src/component/lib.ts
@@ -1808,6 +1808,12 @@ export const completeWebhookDelivery = mutation({
 /**
  * Release a claimed delivery after processing failed, so Logto's retry isn't
  * deduplicated into a lost event.
+ *
+ * Never releases a *completed* delivery. A caller that took over an abandoned
+ * claim can finish while the original owner is still failing, and deleting the
+ * row then would erase the only proof the work happened — re-arming a replay of
+ * a `sub`-only logout token, which revokes whatever the subject has when it
+ * runs, including sessions created since.
  */
 export const forgetWebhookDelivery = mutation({
   args: { bodyHash: v.string() },
@@ -1817,7 +1823,9 @@ export const forgetWebhookDelivery = mutation({
       .query("webhookDeliveries")
       .withIndex("by_bodyHash", (q) => q.eq("bodyHash", args.bodyHash))
       .unique();
-    if (existing) await ctx.db.delete(existing._id);
+    if (existing && existing.completedAt === undefined) {
+      await ctx.db.delete(existing._id);
+    }
     return null;
   },
 });

--- a/packages/convex-logto/src/component/schema.ts
+++ b/packages/convex-logto/src/component/schema.ts
@@ -32,6 +32,10 @@ export default defineSchema({
   webhookDeliveries: defineTable({
     bodyHash: v.string(),
     seenAt: v.number(),
+    // Set once the delivery's work committed. A claim proves a delivery
+    // *started*; only this proves it finished, which is what lets a caller whose
+    // work is idempotent redo an abandoned one instead of answering for it.
+    completedAt: v.optional(v.number()),
   })
     .index("by_bodyHash", ["bodyHash"])
     .index("by_seenAt", ["seenAt"]),

--- a/packages/convex-logto/src/session.ts
+++ b/packages/convex-logto/src/session.ts
@@ -204,7 +204,13 @@ export type LogtoSessionComponent = {
       "mutation",
       "internal",
       { bodyHash: string; now: number },
-      boolean
+      { claimed: boolean; completed: boolean }
+    >;
+    completeWebhookDelivery: FunctionReference<
+      "mutation",
+      "internal",
+      { bodyHash: string; now: number },
+      null
     >;
     forgetWebhookDelivery: FunctionReference<
       "mutation",

--- a/packages/convex-logto/src/webhooks.test.ts
+++ b/packages/convex-logto/src/webhooks.test.ts
@@ -342,7 +342,9 @@ function sessionsHarness(overrides?: {
 }) {
   const calls: Array<{ fn: string; args: unknown }> = [];
   const handlers: Record<string, ReturnType<typeof vi.fn>> = {
-    record: overrides?.record ?? vi.fn().mockResolvedValue(true),
+    record:
+      overrides?.record ??
+      vi.fn().mockResolvedValue({ claimed: true, completed: false }),
     forget: vi.fn().mockResolvedValue(null),
     kill: vi.fn().mockResolvedValue(0),
     sync: overrides?.sync ?? vi.fn().mockResolvedValue(null),
@@ -390,7 +392,7 @@ describe("registerLogtoWebhook with sessions", () => {
 
   it("answers 200 on a duplicate delivery WITHOUT re-running sync", async () => {
     const { handler, runMutation, runAction, handlers } = sessionsHarness({
-      record: vi.fn().mockResolvedValue(false),
+      record: vi.fn().mockResolvedValue({ claimed: false, completed: true }),
     });
     const res = await handler(
       { runMutation, runAction },

--- a/packages/convex-logto/src/webhooks.ts
+++ b/packages/convex-logto/src/webhooks.ts
@@ -501,11 +501,16 @@ export function registerLogtoWebhook(
       let bodyHash: string | undefined;
       if (sessions) {
         bodyHash = toHex(await crypto.subtle.digest("SHA-256", rawBody));
-        const firstSeen = await ctx.runMutation(
+        const delivery = await ctx.runMutation(
           sessions.lib.recordWebhookDelivery,
           { bodyHash, now: Date.now() },
         );
-        if (!firstSeen) return new Response(null, { status: 200 });
+        // Unlike back-channel logout, this route deliberately answers a claimed
+        // delivery without redoing anything, finished or not: an app's sync
+        // handlers write to its own tables and are not idempotent, so running
+        // them twice is worse than answering slightly early for one still in
+        // flight. A delivery whose work failed releases its claim below.
+        if (!delivery.claimed) return new Response(null, { status: 200 });
       }
 
       try {


### PR DESCRIPTION
Closes #135.

The endpoint claimed the logout token's `jti` **before** dispatching the revocation, and a claim only proves a delivery *started*:

1. Logto POSTs *T*. The handler claims the `jti` and dispatches `killSessionsBySid`.
2. Before `beginSidRevocation` commits, Logto times out and re-POSTs *T*.
3. Delivery #2 gets `false` from the claim and returns **200** - asserting the logout is done when no revocation marker exists yet.
4. Delivery #1 fails and runs the compensator, which is `.catch(() => {})`-swallowed because there is nothing left to do about it. If the release also failed, the claim survives the full 24h dedupe window and **every** retry of *T* is answered 200 without revoking anything. The user stays signed in through a completed OIDC back-channel logout.

## The fix

Delivery records carry a completion marker (`completedAt`, optional - no migration). A replay is answered without work only when some delivery got as far as recording completion; an unfinished claim is redone.

Redoing is safe here specifically: revocation is idempotent - the watermark takes the max of what it already holds and the drain deletes rows that are already dead - so the worst case for two deliveries racing inside the in-flight window is doing it twice, simultaneously, for the same token.

Suppressing **completed** replays still matters and is unchanged. A `sub`-only logout token revokes whatever the subject has *at the moment it runs*, so replaying one within its 5-minute freshness window after the user signed in again would sign them out a second time.

The webhook route deliberately keeps its current behaviour - a claimed delivery is answered without redoing anything, finished or not - because an app's sync handlers write to its own tables and are not idempotent. That asymmetry is now commented at both call sites.

## Tests

Three at the route level: a completed replay does no work, an unfinished claim redoes the revocation, and completion is recorded only after the revocation committed (`record` -> `killSid` -> `complete`, in that order).

`recordWebhookDelivery` now returns `{ claimed, completed }`, so the component API type was regenerated with `convex codegen`.

Verified with the full CI sequence (`lint`, `format:check`, `check-types`, `test`) over the whole workspace: 538 library tests, 10 example tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved back-channel logout retry handling so interrupted deliveries are retried safely.
  - Completed deliveries remain suppressed on replay, preventing duplicate session revocation.
  - Failed webhook processing continues to support retry while preserving successful completion records.

- **Tests**
  - Expanded coverage for completed, incomplete, and retried webhook deliveries.
  - Verified successful logout processing and replay behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->