### PR TITLE
fix(session): keep one engine across seed and cookie-fetch changes

### DIFF
--- a/.changeset/engine-seed-stability.md
+++ b/.changeset/engine-seed-stability.md
@@ -1,0 +1,9 @@
+---
+"convex-logto": patch
+---
+
+Session mode: re-seeding SSR state or passing an inline `cookieTransport.fetch`
+no longer rebuilds the auth engine. `getInitialToken()` mints a fresh ID token on
+every call, so any `router.invalidate()` handed the provider a new seed and
+restarted the mount state machine — flashing signed-out, orphaning an in-flight
+callback exchange, and leaving the `convex_authenticated` span open forever.

--- a/packages/convex-logto/src/native-session.tsx
+++ b/packages/convex-logto/src/native-session.tsx
@@ -191,10 +191,13 @@ function useAuthFromSession() {
  */
 function ConvexAuthPhaseWatcher({ engine }: { engine: SessionAuthEngine }) {
   const { isAuthenticated } = useConvexAuth();
-  const reported = useRef(false);
+  // Keyed by engine, not a bare boolean: a replaced engine emits its own
+  // `bootstrap_start`, and a `reported` that survived it would leave that span
+  // open forever.
+  const reportedFor = useRef<SessionAuthEngine | null>(null);
   useEffect(() => {
-    if (!isAuthenticated || reported.current) return;
-    reported.current = true;
+    if (!isAuthenticated || reportedFor.current === engine) return;
+    reportedFor.current = engine;
     engine.reportConvexAuthenticated();
   }, [engine, isAuthenticated]);
   return null;

--- a/packages/convex-logto/src/react-session.provider.test.tsx
+++ b/packages/convex-logto/src/react-session.provider.test.tsx
@@ -8,10 +8,16 @@
 import { act, type ReactNode } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import {
+  getFunctionName,
+  makeFunctionReference,
+  type FunctionReference,
+} from "convex/server";
 import type { LogtoSessionApi } from "./session";
 import {
   ConvexLogtoSessionProvider,
   useLogtoAuth,
+  type ConvexLogtoSessionProviderProps,
   type LogtoAuthEvent,
   type LogtoSessionClientDescriptor,
 } from "./react-session";
@@ -46,25 +52,26 @@ vi.mock("convex/browser", () => ({
     constructor(url: string) {
       httpClientUrls.push(url);
     }
-    action(reference: unknown, args: unknown) {
-      if ((reference as { fn: string }).fn === "callback")
-        return callback(args);
+    action(reference: FunctionReference<"action">, args: unknown) {
+      if (getFunctionName(reference) === "auth:callback") return callback(args);
       return Promise.resolve({});
     }
   },
 }));
 
 const callback = vi.fn();
+// Real references, not stubs: the cookie transport maps every one of them
+// through `getFunctionName`.
 const api = {
-  signIn: { fn: "signIn" },
-  callback: { fn: "callback" },
-  refresh: { fn: "refresh" },
-  signOut: { fn: "signOut" },
-  signOutEverywhere: { fn: "signOutEverywhere" },
-  listSessions: { fn: "listSessions" },
-  renameSession: { fn: "renameSession" },
-  revokeSession: { fn: "revokeSession" },
-  sessionValid: { fn: "sessionValid" },
+  signIn: makeFunctionReference<"action">("auth:signIn"),
+  callback: makeFunctionReference<"action">("auth:callback"),
+  refresh: makeFunctionReference<"action">("auth:refresh"),
+  signOut: makeFunctionReference<"action">("auth:signOut"),
+  signOutEverywhere: makeFunctionReference<"action">("auth:signOutEverywhere"),
+  listSessions: makeFunctionReference<"action">("auth:listSessions"),
+  renameSession: makeFunctionReference<"action">("auth:renameSession"),
+  revokeSession: makeFunctionReference<"action">("auth:revokeSession"),
+  sessionValid: makeFunctionReference<"query">("auth:sessionValid"),
 } as unknown as LogtoSessionApi;
 
 const client = {
@@ -88,6 +95,7 @@ let authErrors: Error[] = [];
 async function render(
   clientDescriptor?: LogtoSessionClientDescriptor,
   onAuthEvent?: (event: LogtoAuthEvent) => void,
+  extra?: Partial<ConvexLogtoSessionProviderProps>,
 ) {
   root ??= createRoot(document.createElement("div"));
   await act(async () => {
@@ -98,6 +106,7 @@ async function render(
         clientDescriptor={clientDescriptor}
         onAuthEvent={onAuthEvent}
         onAuthError={(error) => authErrors.push(error)}
+        {...extra}
       >
         <Probe />
       </ConvexLogtoSessionProvider>,
@@ -146,6 +155,49 @@ it("keeps one engine across an inline descriptor's fresh object identity", async
   const first = capturedSignIn;
 
   await render({ platform: "web" });
+
+  expect(capturedSignIn).toBe(first);
+});
+
+it("keeps one engine when the SSR seed is re-issued", async () => {
+  // `getInitialToken()` rotates the cookie and mints a fresh ID token per call,
+  // so every re-run of the root loader (`router.invalidate()`, a reload) hands
+  // back a different string. That is a new seed, not a new session.
+  const cookieFetch = vi.fn(() => Promise.resolve(new Response("{}")));
+  const cookieTransport = { endpoint: "/api/logto", fetch: cookieFetch };
+  await render(undefined, undefined, {
+    cookieTransport,
+    initialToken: "seed-1",
+    initialSessionId: "session-1",
+  });
+  const first = capturedSignIn;
+
+  await render(undefined, undefined, {
+    cookieTransport,
+    initialToken: "seed-2",
+    initialSessionId: "session-1",
+  });
+
+  expect(capturedSignIn).toBe(first);
+});
+
+it("keeps one engine across an inline cookieTransport fetch", async () => {
+  // `cookieTransport={{ endpoint, fetch: (u, i) => fetch(u, i) }}` is a
+  // documented option; an inline arrow changes identity on every render.
+  await render(undefined, undefined, {
+    cookieTransport: {
+      endpoint: "/api/logto",
+      fetch: () => Promise.resolve(new Response("{}")),
+    },
+  });
+  const first = capturedSignIn;
+
+  await render(undefined, undefined, {
+    cookieTransport: {
+      endpoint: "/api/logto",
+      fetch: () => Promise.resolve(new Response("{}")),
+    },
+  });
 
   expect(capturedSignIn).toBe(first);
 });

--- a/packages/convex-logto/src/react-session.tsx
+++ b/packages/convex-logto/src/react-session.tsx
@@ -204,6 +204,27 @@ export function ConvexLogtoSessionProvider({
   // ref that still held the previous render's handler.
   onAuthEventRef.current = onAuthEvent;
 
+  // Seed values, not dependencies. `handler.getInitialToken()` rotates the
+  // cookie and mints a fresh ID token on every call, so re-running the SSR
+  // loader — `router.invalidate()`, a reload — hands back a different string
+  // every time. Rebuilding the engine for that abandons an in-flight exchange,
+  // spends the callback's single-use transaction under its replacement, and
+  // renders `isAuthenticated: false` with `isLoading: false` for a full
+  // re-auth round trip: a real signed-out flash.
+  const seedRef = useRef({ initialToken, initialSessionId });
+  seedRef.current = { initialToken, initialSessionId };
+  // Same reason: `cookieTransport={{ fetch: (u, i) => fetch(u, i) }}` is a
+  // documented option, and an inline arrow changes identity on every render.
+  const cookieFetchRef = useRef(cookieFetch);
+  cookieFetchRef.current = cookieFetch;
+  const cookieFetchProxy = useCallback<typeof fetch>(
+    (input, init) =>
+      cookieFetchRef.current
+        ? cookieFetchRef.current(input, init)
+        : globalThis.fetch(input, init),
+    [],
+  );
+
   const engine = useMemo(() => {
     // Namespace storage by deployment so two dev apps on the same origin
     // (localhost) don't cross-read each other's sessions.
@@ -212,7 +233,7 @@ export function ConvexLogtoSessionProvider({
     const transport = usesCookieTransport
       ? createLogtoSessionCookieTransport(sessionApi, {
           endpoint: cookieEndpoint,
-          fetch: cookieFetch,
+          fetch: cookieFetchProxy,
           deviceBinding: deviceBinding || cookieDeviceBinding,
         })
       : defaultSessionTransport(client);
@@ -222,12 +243,15 @@ export function ConvexLogtoSessionProvider({
       storage,
       callbackPath,
       afterSignIn,
-      initialToken: initialToken ?? undefined,
+      initialToken: seedRef.current.initialToken ?? undefined,
       // Cookie mode always writes a non-secret marker. That both overwrites a
       // legacy localStorage credential and makes reload attempt the /token
       // route even though JavaScript cannot inspect the HttpOnly cookie.
       initialSession: usesCookieTransport
-        ? createCookieSessionMarker(storage.readSession(), initialSessionId)
+        ? createCookieSessionMarker(
+            storage.readSession(),
+            seedRef.current.initialSessionId,
+          )
         : undefined,
       // The credential is an HttpOnly cookie only the server can expire, so a
       // failed revoke is a failed sign-out — not something to swallow.
@@ -256,11 +280,9 @@ export function ConvexLogtoSessionProvider({
     afterSignIn,
     usesCookieTransport,
     cookieEndpoint,
-    cookieFetch,
+    cookieFetchProxy,
     cookieDeviceBinding,
     deviceBinding,
-    initialToken,
-    initialSessionId,
   ]);
 
   useEffect(() => {
@@ -332,10 +354,13 @@ function useAuthFromSession() {
  */
 function ConvexAuthPhaseWatcher({ engine }: { engine: SessionAuthEngine }) {
   const { isAuthenticated } = useConvexAuth();
-  const reported = useRef(false);
+  // Keyed by engine, not a bare boolean: a replaced engine emits its own
+  // `bootstrap_start`, and a `reported` that survived it would leave that span
+  // open forever.
+  const reportedFor = useRef<SessionAuthEngine | null>(null);
   useEffect(() => {
-    if (!isAuthenticated || reported.current) return;
-    reported.current = true;
+    if (!isAuthenticated || reportedFor.current === engine) return;
+    reportedFor.current = engine;
     engine.reportConvexAuthenticated();
   }, [engine, isAuthenticated]);
   return null;


### PR DESCRIPTION
Closes #155. Reopened from #161, which GitHub closed when its base branch was deleted on merge.

The engine `useMemo` depended on `initialToken`, `initialSessionId` and `cookieFetch`, all of which change while a session is live:

- `handler.getInitialToken()` **rotates the cookie and mints a fresh ID token on every call** (`session-cookie.ts:808-826`), so the documented TanStack Start SSR seed hands back a different string every time the root loader re-runs — `router.invalidate()`, a reload.
- `cookieTransport={{ endpoint, fetch: (u, i) => fetch(u, i) }}` is a documented option, and an inline arrow changes identity on every render.

Rebuilding the engine there does three things the file's own comments say the refs exist to prevent: `fetchAccessToken` gets a new identity, so `ConvexProviderWithAuth`'s cleanup renders `isAuthenticated: false` with `isLoading: false` for a full re-auth round trip (a real signed-out flash, and every authenticated query re-subscribes); an in-flight exchange is orphaned and its replacement finds the single-use transaction already spent ("this sign-in callback doesn't match a sign-in started in this browser tab"); and the new engine's `bootstrap_start` never closes, because `ConvexAuthPhaseWatcher`'s `reported` ref outlived the engine it belonged to.

All three are now held the way `onAuthEvent` already was: seeds through a ref read at construction, the cookie `fetch` behind a stable proxy that reads the current one, and the phase watcher keyed by engine rather than by a bare boolean (both providers).

**Tests** — two engine-identity tests: re-issuing the SSR seed, and an inline `cookieTransport.fetch`. Both fail on `main`. The `sessionApi` fixture now uses real `makeFunctionReference`s, because the cookie transport maps every export through `getFunctionName`.