### PR TITLE
fix(session): retry a transiently failed refresh instead of stranding the tab

### DIFF
--- a/.changeset/transient-refresh-recovery.md
+++ b/.changeset/transient-refresh-recovery.md
@@ -1,0 +1,10 @@
+---
+"convex-logto": patch
+---
+
+Session mode: a transient refresh failure no longer strands the tab signed-out
+until reload. Keeping the session token only helps if something presents it
+again — and nothing did, because Convex stops asking for a token after one
+failure and only re-arms when `isAuthenticated` flips. The engine now retries on
+its own backoff and flips its snapshot back on success, so a tunnel hiccup or a
+laptop waking before its network recovers on its own.

--- a/docs/content/docs/session-mode.mdx
+++ b/docs/content/docs/session-mode.mdx
@@ -596,9 +596,19 @@ The unknown case is a response the component cannot parse as a token response at
 all — a proxy or WAF interstitial where JSON was expected, or a body too large to
 read. Whether Logto processed the grant is then genuinely unknown, so the refresh
 claim is left to expire and that session requires a fresh sign-in. Guessing there
-is what risks spending a rotated token twice. (During *sign-in* the same response
-is terminal instead: the authorization code is spent either way, so there is
-nothing a retry could recover.)
+is what risks spending a rotated token twice. (During *sign-in* every one of
+these is terminal instead — including a wrong client secret. The component
+consumes the sign-in transaction before it contacts Logto, so the authorization
+code is spent either way and a retry could only report a stale callback, hiding
+what actually went wrong.)
+
+A transient failure is not a sign-out, and the browser keeps retrying it. The
+session token stays in storage and the provider re-presents it on its own
+schedule — a second, then five, then ten, then every thirty seconds — until the
+refresh succeeds, the session is signed out, or the tab closes. This matters
+because Convex stops asking for a token after one failure: without the retry, a
+tab that hit a tunnel hiccup or woke from sleep before its network did would sit
+signed-out until the user reloaded.
 
 ## How the token dance works
 

--- a/packages/convex-logto/src/session-client.test.ts
+++ b/packages/convex-logto/src/session-client.test.ts
@@ -106,6 +106,7 @@ function makeHarness(options?: {
   sessionApi?: LogtoSessionApi;
   storage?: SessionStorageAdapter;
   serverHeldCredential?: boolean;
+  recoverySleep?: (ms: number) => Promise<void>;
   onAuthEvent?: (event: LogtoAuthEvent) => void;
   clientDescriptor?: {
     platform?: string;
@@ -155,6 +156,10 @@ function makeHarness(options?: {
     navigate,
     onAuthError,
     sleep: () => Promise.resolve(), // skip retry backoff in tests
+    // Off unless a test asks for it: the recovery loop only ends when a refresh
+    // succeeds, so a no-wait default would spin in every transient-failure test.
+    recoverySleep:
+      options?.recoverySleep ?? (() => new Promise<void>(() => {})),
   });
   return { engine, storage, handlers, navigate, onAuthError };
 }
@@ -701,6 +706,77 @@ describe("mount", () => {
     await settled(engine);
     expect(handlers.refresh).toHaveBeenCalledTimes(1);
   });
+});
+
+it("re-presents the session after a transient refresh failure", async () => {
+  // Keeping the session token is only useful if something presents it again.
+  // Convex clears its auth config after one `null` and re-arms only when
+  // `isAuthenticated` flips, so the engine has to drive the retry itself.
+  let release = () => {};
+  const waited = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const { engine, handlers } = makeHarness({
+    storedSession: { token: "session-token-0", sessionId: "session-id-0" },
+    storedIdToken: staleToken(),
+    recoverySleep: () => waited,
+  });
+  // `retrying` already burns RETRY_DELAYS_MS.length + 1 attempts inside the
+  // one action call; recovery is what happens after all of them fail.
+  handlers.refresh
+    .mockRejectedValueOnce(transientError())
+    .mockRejectedValueOnce(transientError())
+    .mockRejectedValueOnce(transientError())
+    .mockResolvedValue(sessionResult(1));
+
+  engine.start();
+  expect((await settled(engine)).status).toBe("unauthenticated");
+  release();
+
+  await vi.waitFor(() =>
+    expect(engine.getSnapshot().status).toBe("authenticated"),
+  );
+  expect(handlers.refresh).toHaveBeenCalledTimes(4);
+});
+
+it("stops recovering once the session is gone", async () => {
+  let release = () => {};
+  const waited = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const { engine, handlers, storage } = makeHarness({
+    storedSession: { token: "session-token-0", sessionId: "session-id-0" },
+    storedIdToken: staleToken(),
+    recoverySleep: () => waited,
+  });
+  handlers.refresh.mockRejectedValue(transientError());
+
+  engine.start();
+  expect((await settled(engine)).status).toBe("unauthenticated");
+  const attempts = handlers.refresh.mock.calls.length;
+  storage.clearAll();
+  release();
+  await Promise.resolve();
+
+  expect(handlers.refresh).toHaveBeenCalledTimes(attempts);
+});
+
+it("agrees it is signed out when a forced fetch cannot refresh", async () => {
+  // Convex parks at `noAuth` after a single null and only re-arms when
+  // `ConvexProviderWithAuth` calls `setAuth` again, which needs this flip.
+  const idToken = freshToken();
+  const { engine, handlers } = makeHarness({
+    storedSession: { token: "session-token-0", sessionId: "session-id-0" },
+    storedIdToken: idToken,
+  });
+  engine.start();
+  expect((await settled(engine)).status).toBe("authenticated");
+  await expect(engine.fetchAccessToken(false)).resolves.toBe(idToken);
+  handlers.refresh.mockRejectedValue(transientError());
+
+  await expect(engine.fetchAccessToken(true)).resolves.toBeNull();
+
+  expect(engine.getSnapshot().status).toBe("unauthenticated");
 });
 
 // --- callback landing --------------------------------------------------------

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -35,6 +35,12 @@ const ID_TOKEN_SKEW_MS = 30 * 1000;
 
 /** Backoff between retries of a transiently-failing action call. */
 const RETRY_DELAYS_MS = [500, 2000];
