### PR TITLE
fix(component): sweep revocation watermarks in their own transaction

### DIFF
--- a/.changeset/marker-sweep-budget.md
+++ b/.changeset/marker-sweep-budget.md
@@ -1,0 +1,15 @@
+---
+"convex-logto": patch
+---
+
+Give the revocation-watermark sweep its own transaction.
+
+Collecting a watermark proves it governs no surviving session, and that proof
+reads a `sessions` document — the largest this component stores. Running a
+hundred of those lookups inside `gc`, which had already spent most of its
+16 MiB read budget on the transaction and dead-session sweeps, could exceed the
+limit and fail the whole garbage collection, not just the watermark part. The
+sweep is now a separate scheduled mutation with a batch bounded the way the
+revocation drain is, and it continues durably only when a full batch was
+actually collected — a batch that skipped everything found nothing collectable,
+and rescheduling on that would spin on the same rows.

--- a/packages/convex-logto/src/component/lib.test.ts
+++ b/packages/convex-logto/src/component/lib.test.ts
@@ -1,5 +1,5 @@
 import { getFunctionName, type FunctionReference } from "convex/server";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   beginRefresh,
   beginSubjectRevocationByToken,
@@ -8,6 +8,7 @@ import {
   devicePublicKeyForToken,
   exchange,
   gc,
+  gcRevocationMarkers,
   killSession,
   killSubjectSessionsByToken,
   deleteOwnedSession,
@@ -450,6 +451,9 @@ const consumeSessionForSignOutHandler = internalHandler<
   SignOutConsumptionResult
 >(consumeSessionForSignOut);
 const gcHandler = internalHandler<Record<string, never>, null>(gc);
+const gcMarkersHandler = internalHandler<Record<string, never>, null>(
+  gcRevocationMarkers,
+);
 
 type SignOutArgs = {
   endpoint: string;
@@ -1844,7 +1848,12 @@ describe("gc token generations", () => {
       ],
     );
 
-    await expect(gcHandler({ db: harness.db }, {})).resolves.toBeNull();
+    await expect(
+      gcHandler(
+        { db: harness.db, scheduler: { runAfter: () => Promise.resolve() } },
+        {},
+      ),
+    ).resolves.toBeNull();
     expect(harness.session()).toBeNull();
     expect(harness.generations()).toEqual([]);
     expect(harness.deleted).toEqual([
@@ -1937,6 +1946,17 @@ describe("gc revocation watermarks", () => {
 
   const NOW = Date.now();
   const ANCIENT = NOW - REVOCATION_MARKER_GC_AFTER_MS - 60_000;
+  const scheduled: unknown[] = [];
+  const scheduler = {
+    runAfter: (_delay: number, ref: unknown) => {
+      scheduled.push(ref);
+      return Promise.resolve();
+    },
+  };
+
+  beforeEach(() => {
+    scheduled.length = 0;
+  });
 
   it("collects a watermark once nothing it governs survives", async () => {
     // Back-channel logout writes one row per OP session that ever ends,
@@ -1960,7 +1980,9 @@ describe("gc revocation watermarks", () => {
       ],
     });
 
-    await expect(gcHandler({ db: harness.db }, {})).resolves.toBeNull();
+    await expect(
+      gcMarkersHandler({ db: harness.db, scheduler }, {}),
+    ).resolves.toBeNull();
     expect(harness.rows("subjectRevocations")).toEqual([]);
     expect(harness.rows("sidRevocations")).toEqual([]);
     expect(harness.rows("sessions")).toEqual(["live"]);
@@ -1985,9 +2007,46 @@ describe("gc revocation watermarks", () => {
       ],
     });
 
-    await expect(gcHandler({ db: harness.db }, {})).resolves.toBeNull();
+    await expect(
+      gcMarkersHandler({ db: harness.db, scheduler }, {}),
+    ).resolves.toBeNull();
     expect(harness.rows("subjectRevocations")).toEqual(["subject-marker"]);
     expect(harness.rows("sidRevocations")).toEqual(["sid-marker"]);
+  });
+
+  it("continues durably only when a full batch was actually collected", async () => {
+    // Rescheduling on a full batch that *skipped* everything would spin on the
+    // same rows forever, since a skipped marker is not deleted.
+    const collectable = Array.from({ length: 8 }, (_, index) => ({
+      _id: `marker-${index}`,
+      subject: `u${index}`,
+      revokedAt: ANCIENT,
+    }));
+    const harness = gcHarness({
+      subjectRevocations: collectable,
+      sidRevocations: [],
+      sessions: [],
+    });
+
+    await gcMarkersHandler({ db: harness.db, scheduler }, {});
+    expect(harness.rows("subjectRevocations")).toEqual([]);
+    expect(scheduled).toHaveLength(1);
+
+    const stuck = gcHarness({
+      subjectRevocations: collectable,
+      sidRevocations: [],
+      sessions: collectable.map((marker, index) => ({
+        _id: `stranded-${index}`,
+        subject: marker.subject,
+        createdAt: ANCIENT - 1,
+        lastRefreshedAt: NOW,
+      })),
+    });
+    scheduled.length = 0;
+
+    await gcMarkersHandler({ db: stuck.db, scheduler }, {});
+    expect(stuck.rows("subjectRevocations")).toHaveLength(8);
+    expect(scheduled).toHaveLength(0);
   });
 
   it("keeps a watermark inside the horizon even with nothing left to kill", async () => {
@@ -2003,7 +2062,9 @@ describe("gc revocation watermarks", () => {
       sessions: [],
     });
 
-    await expect(gcHandler({ db: harness.db }, {})).resolves.toBeNull();
+    await expect(
+      gcMarkersHandler({ db: harness.db, scheduler }, {}),
+    ).resolves.toBeNull();
     expect(harness.rows("subjectRevocations")).toEqual(["subject-marker"]);
     expect(harness.rows("sidRevocations")).toEqual(["sid-marker"]);
   });

--- a/packages/convex-logto/src/component/lib.ts
+++ b/packages/convex-logto/src/component/lib.ts
@@ -117,9 +117,12 @@ const MAX_REVOCATION_BATCHES = 512;
 // so reserve four of the 16 MiB read/write budget for transaction documents.
 const GC_TRANSACTION_BATCH_SIZE = 4;
 const GC_SMALL_DOCUMENT_BATCH_SIZE = 500;
-// Each watermark costs one indexed session lookup on top of its own row, so
-// this batch buys two document reads per unit rather than one.
-const GC_MARKER_BATCH_SIZE = 100;
+// A watermark row is tiny, but proving it governs nothing reads a *session*
+// document, which can approach Convex's 1 MiB limit. Bound the batch by that
+// read, the same way the revocation drain is bounded, and give the sweep its
+// own transaction so it never has to share a budget with the session and
+// transaction sweeps.
+const GC_MARKER_BATCH_SIZE = 8;
 
 type SessionTokenMatch =
   | { source: "current"; session: Doc<"sessions"> }
@@ -1880,20 +1883,40 @@ export const gc = internalMutation({
     // Revocation watermarks outlive the rows they killed on purpose, but not
     // forever: back-channel logout writes one per OP session that ever ends,
     // including logouts that matched nothing, and nothing else ever deletes
-    // them. Collect only a marker that governs no surviving session — deleting
-    // one that still does would make a logically dead row start validating
-    // again — and only past the horizon where a session could still bind it.
-    const collectedMarkers = await collectRevocationMarkers(ctx.db, now);
+    // them. They sweep in their own transaction because proving a marker
+    // governs nothing reads session documents, which this mutation has already
+    // spent most of its budget on.
+    await ctx.scheduler.runAfter(0, internal.lib.gcRevocationMarkers, {});
     // A full batch might have more rows behind it. Continue durably instead of
     // reducing a daily cron to four abandoned sign-ins or eight dead sessions.
     if (
       expiredTransactions.length === GC_TRANSACTION_BATCH_SIZE ||
       deadSessions.length === REVOCATION_BATCH_SIZE ||
       expiredGenerations.length === GC_SMALL_DOCUMENT_BATCH_SIZE ||
-      staleDeliveries.length === GC_SMALL_DOCUMENT_BATCH_SIZE ||
-      collectedMarkers === GC_MARKER_BATCH_SIZE
+      staleDeliveries.length === GC_SMALL_DOCUMENT_BATCH_SIZE
     ) {
       await ctx.scheduler.runAfter(0, internal.lib.gc, {});
+    }
+    return null;
+  },
+});
+
+/**
+ * Sweep revocation watermarks, one bounded batch per transaction. Split out of
+ * {@link gc} for the read budget: a marker row is tiny, but each one costs an
+ * indexed lookup into `sessions`, whose documents are the largest this
+ * component stores.
+ */
+export const gcRevocationMarkers = internalMutation({
+  args: {},
+  returns: v.null(),
+  handler: async (ctx) => {
+    const deleted = await collectRevocationMarkers(ctx.db, Date.now());
+    // Only a full batch of *deletions* continues. A batch that skipped
+    // everything found nothing collectable, and rescheduling on that would spin
+    // on the same rows forever.
+    if (deleted === GC_MARKER_BATCH_SIZE) {
+      await ctx.scheduler.runAfter(0, internal.lib.gcRevocationMarkers, {});
     }
     return null;
   },

--- a/packages/convex-logto/src/component/lib.ts
+++ b/packages/convex-logto/src/component/lib.ts
@@ -1796,13 +1796,13 @@ export const forgetWebhookDelivery = mutation({
 /**
  * Delete revocation watermarks that can no longer kill anything: no session the
  * marker covers survives, and it is old enough that none can appear. Returns
- * how many rows were deleted so `gc` knows whether to continue.
+ * how many rows were deleted, so the caller knows whether to continue.
  *
  * A marker that still governs a surviving row is skipped, not deleted — that
  * row is logically dead *because* of the marker, and dropping it early would
- * hand its token back its authority. Skipped markers are the oldest, so they
- * hold up younger ones until the session sweep in the same mutation removes
- * what they govern; that is the safe direction to be stuck in.
+ * hand its token back its authority. Skipped markers are the oldest in the
+ * table, so they hold up younger ones until `gc`'s dead-session sweep removes
+ * what they govern; being stuck retaining watermarks is the safe direction.
  */
 async function collectRevocationMarkers(
   db: DatabaseWriter,

--- a/packages/convex-logto/src/component/revocation.test.ts
+++ b/packages/convex-logto/src/component/revocation.test.ts
@@ -1,3 +1,4 @@
+import { getFunctionName } from "convex/server";
 import { describe, expect, it } from "vitest";
 import {
   REVOCATION_BATCH_SIZE,
@@ -218,7 +219,7 @@ describe("bounded session revocation", () => {
       (_, index) => ({ _id: `session-${index}` }),
     );
     const deleted: string[] = [];
-    const scheduled: Array<{ delay: number; args: unknown }> = [];
+    const scheduled: Array<{ delay: number; args: unknown; name: string }> = [];
     let transactionTakeLimit: number | undefined;
     let sessionTakeLimit: number | undefined;
     const db = {
@@ -257,8 +258,12 @@ describe("bounded session revocation", () => {
     const handler = handlerOf<Record<string, never>, null>(gc);
 
     const scheduler = {
-      runAfter: (delay: number, _reference: unknown, args: unknown) => {
-        scheduled.push({ delay, args });
+      runAfter: (delay: number, reference: unknown, args: unknown) => {
+        scheduled.push({
+          delay,
+          args,
+          name: getFunctionName(reference as never),
+        });
         return Promise.resolve("scheduled-gc");
       },
     };
@@ -267,7 +272,13 @@ describe("bounded session revocation", () => {
     expect(transactionTakeLimit).toBe(4);
     expect(sessionTakeLimit).toBe(REVOCATION_BATCH_SIZE);
     expect(deleted).toHaveLength(REVOCATION_BATCH_SIZE);
-    expect(scheduled).toEqual([{ delay: 0, args: {} }]);
+    // The watermark sweep runs in its own transaction — proving a watermark
+    // governs nothing reads session documents, and this budget is spent.
+    expect(scheduled.map((entry) => entry.name)).toEqual([
+      "lib:gcRevocationMarkers",
+      "lib:gc",
+    ]);
+    expect(scheduled.every((entry) => entry.delay === 0)).toBe(true);
   });
 
   it("includes a session committed after the action sampled its clock", async () => {


### PR DESCRIPTION
Follow-up to #140, catching a read-budget mistake in my own change before it can bite.

Collecting a watermark proves it governs no surviving session, and that proof reads a `sessions` document — the largest thing this component stores (the drain's own batch size exists for exactly this reason: "eight aggregate roots … eleven session documents at worst"). #140 ran up to 100 of those lookups **inside `gc`**, which had already spent most of its 16 MiB read budget on the transaction and dead-session sweeps. A deployment with a backlog of stranded rows could therefore blow the transaction limit and fail the *whole* garbage collection — transactions, dead sessions, generations and delivery hashes included — not just the watermark part.

The sweep is now `gcRevocationMarkers`, scheduled by `gc` and running in its own transaction, with the batch bounded the way the revocation drain is (8, one session document each).

It continues durably only when a full batch was actually **collected**. A batch that skipped everything found nothing collectable — a skipped marker is not deleted — so rescheduling on "batch was full" would spin on the same rows forever.

## Tests

The existing GC budget test now asserts both schedules by name (`lib:gcRevocationMarkers` in its own transaction, then the `lib:gc` continuation), and a new test covers the chaining rule in both directions: eight collectable markers reschedule, eight stranded ones do not.

Verified with the full CI sequence (`lint`, `format:check`, `check-types`, `test`) over the whole workspace.
