### PR TITLE
feat(native-session): add completeSignIn for cold-start deep links

### DIFF
--- a/.changeset/native-deep-link-signin.md
+++ b/.changeset/native-deep-link-signin.md
@@ -1,0 +1,9 @@
+---
+"convex-logto": minor
+---
+
+Native session mode: `useLogtoAuth()` gains `completeSignIn(url)`, for a sign-in
+whose deep link arrives outside the system-browser promise. When the OS reclaims
+the app mid-flow that promise dies with the process, and the user used to come
+back signed in at Logto but signed out in the app, with no error. Wire it to
+Expo `Linking` — anything that is not the app's `redirectUri` is ignored.

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -30,7 +30,7 @@ description: Every export from convex-logto and its web, native, and session-mod
 | `ConvexLogtoProvider` | `convex-logto/native` | React Native / Expo provider (on `@logto/rn`). Same `config` / `configQuery` model; no callback route. |
 | `useLogtoAuth()` | `convex-logto/native` | Native `{ isAuthenticated, isLoading, user, signIn, signOut }`; `signOut()` takes no argument. |
 | `ConvexLogtoSessionProvider` | `convex-logto/native-session` | React Native / Expo session provider using SecureStore + the system browser. |
-| `useLogtoAuth()` | `convex-logto/native-session` | Native session `{ isAuthenticated, isLoading, user, signIn, signOut, signOutEverywhere, listSessions, renameSession, revokeSession }`; no device-binding surface. |
+| `useLogtoAuth()` | `convex-logto/native-session` | Native session `{ isAuthenticated, isLoading, user, signIn, completeSignIn, signOut, signOutEverywhere, listSessions, renameSession, revokeSession }`; no device-binding surface. |
 
 ## Backend
 
