### PR TITLE
fix(session): run session actions over HTTP, not the app's socket

### DIFF
--- a/.changeset/session-http-transport.md
+++ b/.changeset/session-http-transport.md
@@ -1,0 +1,9 @@
+---
+"convex-logto": patch
+---
+
+Session mode: run session actions over HTTP instead of the app's WebSocket
+client. Convex stops that socket before asking for a fresh token, so the
+`refresh` action it triggered parked forever and the socket was never restarted
+— a server-rejected ID token (a suspended tab, a backgrounded native app) wedged
+the whole app until reload.

--- a/packages/convex-logto/src/native-session.tsx
+++ b/packages/convex-logto/src/native-session.tsx
@@ -26,6 +26,7 @@ import {
 } from "./native-session-client";
 import type { LogtoAuthEventHandler } from "./auth-events";
 import { SessionAuthEngine } from "./session-client";
+import { defaultSessionTransport } from "./session-transport";
 import type {
   LogtoSessionApi,
   LogtoSessionClientDescriptor,
@@ -113,7 +114,7 @@ export function ConvexLogtoSessionProvider({
       SecureStore,
     );
     return new SessionAuthEngine({
-      transport: client,
+      transport: defaultSessionTransport(client),
       api: sessionApi,
       storage,
       callbackPath: "",

--- a/packages/convex-logto/src/react-session.provider.test.tsx
+++ b/packages/convex-logto/src/react-session.provider.test.tsx
@@ -30,6 +30,22 @@ vi.mock("convex/react", () => ({
   useQuery: () => undefined,
 }));
 
+// Session actions must reach the deployment over HTTP, never over the app's
+// WebSocket client — see `session-transport.ts`.
+const httpClientUrls: string[] = [];
+vi.mock("convex/browser", () => ({
+  ConvexHttpClient: class {
+    constructor(url: string) {
+      httpClientUrls.push(url);
+    }
+    action(reference: unknown, args: unknown) {
+      if ((reference as { fn: string }).fn === "callback")
+        return callback(args);
+      return Promise.resolve({});
+    }
+  },
+}));
+
 const callback = vi.fn();
 const api = {
   signIn: { fn: "signIn" },
@@ -45,9 +61,8 @@ const api = {
 
 const client = {
   url: "https://example.convex.cloud",
-  action: (reference: unknown, args: unknown) => {
-    if ((reference as { fn: string }).fn === "callback") return callback(args);
-    return Promise.resolve({});
+  action: () => {
+    throw new Error("session action ran on the app's WebSocket client");
   },
 } as never;
 
@@ -88,6 +103,7 @@ beforeEach(() => {
   sessionStorage.clear();
   convexAuthenticated = false;
   authEvents = [];
+  httpClientUrls.length = 0;
   callback.mockReset().mockResolvedValue({
     idToken: "id-token",
     sessionToken: "session-token",
@@ -139,6 +155,24 @@ it("passes the descriptor through to the exchange", async () => {
       client: { platform: "web", browser: "Firefox" },
     }),
   );
+});
+
+it("runs session actions off the app's WebSocket client", async () => {
+  // Convex stops the socket *before* asking for a fresh token, so an action
+  // sent on that client during reauthentication parks forever and the socket is
+  // never restarted. `client.action` throws here to catch a regression.
+  sessionStorage.setItem(
+    "convex-logto:https://example.convex.cloud:txn",
+    JSON.stringify({ state: "st" }),
+  );
+  (
+    window as unknown as { happyDOM: { setURL: (url: string) => void } }
+  ).happyDOM.setURL("http://localhost:5173/callback?code=c&state=st");
+
+  await render(undefined);
+  await vi.waitFor(() => expect(callback).toHaveBeenCalled());
+
+  expect(httpClientUrls).toEqual(["https://example.convex.cloud"]);
 });
 
 it("reports convex_authenticated once Convex accepts the token, and only once", async () => {

--- a/packages/convex-logto/src/react-session.tsx
+++ b/packages/convex-logto/src/react-session.tsx
@@ -21,9 +21,9 @@ import {
 import {
   SessionAuthEngine,
   SessionStorageArea,
-  type SessionTransport,
   type TokenStorageKind,
 } from "./session-client";
+import { defaultSessionTransport } from "./session-transport";
 import type { LogtoAuthEventHandler } from "./auth-events";
 import { createSessionDeviceBinding } from "./session-device";
 import {
@@ -214,7 +214,7 @@ export function ConvexLogtoSessionProvider({
           fetch: cookieFetch,
           deviceBinding: deviceBinding || cookieDeviceBinding,
         })
-      : (client as SessionTransport);
+      : defaultSessionTransport(client);
     return new SessionAuthEngine({
       transport,
       api: sessionApi,

--- a/packages/convex-logto/src/session-transport.test.ts
+++ b/packages/convex-logto/src/session-transport.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { ConvexError } from "convex/values";
+import { makeFunctionReference } from "convex/server";
+import type { ConvexReactClient } from "convex/react";
+import { defaultSessionTransport } from "./session-transport";
+
+const refresh = makeFunctionReference<"action">("auth:refresh");
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+it("sends actions over HTTP instead of the app's client", async () => {
+  // Convex stops the WebSocket before asking for a fresh token; an action sent
+  // on that client parks forever and the socket is never restarted.
+  const fetchStub = vi.fn(() =>
+    Promise.resolve(jsonResponse({ status: "success", value: { ok: true } })),
+  );
+  vi.stubGlobal("fetch", fetchStub);
+  const clientAction = vi.fn();
+  const client = {
+    url: "https://example.convex.cloud",
+    action: clientAction,
+  } as unknown as ConvexReactClient;
+
+  const result = await defaultSessionTransport(client).action(refresh, {
+    sessionToken: "st",
+  });
+
+  expect(result).toEqual({ ok: true });
+  expect(clientAction).not.toHaveBeenCalled();
+  const [url, init] = fetchStub.mock.calls[0] as unknown as [
+    string,
+    { method: string; body: string },
+  ];
+  expect(url).toBe("https://example.convex.cloud/api/action");
+  expect(init.method).toBe("POST");
+  expect(JSON.parse(init.body)).toMatchObject({
+    path: "auth:refresh",
+    args: [{ sessionToken: "st" }],
+  });
+});
+
+it("keeps the ConvexError payload the session error taxonomy reads", async () => {
+  // `terminal` vs `transient` is decided from `error.data`, so the HTTP channel
+  // has to reconstruct it the way the WebSocket client does.
+  vi.stubGlobal("fetch", () =>
+    Promise.resolve(
+      jsonResponse({
+        status: "error",
+        errorMessage: "session revoked",
+        errorData: { kind: "terminal" },
+      }),
+    ),
+  );
+  const client = {
+    url: "https://example.convex.cloud",
+    action: vi.fn(),
+  } as unknown as ConvexReactClient;
+
+  const error = await defaultSessionTransport(client)
+    .action(refresh, { sessionToken: "st" })
+    .catch((thrown: unknown) => thrown);
+
+  expect(error).toBeInstanceOf(ConvexError);
+  expect((error as ConvexError<{ kind: string }>).data).toEqual({
+    kind: "terminal",
+  });
+});
+
+it("falls back to the client when it exposes no deployment URL", async () => {
+  // `ConvexReactClient.url` exists on every supported version — a client-shaped
+  // stub should still mount rather than throw.
+  const clientAction = vi.fn(() => Promise.resolve("client"));
+  const client = { action: clientAction } as unknown as ConvexReactClient;
+
+  const result = await defaultSessionTransport(client).action(refresh, {
+    sessionToken: "st",
+  });
+
+  expect(result).toBe("client");
+  expect(clientAction).toHaveBeenCalledWith(refresh, { sessionToken: "st" });
+});

--- a/packages/convex-logto/src/session-transport.ts
+++ b/packages/convex-logto/src/session-transport.ts
@@ -1,0 +1,64 @@
+// The transport session actions travel over.
+//
+// It must NOT be the app's `ConvexReactClient`. Convex stops the WebSocket
+// *before* asking for a fresh token:
+//
+//   await this.stopSocket();
+//   const token = await this.fetchTokenAndGuardAgainstRace(fetchToken, {
+//     forceRefreshToken: true,
+//   });
+//   ...
+//   this.tryRestartSocket();
+//
+// (convex/browser/sync/authentication_manager.js, `tryToReauthenticate`.)
+//
+// Our `fetchAccessToken` answers that call by running the `refresh` action. On
+// a stopped socket `sendMessage` returns false and the action parks as
+// `"NotSent"` in a promise that never settles, so `tryRestartSocket()` is never
+// reached — and it is the only caller of `tryRestart()`. The app wedges until a
+// reload: queries stop updating, mutations queue silently, and every later
+// refresh merges into the dead promise. A backgrounded tab or a suspended
+// native app reaches that path routinely.
+//
+// Session actions carry their own credential in their arguments and never use
+// Convex auth, so a plain HTTP client is all they need.
+
+import { ConvexHttpClient } from "convex/browser";
+import type { ConvexReactClient } from "convex/react";
+import type { SessionTransport } from "./session-client";
+
+/**
+ * A session transport that reaches the deployment over HTTP, independent of the
+ * app's WebSocket.
+ *
+ * The URL already passed `ConvexReactClient`'s own validation, so revalidating
+ * it here could only reject a deployment the app is otherwise talking to
+ * happily (a proxied origin, a self-hosted backend).
+ */
+export function createDeploymentSessionTransport(
+  url: string,
+): SessionTransport {
+  const client = new ConvexHttpClient(url, {
+    skipConvexDeploymentUrlCheck: true,
+  });
+  return {
+    action: (reference, args) => client.action(reference, args),
+  };
+}
+
+/**
+ * The default transport for a provider: HTTP when the client exposes its URL,
+ * otherwise the client itself.
+ *
+ * `ConvexReactClient.url` exists on every version this package supports; the
+ * fallback only keeps a client-shaped stub working rather than throwing at
+ * mount.
+ */
+export function defaultSessionTransport(
+  client: ConvexReactClient,
+): SessionTransport {
+  const url = (client as { url?: unknown }).url;
+  return typeof url === "string" && url !== ""
+    ? createDeploymentSessionTransport(url)
+    : client;
+}


### PR DESCRIPTION
Closes #153.

Session mode's default transport was the app's own `ConvexReactClient`, so `refresh` rode the very WebSocket Convex stops before it asks for a fresh token:

```js
// convex@1.44.0 browser/sync/authentication_manager.js
await this.stopSocket();
const token = await this.fetchTokenAndGuardAgainstRace(fetchToken, { forceRefreshToken: true });
...
this.tryRestartSocket();   // the only caller of tryRestart()
```

On a stopped socket the action parks as `"NotSent"` in a promise that never settles, so `tryRestartSocket()` is never reached and nothing reconnects. A server-rejected ID token — a tab suspended past the preemptive refetch, a backgrounded native app, clock skew — wedged the app until reload: queries frozen, mutations queued silently, `onAuthError` never called, and every later refresh merged into the dead promise.

`session-transport.ts` now builds the transport from `ConvexHttpClient(client.url)`. Session actions carry their credential in their arguments and never use Convex auth, so they need no socket; `ConvexHttpClient` reconstructs `ConvexError` with `.data`, so the terminal/transient taxonomy and the missing-function feature detection are unchanged. Cookie transport already used `fetch` and is untouched; a client that exposes no `url` still falls back to itself.

**Tests** — `session-transport.test.ts` stubs `fetch` and asserts the request really goes to `/api/action`, that `client.action` is never called, and that a `ConvexError` payload survives the channel. `react-session.provider.test.tsx` now throws from `client.action`, so the callback exchange fails if anything routes back onto the socket; both new assertions fail on `main`.