### PR TITLE
fix(session): contain a failing sessionValid subscription

### DIFF
--- a/.changeset/revocation-watch-containment.md
+++ b/.changeset/revocation-watch-containment.md
@@ -1,0 +1,10 @@
+---
+"convex-logto": patch
+---
+
+Session mode: a failing `sessionValid` subscription no longer blanks the app.
+The revocation watcher sits above every error boundary an app can install, and
+`useQuery` rethrows a query error during render — so a frontend deployed ahead
+of its Convex functions took the whole page down for signed-in users. The error
+is now handled as a value: reactive revocation turns off and reports through
+`onAuthError`, and sessions still expire on their own schedule.

--- a/packages/convex-logto/src/native-session.tsx
+++ b/packages/convex-logto/src/native-session.tsx
@@ -8,7 +8,8 @@ import {
   ConvexProviderWithAuth,
   type ConvexReactClient,
   useConvexAuth,
-  useQuery,
+  useQueries,
+  type RequestForQueries,
 } from "convex/react";
 import {
   createContext,
@@ -214,11 +215,30 @@ function RevocationWatcher() {
   );
   const sessionId = snapshot.sessionId;
   const hasSessionId = sessionId !== null && sessionId.length > 0;
-  const valid = useQuery(
-    sessionApi.sessionValid,
-    hasSessionId ? { sessionId } : "skip",
-  );
+  // `useQueries`, not `useQuery`, because `useQuery` rethrows a query error
+  // during render and this component is a sibling of `{children}` — above every
+  // error boundary the app can install. A frontend deployed ahead of its Convex
+  // functions would otherwise blank the page for every signed-in user instead of
+  // merely losing reactive revocation. Here the error arrives as a value.
+  const queries = useMemo(() => {
+    const request: RequestForQueries = {};
+    if (hasSessionId) {
+      request.valid = { query: sessionApi.sessionValid, args: { sessionId } };
+    }
+    return request;
+  }, [hasSessionId, sessionApi, sessionId]);
+  const valid: unknown = useQueries(queries).valid;
   useEffect(() => {
+    if (valid instanceof Error) {
+      engine.reportWatchFailure(
+        new Error(
+          "convex-logto: reactive revocation is off — the sessionValid query failed. " +
+            "Sessions still expire on their own schedule.",
+          { cause: valid },
+        ),
+      );
+      return;
+    }
     if (hasSessionId && valid === false) engine.handleRevoked();
   }, [engine, hasSessionId, valid]);
   return null;

--- a/packages/convex-logto/src/react-session.provider.test.tsx
+++ b/packages/convex-logto/src/react-session.provider.test.tsx
@@ -21,13 +21,21 @@ import {
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
 let convexAuthenticated = false;
+let sessionValidResult: unknown = undefined;
 vi.mock("convex/react", () => ({
   ConvexProviderWithAuth: ({ children }: { children: ReactNode }) => children,
   useConvexAuth: () => ({
     isLoading: false,
     isAuthenticated: convexAuthenticated,
   }),
-  useQuery: () => undefined,
+  // Mirrors the real hooks: `useQuery` rethrows a query error during render,
+  // `useQueries` hands it back as a value.
+  useQuery: () => {
+    if (sessionValidResult instanceof Error) throw sessionValidResult;
+    return sessionValidResult;
+  },
+  useQueries: (queries: Record<string, unknown>) =>
+    "valid" in queries ? { valid: sessionValidResult } : {},
 }));
 
 // Session actions must reach the deployment over HTTP, never over the app's
@@ -76,6 +84,7 @@ function Probe() {
 
 let root: Root | null = null;
 let authEvents: LogtoAuthEvent[] = [];
+let authErrors: Error[] = [];
 async function render(
   clientDescriptor?: LogtoSessionClientDescriptor,
   onAuthEvent?: (event: LogtoAuthEvent) => void,
@@ -88,6 +97,7 @@ async function render(
         sessionApi={api}
         clientDescriptor={clientDescriptor}
         onAuthEvent={onAuthEvent}
+        onAuthError={(error) => authErrors.push(error)}
       >
         <Probe />
       </ConvexLogtoSessionProvider>,
@@ -102,8 +112,10 @@ beforeEach(() => {
   localStorage.clear();
   sessionStorage.clear();
   convexAuthenticated = false;
+  sessionValidResult = undefined;
   authEvents = [];
   httpClientUrls.length = 0;
+  authErrors = [];
   callback.mockReset().mockResolvedValue({
     idToken: "id-token",
     sessionToken: "session-token",
@@ -173,6 +185,31 @@ it("runs session actions off the app's WebSocket client", async () => {
   await vi.waitFor(() => expect(callback).toHaveBeenCalled());
 
   expect(httpClientUrls).toEqual(["https://example.convex.cloud"]);
+});
+
+it("survives a sessionValid query error instead of blanking the app", async () => {
+  // The watcher is a sibling of `{children}`, above every error boundary an app
+  // can install, so a deployment that has not caught up with the bundle would
+  // take the whole page down. Reactive revocation degrades; sign-in does not.
+  sessionStorage.setItem(
+    "convex-logto:https://example.convex.cloud:txn",
+    JSON.stringify({ state: "st" }),
+  );
+  (
+    window as unknown as { happyDOM: { setURL: (url: string) => void } }
+  ).happyDOM.setURL("http://localhost:5173/callback?code=c&state=st");
+  await render(undefined);
+  await vi.waitFor(() => expect(callback).toHaveBeenCalled());
+
+  sessionValidResult = new Error(
+    "Could not find public function for 'auth:sessionValid'",
+  );
+  await render(undefined);
+
+  expect(capturedSignIn).not.toBeNull();
+  expect(authErrors.map((error) => error.message)).toContainEqual(
+    expect.stringContaining("reactive revocation is off"),
+  );
 });
 
 it("reports convex_authenticated once Convex accepts the token, and only once", async () => {

--- a/packages/convex-logto/src/react-session.tsx
+++ b/packages/convex-logto/src/react-session.tsx
@@ -6,7 +6,8 @@ import {
   ConvexProviderWithAuth,
   type ConvexReactClient,
   useConvexAuth,
-  useQuery,
+  useQueries,
+  type RequestForQueries,
 } from "convex/react";
 import {
   createContext,
@@ -354,11 +355,30 @@ function RevocationWatcher() {
   );
   const sessionId = snapshot.sessionId;
   const hasSessionId = sessionId !== null && sessionId.length > 0;
-  const valid = useQuery(
-    sessionApi.sessionValid,
-    hasSessionId ? { sessionId } : "skip",
-  );
+  // `useQueries`, not `useQuery`, because `useQuery` rethrows a query error
+  // during render and this component is a sibling of `{children}` — above every
+  // error boundary the app can install. A frontend deployed ahead of its Convex
+  // functions would otherwise blank the page for every signed-in user instead of
+  // merely losing reactive revocation. Here the error arrives as a value.
+  const queries = useMemo(() => {
+    const request: RequestForQueries = {};
+    if (hasSessionId) {
+      request.valid = { query: sessionApi.sessionValid, args: { sessionId } };
+    }
+    return request;
+  }, [hasSessionId, sessionApi, sessionId]);
+  const valid: unknown = useQueries(queries).valid;
   useEffect(() => {
+    if (valid instanceof Error) {
+      engine.reportWatchFailure(
+        new Error(
+          "convex-logto: reactive revocation is off — the sessionValid query failed. " +
+            "Sessions still expire on their own schedule.",
+          { cause: valid },
+        ),
+      );
+      return;
+    }
     if (hasSessionId && valid === false) engine.handleRevoked();
   }, [engine, hasSessionId, valid]);
   return null;

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -1438,6 +1438,16 @@ export class SessionAuthEngine {
   }
 
   /** The reactive `sessionValid` subscription pushed `false`: the session was revoked. */
+  /**
+   * Surface a failure the provider detected rather than the engine — today a
+   * broken `sessionValid` subscription. Routed through the same observer as
+   * every other auth error, and deduped by Error identity, so a re-render that
+   * hands back the same object stays quiet.
+   */
+  reportWatchFailure(error: Error): void {
+    this.reportError(error);
+  }
+
   handleRevoked(): void {
     this.authGeneration += 1;
     this.events("revoked");


### PR DESCRIPTION
Closes #154.

`RevocationWatcher` is a sibling of `{children}` inside `ConvexProviderWithAuth`, so its query sits *above* every error boundary an app can install — and `useQuery` rethrows a query error during render (`convex/react/client.js:465-467`). Deploy a frontend bundle before `npx convex deploy` catches up and `api.auth.sessionValid` names a function the deployment does not have: every signed-in user got a blank page rather than merely losing reactive revocation.

Both providers now subscribe with `useQueries`, which returns the error as a value. The watcher reports it through the engine's normal error channel (`reportWatchFailure` → `onAuthError`, deduped by Error identity) and stops watching; sessions still expire on their own schedule, so this is a graceful degradation of a real-time nicety rather than a loss of security. That also makes the `sessionApi` prop doc's rolling-upgrade promise true for `sessionValid`, the one call in that list with neither feature detection nor containment.

**Test** — `react-session.provider.test.tsx` mocks the two hooks the way the real ones behave (`useQuery` rethrows an `Error` result, `useQueries` returns it) and asserts the tree stays mounted and `onAuthError` fires. It fails on `main`.