@@ -442,10 +442,13 @@ device-binding option.
 | `onAuthEvent` | — | Opt-in phase timings (see [Auth phase events](#auth-phase-events)). Absent means nothing is measured. |
 
 `useLogtoAuth()` returns `{ isAuthenticated, isLoading, user, signIn,
-signOut, signOutEverywhere, listSessions, renameSession, revokeSession }`, with
-the same session-management semantics as web session mode and an optional
-`clientDescriptor` prop for the device description shown in the list.
-`signIn()` opens and completes the system-browser flow in place.
+completeSignIn, signOut, signOutEverywhere, listSessions, renameSession,
+revokeSession }`, with the same session-management semantics as web session mode
+and an optional `clientDescriptor` prop for the device description shown in the
+list. `signIn()` opens and completes the system-browser flow in place.
+`completeSignIn(url)` finishes a sign-in whose deep link came back *outside*
+that flow — see [Recovering a reclaimed
+sign-in](/docs/react-native#recovering-a-reclaimed-sign-in).
 `signOut({ postLogoutRedirectUri?, federated? })` clears SecureStore and revokes
 the server session, then ends Logto browser SSO unless `federated: false`.
 `signOutEverywhere({ postLogoutRedirectUri? })` clears SecureStore, kills every

--- a/docs/content/docs/react-native.mdx
+++ b/docs/content/docs/react-native.mdx
@@ -261,6 +261,37 @@ export default function App() {
 the single-use state stashed before the browser opened, and exchanges the code
 in place. There is no `/callback` screen or router integration.
 
+### Recovering a reclaimed sign-in
+
+That whole flow lives in one in-memory promise. If the OS reclaims the app while
+Logto has the browser — routine on a low-memory Android device — the promise dies
+with the process and the redirect arrives as a cold-start deep link instead. Hand
+it to `completeSignIn(url)` and the exchange finishes as normal; without it the
+user comes back signed in at Logto and signed out in the app, with no error.
+(Web needs no equivalent: the callback is in the URL, so the provider re-reads it
+on the next mount.)
+
+```tsx title="Main.tsx"
+import * as Linking from "expo-linking";
+import { useEffect } from "react";
+import { useLogtoAuth } from "convex-logto/native-session";
+
+const { completeSignIn } = useLogtoAuth();
+useEffect(() => {
+  void Linking.getInitialURL().then((url) => url && completeSignIn(url));
+  const subscription = Linking.addEventListener("url", ({ url }) => {
+    void completeSignIn(url);
+  });
+  return () => subscription.remove();
+}, [completeSignIn]);
+```
+
+Pass every deep link through — anything that is not this app's `redirectUri` is
+ignored. A user who *cancelled* in the browser is deliberately not recoverable
+this way: cancelling discards the OIDC state so a later deep link cannot replay
+it. Tapping Sign in again is instant, since Logto's browser SSO session is still
+there.
+
 Native session mode keeps the rotating session token, OAuth state stash, and
 **short-lived ID token** in deployment-namespaced SecureStore. Persisting the ID
 token is a deliberate cold-start choice: while it remains fresh, the app can

--- a/packages/convex-logto/.oxlintrc.json
+++ b/packages/convex-logto/.oxlintrc.json
@@ -76,6 +76,7 @@
     {
       "files": [
         "src/native.bridge.test.tsx",
+        "src/native-session.provider.test.tsx",
         "src/react.bridge.test.tsx",
         "src/react.config-loading.test.tsx",
         "src/react-session.provider.test.tsx"

--- a/packages/convex-logto/src/native-session.provider.test.tsx
+++ b/packages/convex-logto/src/native-session.provider.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment happy-dom
+//
+// Native sign-in lives entirely in one in-memory promise from
+// `openAuthSessionAsync`. When the OS reclaims the app mid-flow that promise
+// dies with the process and the redirect arrives as a cold-start deep link
+// instead — `completeSignIn` is the only way back into the exchange.
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import {
+  getFunctionName,
+  makeFunctionReference,
+  type FunctionReference,
+} from "convex/server";
+import type { LogtoSessionApi } from "./session";
+import { ConvexLogtoSessionProvider, useLogtoAuth } from "./native-session";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const store = new Map<string, string>();
+vi.mock("expo-secure-store", () => ({
+  isAvailableAsync: () => Promise.resolve(true),
+  getItemAsync: (key: string) => Promise.resolve(store.get(key) ?? null),
+  setItemAsync: (key: string, value: string) => {
+    store.set(key, value);
+    return Promise.resolve();
+  },
+  deleteItemAsync: (key: string) => {
+    store.delete(key);
+    return Promise.resolve();
+  },
+}));
+
+// Never resolves: the app was reclaimed while Logto had the browser.
+const openAuthSessionAsync = vi.fn(
+  (_url: string, _returnUrl: string) => new Promise<never>(() => {}),
+);
+vi.mock("expo-web-browser", () => ({
+  openAuthSessionAsync: (url: string, returnUrl: string) =>
+    openAuthSessionAsync(url, returnUrl),
+}));
+
+vi.mock("convex/react", () => ({
+  ConvexProviderWithAuth: ({ children }: { children: unknown }) => children,
+  useConvexAuth: () => ({ isLoading: false, isAuthenticated: false }),
+  useQueries: () => ({}),
+}));
+
+const signInAction = vi.fn(() =>
+  Promise.resolve({ url: "https://logto.example.com/oidc/auth?state=st" }),
+);
+const callbackAction = vi.fn((_args: unknown) =>
+  Promise.resolve({
+    idToken: "id-token",
+    sessionToken: "session-token",
+    sessionId: "session-1",
+  }),
+);
+vi.mock("convex/browser", () => ({
+  ConvexHttpClient: class {
+    action(reference: FunctionReference<"action">, args: unknown) {
+      const name = getFunctionName(reference);
+      if (name === "auth:signIn") return signInAction();
+      if (name === "auth:callback") return callbackAction(args);
+      return Promise.resolve({});
+    }
+  },
+}));
+
+const api = {
+  signIn: makeFunctionReference<"action">("auth:signIn"),
+  callback: makeFunctionReference<"action">("auth:callback"),
+  refresh: makeFunctionReference<"action">("auth:refresh"),
+  signOut: makeFunctionReference<"action">("auth:signOut"),
+  signOutEverywhere: makeFunctionReference<"action">("auth:signOutEverywhere"),
+  listSessions: makeFunctionReference<"action">("auth:listSessions"),
+  renameSession: makeFunctionReference<"action">("auth:renameSession"),
+  revokeSession: makeFunctionReference<"action">("auth:revokeSession"),
+  sessionValid: makeFunctionReference<"query">("auth:sessionValid"),
+} as unknown as LogtoSessionApi;
+
+const client = { url: "https://example.convex.cloud" } as never;
+
+type AuthApi = ReturnType<typeof useLogtoAuth>;
+let capturedApi: AuthApi | null = null;
+function Probe() {
+  capturedApi = useLogtoAuth();
+  return null;
+}
+
+let root: Root | null = null;
+async function render() {
+  root ??= createRoot(document.createElement("div"));
+  await act(async () => {
+    root!.render(
+      <ConvexLogtoSessionProvider
+        client={client}
+        sessionApi={api}
+        redirectUri="myapp://callback"
+      >
+        <Probe />
+      </ConvexLogtoSessionProvider>,
+    );
+  });
+}
+
+beforeEach(() => {
+  store.clear();
+  signInAction.mockClear();
+  callbackAction.mockClear();
+  openAuthSessionAsync.mockClear();
+});
+
+afterEach(async () => {
+  if (root) await act(async () => root!.unmount());
+  root = null;
+  capturedApi = null;
+});
+
+it("finishes a sign-in whose deep link outlived the browser promise", async () => {
+  await render();
+  await act(async () => {
+    void capturedApi!.signIn();
+  });
+  await vi.waitFor(() => expect(openAuthSessionAsync).toHaveBeenCalled());
+
+  await act(async () => {
+    await capturedApi!.completeSignIn("myapp://callback?code=c&state=st");
+  });
+
+  expect(callbackAction).toHaveBeenCalledWith(
+    expect.objectContaining({ code: "c", state: "st" }),
+  );
+});
+
+it("ignores a deep link that is not this app's redirect", async () => {
+  await render();
+  await act(async () => {
+    void capturedApi!.signIn();
+  });
+  await vi.waitFor(() => expect(openAuthSessionAsync).toHaveBeenCalled());
+
+  await act(async () => {
+    await capturedApi!.completeSignIn("myapp://posts/42?code=c&state=st");
+  });
+
+  expect(callbackAction).not.toHaveBeenCalled();
+});

--- a/packages/convex-logto/src/native-session.tsx
+++ b/packages/convex-logto/src/native-session.tsx
@@ -37,6 +37,7 @@ import type {
 const SessionContext = createContext<{
   engine: SessionAuthEngine;
   sessionApi: LogtoSessionApi;
+  redirectUri: string;
 } | null>(null);
 
 function useSessionContext(caller: string) {
@@ -139,8 +140,8 @@ export function ConvexLogtoSessionProvider({
   }, [engine]);
 
   const contextValue = useMemo(
-    () => ({ engine, sessionApi }),
-    [engine, sessionApi],
+    () => ({ engine, sessionApi, redirectUri }),
+    [engine, sessionApi, redirectUri],
   );
 
   return (
@@ -259,6 +260,33 @@ export type LogtoSessionAuth = {
    */
   signIn: () => Promise<void>;
   /**
+   * Finish a sign-in whose deep link came back outside the system-browser
+   * promise — the OS reclaimed the app while Logto had it, so the app
+   * cold-started on the redirect instead of resuming.
+   *
+   * Web needs no equivalent: the callback lives in the URL and the provider
+   * re-reads it on the next mount. Native's flow otherwise lives entirely in one
+   * in-memory promise, so without this the user returns signed in at Logto and
+   * signed out in the app, with no error.
+   *
+   * Wire it to both Expo `Linking` entry points and pass the URL through
+   * unchanged; anything that is not this app's `redirectUri` is ignored:
+   *
+   * ```tsx
+   * useEffect(() => {
+   *   void Linking.getInitialURL().then((url) => url && completeSignIn(url));
+   *   const sub = Linking.addEventListener("url", ({ url }) => {
+   *     void completeSignIn(url);
+   *   });
+   *   return () => sub.remove();
+   * }, [completeSignIn]);
+   * ```
+   *
+   * A user who cancelled in the browser is not recoverable this way, by design:
+   * cancelling discards the OIDC state so a later deep link cannot replay it.
+   */
+  completeSignIn: (url: string) => Promise<void>;
+  /**
    * Revoke the session, clear SecureStore, and end browser SSO by default.
    * Rejects with `SessionSignOutError` when durable cleanup fails twice; its
    * `serverSessionStatus` distinguishes a successful revocation from a dual failure.
@@ -300,7 +328,7 @@ export type LogtoSessionAuth = {
 };
 
 export function useLogtoAuth(): LogtoSessionAuth {
-  const { engine } = useSessionContext("useLogtoAuth");
+  const { engine, redirectUri } = useSessionContext("useLogtoAuth");
   const { isAuthenticated, isLoading } = useConvexAuth();
   const snapshot = useSyncExternalStore(
     engine.subscribe,
@@ -308,6 +336,15 @@ export function useLogtoAuth(): LogtoSessionAuth {
     engine.getServerSnapshot,
   );
   const signIn = useCallback(() => engine.signIn(), [engine]);
+  const completeSignIn = useCallback(
+    async (url: string) => {
+      // Apps hand over every deep link they receive, most of which are their
+      // own routes. Only this flow's redirect can carry an OIDC response.
+      if (!url.startsWith(redirectUri)) return;
+      await engine.completeSignIn(url, redirectUri);
+    },
+    [engine, redirectUri],
+  );
   const signOut = useCallback(
     (options?: { postLogoutRedirectUri?: string; federated?: boolean }) =>
       engine.signOut(options),
@@ -334,6 +371,7 @@ export function useLogtoAuth(): LogtoSessionAuth {
       isLoading,
       user: isAuthenticated ? snapshot.user : undefined,
       signIn,
+      completeSignIn,
       signOut,
       signOutEverywhere,
       listSessions,
@@ -345,6 +383,7 @@ export function useLogtoAuth(): LogtoSessionAuth {
       isLoading,
       snapshot.user,
       signIn,
+      completeSignIn,
       signOut,
       signOutEverywhere,
       listSessions,


### PR DESCRIPTION
Closes #156. Stacked on #161 — retarget to `main` once that merges.

Native sign-in lives entirely in the one in-memory promise returned by `openAuthSessionAsync`. When the OS reclaims the app while Logto has the browser — routine on a low-memory Android device — that promise dies with the process and Logto's redirect arrives as a cold-start deep link instead. The user came back **signed in at Logto and signed out in the app, with no error and no `onAuthError`**; tapping Sign in again worked instantly via SSO, so it read as "the button did nothing that one time". Web survives the same interruption because the callback is in the URL.

`useLogtoAuth()` now returns `completeSignIn(url)`, which filters to this flow's `redirectUri` and hands the rest to the engine's `completeSignIn` — the method already documented as "Public for deep-link adapters". No new dependency: the app wires Expo `Linking` itself, which the Expo docs section now shows.

A cancelled browser session is deliberately *not* recoverable this way. `signInInner` discards the OIDC state on cancel precisely so a later deep link cannot replay it, and that stays as it is; only a process death — where the engine never ran that line — leaves the stash intact in SecureStore.

**Tests** — a new `native-session.provider.test.tsx` (the native session provider had no provider-level coverage). `openAuthSessionAsync` returns a promise that never resolves, which is exactly what the engine observes when the process is reclaimed; the deep link then completes the exchange, and a link that is not the redirect is ignored. Both fail on `main`.