### PR TITLE
fix(session): report what actually failed a sign-in

### DIFF
--- a/.changeset/sign-in-failure-diagnosis.md
+++ b/.changeset/sign-in-failure-diagnosis.md
@@ -1,0 +1,10 @@
+---
+"convex-logto": patch
+---
+
+Session mode: a failed sign-in now reports what actually went wrong. The
+component consumes the sign-in transaction before it contacts Logto, so the
+client's retry could only ever come back with `transaction_not_found` — and a
+wrong `LOGTO_CLIENT_SECRET` was reported as a stale or replayed callback. The
+exchange is no longer retried, and a token-endpoint failure on the sign-in path
+keeps Logto's own error code and message.

--- a/packages/convex-logto/src/component/core.ts
+++ b/packages/convex-logto/src/component/core.ts
@@ -644,6 +644,31 @@ export function transient(
  * next. A response we could not parse is a different case — the outcome is
  * unknown and `outcomeUnknown` handles it.
  */
+/**
+ * Re-classify a token-endpoint failure that happened on the *sign-in* path.
+ *
+ * {@link classifyTokenEndpointFailure} answers for `refresh`, where transient is
+ * the safe default because terminal deletes the session row. Sign-in has no
+ * session to lose, and by the time Logto is contacted the transaction row is
+ * already consumed and the authorization code spent — so a retry can only find
+ * nothing and report `transaction_not_found`, burying the diagnosis Logto just
+ * gave us. Keep the code and the message; only the verdict changes.
+ */
+export function asSpentAuthorizationCode(
+  error: unknown,
+): ConvexError<SessionErrorData> {
+  const suffix =
+    " Start sign-in again: the authorization code is spent, so this attempt " +
+    "cannot be retried.";
+  if (error instanceof ConvexError && isSessionErrorData(error.data)) {
+    return terminal(error.data.code, `${error.data.message}${suffix}`);
+  }
+  return terminal(
+    "sign_in_failed",
+    `Could not exchange the authorization code with Logto.${suffix}`,
+  );
+}
+
 export function asDeploymentFault(
   error: unknown,
 ): ConvexError<SessionErrorData> {

--- a/packages/convex-logto/src/component/lib.test.ts
+++ b/packages/convex-logto/src/component/lib.test.ts
@@ -903,6 +903,44 @@ describe("bounded token endpoint", () => {
     }
   });
 
+  it("reports Logto's own rejection on the sign-in path, terminally", async () => {
+    // `classifyTokenEndpointFailure` calls this transient for refresh's sake.
+    // Here the transaction is already consumed, so a retry can only report
+    // `transaction_not_found` — and the operator never learns their client
+    // secret is wrong.
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ error: "invalid_client" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const runMutation = vi.fn().mockResolvedValueOnce({
+      codeVerifier: "verifier",
+      returnTo: undefined,
+    });
+    try {
+      await expect(
+        exchangeActionHandler(
+          { runQuery: () => Promise.resolve(null), runMutation },
+          {
+            ...refreshArgs,
+            code: "code",
+            state: "state",
+            redirectUri: "https://app.example.com/callback",
+          },
+        ),
+      ).rejects.toMatchObject({
+        data: {
+          kind: "terminal",
+          code: "invalid_client",
+          message: expect.stringContaining("LOGTO_CLIENT_SECRET"),
+        },
+      });
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
   it("releases the claim when Logto answered but rotated nothing", async () => {
     // Logto rotates a confidential-client refresh token only at >=70% TTL, so
     // most refreshes return none — the stored token stays current, which is what

--- a/packages/convex-logto/src/component/lib.ts
+++ b/packages/convex-logto/src/component/lib.ts
@@ -19,6 +19,7 @@ import {
   TRANSACTION_TTL_MS,
   WEBHOOK_DELIVERY_GC_AFTER_MS,
   asDeploymentFault,
+  asSpentAuthorizationCode,
   assertDeviceProof,
   buildAuthorizeUrl,
   buildEndSessionUrl,
@@ -576,12 +577,21 @@ export const exchange = action({
         now: Date.now(),
       },
     );
-    const tokens = await tokenEndpoint(args, {
-      grant_type: "authorization_code",
-      code: args.code,
-      redirect_uri: args.redirectUri,
-      code_verifier: transaction.codeVerifier,
-    });
+    let tokens: Awaited<ReturnType<typeof tokenEndpoint>>;
+    try {
+      tokens = await tokenEndpoint(args, {
+        grant_type: "authorization_code",
+        code: args.code,
+        redirect_uri: args.redirectUri,
+        code_verifier: transaction.codeVerifier,
+      });
+    } catch (error) {
+      // `tokenEndpoint` classifies for refresh, where transient is the safe
+      // default. Here the transaction is already consumed, so a retry finds
+      // nothing and reports `transaction_not_found` — losing Logto's own answer,
+      // which is usually the one an operator needs.
+      throw asSpentAuthorizationCode(error);
+    }
     if (!tokens.tokenResponse || tokens.id_token === undefined) {
       // Sign-in cannot retry: the authorization code is spent either way, so
       // there is nothing to gain by calling this transient.

--- a/packages/convex-logto/src/session-client.test.ts
+++ b/packages/convex-logto/src/session-client.test.ts
@@ -883,6 +883,24 @@ describe("callback", () => {
     await vi.waitFor(() => expect(navigate).toHaveBeenCalledWith("/"));
   });
 
+  it("does not retry a transient exchange failure", async () => {
+    // The component consumes the transaction row before it contacts Logto, so a
+    // second attempt can only report `transaction_not_found` — replacing the
+    // diagnosis Logto just gave with a stale-callback one.
+    const { engine, storage, handlers, onAuthError } = makeHarness();
+    setURL("http://localhost:5173/callback?code=c1&state=s1");
+    storage.stashTransaction({ state: "s1" });
+    handlers.callback.mockRejectedValue(transientError());
+
+    engine.start();
+    expect((await settled(engine)).status).toBe("unauthenticated");
+
+    expect(handlers.callback).toHaveBeenCalledTimes(1);
+    expect(onAuthError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining("down") }),
+    );
+  });
+
   it("benign ?error=access_denied → back to the app without reporting an error", async () => {
     const { engine, navigate, onAuthError } = makeHarness();
     setURL("http://localhost:5173/callback?error=access_denied&state=s1");

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -741,14 +741,19 @@ export class SessionAuthEngine {
       );
       // Nothing has been minted yet, so simply abandoning the code is enough.
       if (generation !== this.authGeneration) return;
-      const result = await this.retrying(() =>
-        this.options.transport.action(this.options.api.callback, {
+      // Deliberately not `retrying`: the exchange is single-use. The component
+      // consumes the transaction row before it contacts Logto, so a second
+      // attempt can only report `transaction_not_found` — replacing whatever
+      // actually went wrong with a stale-callback diagnosis.
+      const result = await this.options.transport.action(
+        this.options.api.callback,
+        {
           code,
           state,
           redirectUri,
           ...(devicePublicKey === undefined ? {} : { devicePublicKey }),
           ...(client === undefined ? {} : { client }),
-        }),
+        },
       );
       if (generation !== this.authGeneration) {
         await this.revokeAbandonedSession(result.sessionToken);


### PR DESCRIPTION
Closes #165, closes #168.

Two halves of the same bug — the one that turns "sign-in is broken" into an unanswerable support ticket.

**The client retried a single-use exchange** (`session-client.ts:744`). `exchange` consumes the transaction row and commits *before* it contacts Logto (`component/lib.ts:571-584`), so attempt 2 can only find nothing and throw `terminal("transaction_not_found", "No pending sign-in for this state — the callback is stale, replayed, or the sign-in expired.")`. `retrying` throws the last error, so that is what reaches `onAuthError`. The exchange is now called once.

**The server classified the failure for the wrong caller.** `tokenEndpoint` throws `classifyTokenEndpointFailure(...)` verbatim for both callers (`lib.ts:467`), and that classifier is written for refresh, where transient is the safe default because terminal deletes the session row: `invalid_client`, a bare 400/401, 429 and every 5xx all come back transient (`core.ts:687-756`). The file already states the rule — *"Sign-in has no session to lose and cannot retry a spent authorization code, so it fails terminally"* — but applied it only to the `!tokenResponse` branch. `asSpentAuthorizationCode` now re-wraps a sign-in-path failure as terminal, keeping Logto's code and message and appending why a retry cannot help.

Net effect for the most common session-mode misconfiguration: a stale `LOGTO_CLIENT_SECRET` used to surface as *"the callback is stale, replayed, or the sign-in expired. Start sign-in again"* — forever. It now surfaces as *"Logto rejected this deployment's own request (invalid_client) — check LOGTO_APP_ID / LOGTO_CLIENT_SECRET / LOGTO_ENDPOINT."*

The `AGENTS.md` invariant that a deployment misconfiguration must stay transient is about refresh, where terminal deletes rows. Sign-in has no session yet to lose, and this path is unreachable once a session exists.

**Tests** — the component test drives `exchange` with a mocked `401 {"error":"invalid_client"}` and asserts a terminal error that still names `LOGTO_CLIENT_SECRET`; the client test asserts the callback action is invoked exactly once and the transient error survives to `onAuthError`. Both fail on `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in failure messages by preserving the original error code and details.
  * Prevented misleading transaction errors when token exchange fails.
  * Removed automatic retries during sign-in callback exchanges to respect single-use sign-in transactions.
  * Sign-in now reports configuration issues, such as invalid client credentials, as clear, non-retryable errors.
  * Transient exchange failures are surfaced directly after a single attempt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->