### PR TITLE
fix(component): continue the watermark sweep when either table is full

### DIFF
--- a/.changeset/marker-sweep-progress.md
+++ b/.changeset/marker-sweep-progress.md
@@ -1,0 +1,11 @@
+---
+"convex-logto": patch
+---
+
+Keep the revocation-watermark sweep going when both tables are backlogged.
+
+The sweep continued only when its combined deletion count equalled one batch, so
+a run that filled *both* batches — subject watermarks and `sid` watermarks
+together, which is exactly the backlogged case — counted sixteen and stopped.
+Each table's deletions are now counted separately, and either one filling its
+batch continues the chain.

--- a/packages/convex-logto/src/component/lib.test.ts
+++ b/packages/convex-logto/src/component/lib.test.ts
@@ -2017,6 +2017,30 @@ describe("gc revocation watermarks", () => {
     expect(harness.rows("sidRevocations")).toEqual(["sid-marker"]);
   });
 
+  it("continues when either table filled its batch", async () => {
+    // Counting the two tables together would stop the chain exactly when both
+    // are backlogged, which is when it is needed most.
+    const harness = gcHarness({
+      subjectRevocations: Array.from({ length: 8 }, (_, index) => ({
+        _id: `subject-${index}`,
+        subject: `u${index}`,
+        revokedAt: ANCIENT,
+      })),
+      sidRevocations: Array.from({ length: 8 }, (_, index) => ({
+        _id: `sid-${index}`,
+        sid: `s${index}`,
+        revokedAt: ANCIENT,
+      })),
+      sessions: [],
+    });
+
+    await gcMarkersHandler({ db: harness.db, scheduler }, {});
+
+    expect(harness.rows("subjectRevocations")).toEqual([]);
+    expect(harness.rows("sidRevocations")).toEqual([]);
+    expect(scheduled).toHaveLength(1);
+  });
+
   it("continues durably only when a full batch was actually collected", async () => {
     // Rescheduling on a full batch that *skipped* everything would spin on the
     // same rows forever, since a skipped marker is not deleted.

--- a/packages/convex-logto/src/component/lib.ts
+++ b/packages/convex-logto/src/component/lib.ts
@@ -1837,8 +1837,9 @@ export const forgetWebhookDelivery = mutation({
 
 /**
  * Delete revocation watermarks that can no longer kill anything: no session the
- * marker covers survives, and it is old enough that none can appear. Returns
- * how many rows were deleted, so the caller knows whether to continue.
+ * marker covers survives, and it is old enough that none can appear. Reports
+ * the two tables' deletions separately, since either one filling its batch
+ * means there is more to collect.
  *
  * A marker that still governs a surviving row is skipped, not deleted — that
  * row is logically dead *because* of the marker, and dropping it early would
@@ -1849,9 +1850,10 @@ export const forgetWebhookDelivery = mutation({
 async function collectRevocationMarkers(
   db: DatabaseWriter,
   now: number,
-): Promise<number> {
+): Promise<{ subjectDeleted: number; sidDeleted: number }> {
   const horizon = now - REVOCATION_MARKER_GC_AFTER_MS;
-  let deleted = 0;
+  let subjectDeleted = 0;
+  let sidDeleted = 0;
   const subjectMarkers = await db
     .query("subjectRevocations")
     .withIndex("by_revokedAt", (q) => q.lt("revokedAt", horizon))
@@ -1865,7 +1867,7 @@ async function collectRevocationMarkers(
       .first();
     if (governed !== null) continue;
     await db.delete(marker._id);
-    deleted += 1;
+    subjectDeleted += 1;
   }
   const sidMarkers = await db
     .query("sidRevocations")
@@ -1880,9 +1882,9 @@ async function collectRevocationMarkers(
       .first();
     if (governed !== null) continue;
     await db.delete(marker._id);
-    deleted += 1;
+    sidDeleted += 1;
   }
-  return deleted;
+  return { subjectDeleted, sidDeleted };
 }
 
 export const gc = internalMutation({
@@ -1953,11 +1955,18 @@ export const gcRevocationMarkers = internalMutation({
   args: {},
   returns: v.null(),
   handler: async (ctx) => {
-    const deleted = await collectRevocationMarkers(ctx.db, Date.now());
-    // Only a full batch of *deletions* continues. A batch that skipped
-    // everything found nothing collectable, and rescheduling on that would spin
-    // on the same rows forever.
-    if (deleted === GC_MARKER_BATCH_SIZE) {
+    const { subjectDeleted, sidDeleted } = await collectRevocationMarkers(
+      ctx.db,
+      Date.now(),
+    );
+    // Continue while either table filled its batch with *deletions*. Counting
+    // the two together would stop the chain exactly when both are backlogged,
+    // and counting rows merely examined would spin forever on a batch that
+    // skipped everything — a skipped marker is retained, not collected.
+    if (
+      subjectDeleted === GC_MARKER_BATCH_SIZE ||
+      sidDeleted === GC_MARKER_BATCH_SIZE
+    ) {
       await ctx.scheduler.runAfter(0, internal.lib.gcRevocationMarkers, {});
     }
     return null;


### PR DESCRIPTION
Follow-up to #149, fixing a stopping condition I got wrong there.

`collectRevocationMarkers` sweeps two tables — `subjectRevocations` and `sidRevocations` — with a batch of 8 each, and returned one combined count. The caller continued when that count equalled the batch size, so:

| subject deletions | sid deletions | total | continued? |
|---|---|---|---|
| 8 | 0 | 8 | yes |
| 4 | 4 | 8 | yes (harmlessly — the next run finds nothing) |
| **8** | **8** | **16** | **no** |

The chain therefore stopped exactly in the case it exists for: both tables backlogged. With back-channel logout writing one `sid` row per OP session that ends, that caps collection at 16 rows per daily cron.

Each table's deletions are now counted separately and either one filling its batch continues. The condition still counts **deletions**, not rows examined: a batch that skipped everything collected nothing, and rescheduling on that would spin on the same rows forever.

## Tests

A new case fills both batches and asserts one continuation is scheduled; it fails on `main`. The existing pair (a full batch of collectable markers continues, a full batch of stranded ones does not) still passes.

Verified with the full CI sequence (`lint`, `format:check`, `check-types`, `test`) over the whole workspace.
