### PR TITLE
chore(examples): wire onAuthError in the Expo bridge example

### DIFF
--- a/examples/expo/App.tsx
+++ b/examples/expo/App.tsx
@@ -9,6 +9,7 @@ import {
 import { StatusBar } from "expo-status-bar";
 import {
   ActivityIndicator,
+  Alert,
   Button,
   SafeAreaView,
   ScrollView,
@@ -48,7 +49,10 @@ function SignedIn() {
     <View style={styles.stack}>
       <Button
         title={`Sign out (${user?.email ?? user?.sub ?? "user"})`}
-        onPress={() => void signOut()}
+        // The provider's `onAuthError` reports the failure; swallowing the
+        // rejection here just keeps it from also surfacing unhandled. A sign-out
+        // that fails leaves the user signed in — worth telling them about.
+        onPress={() => void signOut().catch(() => {})}
       />
       <Me />
     </View>
@@ -58,7 +62,9 @@ function SignedIn() {
 function SignIn() {
   // `signIn()` defaults to the provider's `redirectUri` ("io.logto://callback").
   const { signIn } = useLogtoAuth();
-  return <Button title="Sign in" onPress={() => void signIn()} />;
+  return (
+    <Button title="Sign in" onPress={() => void signIn().catch(() => {})} />
+  );
 }
 
 export default function App() {
@@ -71,6 +77,10 @@ export default function App() {
       configQuery={api.logto.config}
       redirectUri="io.logto://callback"
       fallback={<Spinner label="Loading config…" />}
+      // `@logto/rn` rejects instead of storing the error, and the two failures
+      // an app actually sees — the user dismissing the system browser, and a
+      // sign-out that could not reach Logto — are both invisible without this.
+      onAuthError={(error) => Alert.alert("Logto", error.message)}
     >
       <SafeAreaView style={styles.screen}>
         <Text style={styles.title}>convex-logto + Expo</Text>


### PR DESCRIPTION
Follow-up to #147, which gave the native bridge provider an `onAuthError`.

No example wired it, and the examples are what people copy. On native the gap is the widest: `@logto/rn` rejects rather than storing the error, so the two failures an app actually sees — the user dismissing the system browser, and a sign-out that could not reach Logto — are invisible without a handler. The second one matters most: the SDK reaches OIDC discovery before it clears tokens, so a failed sign-out leaves the user signed in.

The Expo bridge example now passes `onAuthError` and surfaces the message with `Alert.alert`, and its two fire-and-forget calls carry `.catch(() => {})` — reporting a failure is not handling its rejection, which is what the docs now say too.

No changeset: example only.