+/**
+ * Backoff for re-presenting a session after a transient refresh failure. The
+ * last entry repeats: an outage that outlives the ladder still has to end with
+ * the tab signed in, not stranded.
+ */
+const RECOVERY_DELAYS_MS = [1_000, 2_000, 5_000, 10_000, 30_000];
 
 /** Error objects already surfaced through the public auth-error channel. */
 const REPORTED_AUTH_ERRORS = new WeakSet<Error>();
@@ -531,6 +537,12 @@ export type SessionEngineOptions = {
   /** Injectable for tests. */
   now?: () => number;
   sleep?: (ms: number) => Promise<void>;
+  /**
+   * Separate from `sleep` on purpose: the retry backoff inside one action call
+   * is something a test wants to skip, while the recovery loop is unbounded and
+   * a test that skipped its waits would spin.
+   */
+  recoverySleep?: (ms: number) => Promise<void>;
 };
 
 const SERVER_SNAPSHOT: SessionSnapshot = {
@@ -562,6 +574,7 @@ export class SessionAuthEngine {
   private settleReported = false;
   private inflightSignIn: Promise<void> | null = null;
   private inflightRefresh: Promise<string | null> | null = null;
+  private recovering = false;
   private storagePreparation: Promise<void> | null = null;
   /** Invalidates async credential work that started before a local sign-out. */
   private authGeneration = 0;
@@ -569,12 +582,16 @@ export class SessionAuthEngine {
   private lastServed: string | null = null;
   private now: () => number;
   private sleep: (ms: number) => Promise<void>;
+  private recoverySleep: (ms: number) => Promise<void>;
 
   constructor(private options: SessionEngineOptions) {
     this.now = options.now ?? (() => Date.now());
     this.events = createAuthEventEmitter(options.onAuthEvent);
     this.sleep =
       options.sleep ??
+      ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+    this.recoverySleep =
+      options.recoverySleep ??
       ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
     if (options.initialSession !== undefined) {
       options.storage.writeSession(options.initialSession);
@@ -899,6 +916,13 @@ export class SessionAuthEngine {
       this.lastServed = token;
       if (this.snapshot.status !== "authenticated")
         this.setAuthenticated(token);
+    } else if (this.snapshot.status === "authenticated") {
+      // Convex is about to park at `noAuth`, and it only re-arms when
+      // `ConvexProviderWithAuth` calls `setAuth` again — which needs
+      // `isAuthenticated` to flip. Staying "authenticated" here is what wedged
+      // the tab: the app already reads as signed out, but nothing could ever
+      // undo it.
+      this.setUnauthenticated();
     }
     return token;
   }
@@ -969,8 +993,12 @@ export class SessionAuthEngine {
           this.options.storage.clearAll();
           this.setUnauthenticated();
         }
-        // Transient (Logto/Convex unreachable): keep the session token — the
-        // next fetch after the network heals refreshes cleanly. Never a sign-out.
+        // Transient (Logto/Convex unreachable): keep the session token. Nothing
+        // else will re-present it — `ConvexProviderWithAuth` calls
+        // `fetchAccessToken` only while our snapshot says authenticated, and
+        // Convex parks at `noAuth` after a single null — so retry on our own
+        // clock. Never a sign-out.
+        else this.scheduleRecovery();
         return null;
       }
     };
@@ -1421,6 +1449,47 @@ export class SessionAuthEngine {
     if (signOutError !== undefined) throw signOutError;
     if (fatalServerError !== undefined) throw fatalServerError;
     if (navigationError !== undefined) throw navigationError;
+  }
+
+  /**
+   * Re-present the session after a transient refresh failure until it works.
+   *
+   * Keeping the session token is only useful if something presents it again,
+   * and nothing does: Convex clears its auth config after one `null` and only
+   * `client.setAuth` re-arms it, which `ConvexProviderWithAuth` calls solely
+   * when `isAuthenticated` flips. So the engine drives the retry itself and
+   * flips its own snapshot back on success.
+   *
+   * Bounded by the session's existence and the auth generation, not by an
+   * attempt count: a five-minute outage must still end with the tab signed in.
+   */
+  private scheduleRecovery(): void {
+    if (this.recovering) return;
+    this.recovering = true;
+    const generation = this.authGeneration;
+    void this.recover(generation).finally(() => {
+      this.recovering = false;
+    });
+  }
+
+  private async recover(generation: number): Promise<void> {
+    for (let attempt = 0; ; attempt += 1) {
+      const delay =
+        RECOVERY_DELAYS_MS[Math.min(attempt, RECOVERY_DELAYS_MS.length - 1)] ??
+        30_000;
+      await this.recoverySleep(delay);
+      // A sign-out, a revocation, or another tab getting there first all end the
+      // retry: there is nothing left to re-present.
+      if (generation !== this.authGeneration) return;
+      if (this.options.storage.readSession() === null) return;
+      const idToken = await this.refreshIdToken(null);
+      if (generation !== this.authGeneration) return;
+      if (idToken === null) continue;
+      this.lastServed = idToken;
+      if (this.snapshot.status !== "authenticated")
+        this.setAuthenticated(idToken);
+      return;
+    }
   }
 
   // -- external events --


### PR DESCRIPTION
Closes #164.

The transient branch of `refreshIdToken` keeps the session token on the stated premise that *"the next fetch after the network heals refreshes cleanly."* Nothing ever issued that fetch:

- `ConvexAuthState.js:83-84` calls `client.setAuth(fetchAccessToken, …)` **only** inside `if (authProviderAuthenticated)`.
- `authentication_manager.js:190-231` — `refetchToken()` receiving `null` runs `clearAuth()` + `setAndReportAuthFailed()` → `noAuth`, and the only re-arm is `setConfig`, reachable only from `client.setAuth`.
- The package registered exactly one listener anywhere (`storage`) and no timer.

So a user who hits a tunnel hiccup at mount, or whose laptop wakes before its network does, sits signed-out with a perfectly valid session token in storage until they reload. The mid-session case is worse: our snapshot stayed `"authenticated"` while Convex parked at `noAuth`, so `authProviderAuthenticated` never changed and the `setAuth` effect could never re-run — a permanently wedged tab.

Two changes:

1. **The engine drives its own retry.** A transient failure schedules `recover()`, which re-presents the session on a 1s → 2s → 5s → 10s → 30s ladder (the last entry repeats — an outage that outlives the ladder must still end with the tab signed in) and flips the snapshot back on success. It stops when the auth generation changes (sign-out, revocation, cross-tab sign-out) or the session leaves storage.
2. **`fetchAccessToken` agrees it is signed out** when it has to answer `null`. Convex is about to report exactly that anyway; the engine saying otherwise is what made the state unrecoverable, since only a flip of `isAuthenticated` re-arms `setAuth`.

`recoverySleep` is a separate injectable from `sleep` on purpose: tests skip the in-call retry backoff, and a recovery loop that skipped its waits would spin. The harness leaves it blocked unless a test asks for it.

**Tests** — recovery after a fully-failed refresh (all of `retrying`'s attempts included), the guard that stops it once the session is gone, and the forced-fetch snapshot flip. The first and third fail on `main`.

Docs: the session-mode failure-handling section now says the browser retries, and the sign-in parenthetical is broadened to match #171.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery for temporary session refresh failures with increasing retry delays.
  * Preserves the active session during recovery and restores authentication after a successful refresh.
  * Re-arms authentication when a temporary refresh returns no session.

* **Bug Fixes**
  * Recovery now stops correctly after sign-out, session removal, revocation, or tab closure.
  * Clarified that sign-in failures are terminal once the authorization transaction is consumed.

* **Documentation**
  * Updated session mode guidance to explain refresh recovery and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->