### PR TITLE
docs: fix four inaccuracies found by an audit sweep

### DIFF
--- a/docs/content/docs/auth-in-your-app.mdx
+++ b/docs/content/docs/auth-in-your-app.mdx
@@ -19,7 +19,10 @@ You usually **don't need a users table**. Every Convex function already has the
 signed-in user's identity from the token — `identity.subject` is their stable Logto
 id — so attach your data to _your own_ tables, keyed by it:
 
-```ts
+```ts title="convex/posts.ts"
+import { v } from "convex/values";
+import { mutation } from "./_generated/server";
+
 export const createPost = mutation({
   args: { body: v.string() },
   handler: async (ctx, { body }) => {

--- a/docs/content/docs/backchannel-logout.mdx
+++ b/docs/content/docs/backchannel-logout.mdx
@@ -80,9 +80,11 @@ The endpoint accepts only a form-encoded POST containing exactly one
 - streams the request body through a 1 MiB application limit.
 
 Verified `jti` values are claimed for 24 hours using the component's existing
-delivery-deduplication table. A retry is answered with the same `200` without
-re-running revocation; if the revocation mutation fails, the claim is released
-so Logto can retry the work.
+delivery-deduplication table. A retry of a delivery that already *completed* is
+answered with the same `200` without re-running revocation; a claim whose work
+never completed is redone, because it may never have committed — revocation is
+idempotent. If the revocation mutation fails, the claim is released so Logto can
+retry the work.
 
 Responses include `Cache-Control: no-store`. Success is always `200`, including
 when no session matched, so the endpoint never reveals session existence.

--- a/docs/content/docs/nextjs.mdx
+++ b/docs/content/docs/nextjs.mdx
@@ -9,6 +9,14 @@ a Server Component and just renders it.
 
 <Callout>Use `NEXT_PUBLIC_CONVEX_URL` — not `import.meta.env`.</Callout>
 
+`configQuery` resolves the Logto endpoint and app id from the Convex deployment,
+so the frontend needs no Logto env vars. Add the query it reads:
+
+```ts title="convex/logto.ts"
+import { logtoConfigQuery } from "convex-logto";
+export const config = logtoConfigQuery();
+```
+
 ## Provider
 
 ```tsx title="app/providers.tsx"

--- a/docs/content/docs/quick-start.mdx
+++ b/docs/content/docs/quick-start.mdx
@@ -150,7 +150,9 @@ to land somewhere else — just register that URI too.
 
 In any Convex function, the Logto identity is already there:
 
-```ts
+```ts title="convex/me.ts"
+import { query } from "./_generated/server";
+
 export const me = query({
   handler: async (ctx) => {
     const identity = await ctx.auth.getUserIdentity();

--- a/docs/content/docs/react-native.mdx
+++ b/docs/content/docs/react-native.mdx
@@ -145,7 +145,9 @@ function Main() {
 In any Convex function, the Logto identity is already there — the same `me` query as
 the web examples:
 
-```ts
+```ts title="convex/me.ts"
+import { query } from "./_generated/server";
+
 export const me = query({
   handler: async (ctx) => {
     const identity = await ctx.auth.getUserIdentity();

--- a/docs/content/docs/session-mode.mdx
+++ b/docs/content/docs/session-mode.mdx
@@ -46,8 +46,8 @@ In Logto Console: **Applications → Create application → Traditional web**. A
 - **Post sign-out redirect URI** → `http://localhost:5173`
 
 Note the **App ID** and **App Secret**. As in bridge mode, the tenant's OIDC
-signing key must be **RSA** (Convex rejects Logto's default ES384 — see
-[Quick start](/docs/quick-start) step 2).
+signing key must be **RSA** (Convex rejects Logto's default ES384 — see the
+warning at the top of the [Quick start](/docs/quick-start)).
 
 ### 2. Install the component
 

--- a/docs/content/docs/tanstack-router.mdx
+++ b/docs/content/docs/tanstack-router.mdx
@@ -6,6 +6,14 @@ description: Mount ConvexLogtoProvider in a TanStack Router SPA — soft navigat
 Finish [Quick start](/docs/quick-start) steps 1–3 (the backend is framework-agnostic),
 then wire the provider and callback the TanStack Router way.
 
+`configQuery` resolves the Logto endpoint and app id from the Convex deployment,
+so the frontend needs no Logto env vars. Add the query it reads:
+
+```ts title="convex/logto.ts"
+import { logtoConfigQuery } from "convex-logto";
+export const config = logtoConfigQuery();
+```
+
 ## Provider
 
 Pass `navigate` so post-sign-in is a soft router navigation, not a full reload.

--- a/docs/content/docs/tanstack-start.mdx
+++ b/docs/content/docs/tanstack-start.mdx
@@ -9,6 +9,14 @@ client boundary to add — use the same single provider you'd use in a SPA.
 ([How it works → Server-side rendering](/docs/how-it-works#server-side-rendering)
 explains the inert-client trick that makes this safe.)
 
+`configQuery` resolves the Logto endpoint and app id from the Convex deployment,
+so the frontend needs no Logto env vars. Add the query it reads:
+
+```ts title="convex/logto.ts"
+import { logtoConfigQuery } from "convex-logto";
+export const config = logtoConfigQuery();
+```
+
 ## Provider
 
 ```tsx title="src/router.tsx"

--- a/docs/content/docs/vite.mdx
+++ b/docs/content/docs/vite.mdx
@@ -8,9 +8,17 @@ condensed reference for the two Vite-specific pieces — where the provider moun
 the callback route.
 
 <Callout>
-Backend setup (Logto app + RSA key, Convex env, `auth.config.ts`, `logtoConfigQuery`)
-is identical for every framework — see [Quick start](/docs/quick-start) steps 1–3.
+Backend setup (Logto app + RSA key, Convex env, `auth.config.ts`) is identical for
+every framework — see [Quick start](/docs/quick-start) steps 1–3.
 </Callout>
+
+`configQuery` resolves the Logto endpoint and app id from the Convex deployment,
+so the frontend needs no Logto env vars. Add the query it reads:
+
+```ts title="convex/logto.ts"
+import { logtoConfigQuery } from "convex-logto";
+export const config = logtoConfigQuery();
+```
 
 ## Provider
 

--- a/docs/content/docs/webhook-sync.mdx
+++ b/docs/content/docs/webhook-sync.mdx
@@ -91,6 +91,8 @@ Create the row from an **authenticated mutation** instead — it runs as the sig
 user, so it always fires — and let the webhook keep it in sync afterward:
 
 ```ts title="convex/users.ts"
+import { mutation } from "./_generated/server";
+
 export const ensureUser = mutation({
   handler: async (ctx) => {
     const identity = await ctx.auth.getUserIdentity();

--- a/packages/convex-logto/README.md
+++ b/packages/convex-logto/README.md
@@ -138,7 +138,9 @@ rejection into its own error state.
 
 In any Convex function, the Logto identity is already there:
 
-```ts
+```ts title="convex/me.ts"
+import { query } from "./_generated/server";
+
 export const me = query({
   handler: async (ctx) => {
     const identity = await ctx.auth.getUserIdentity();


### PR DESCRIPTION
Closes #157.

1. **`api.logto.config` was used but never created.** The four framework pages point at Quick start "steps 1–3" and then pass `configQuery={api.logto.config}`, but `logtoConfigQuery()` only appears in a Callout under step 4 — following the referenced range gives `Property 'logto' does not exist` at build time. Each page now shows the two-line `convex/logto.ts` inline, the way `react-native.mdx` already did.
2. **Wrong pointer for the RSA key requirement.** `session-mode.mdx` sent readers to Quick start "step 2" (the env vars); the rotation lives in the warning above step 1. This is the package's flagship silent failure — `getUserIdentity()` returning `null` — so it now points at the warning.
3. **Titled Convex snippets missing their runtime imports.** `webhook-sync.mdx`'s `convex/users.ts`, `auth-in-your-app.mdx`'s mutation (which also used `v` unimported), and the three `me` query snippets now carry their `_generated/server` / `convex/values` imports and a file title, matching the pattern in `session-mode.mdx`. Schema fragments are deliberately left as fragments.
4. **Back-channel replay handling no longer matched the code.** Since #148 the short-circuit fires only for a *completed* delivery; a claimed-but-incomplete replay deliberately redoes the (idempotent) revocation because it may never have committed.

Docs only. `pnpm build` passes.