### PR TITLE
fix(session): stop leaving sessions and tokens behind

### DIFF
--- a/.changeset/storage-and-orphans.md
+++ b/.changeset/storage-and-orphans.md
@@ -1,0 +1,16 @@
+---
+"convex-logto": patch
+---
+
+Session mode: two ways a session could be left behind.
+
+Signing in over a live session now revokes the one it replaces. Logto's SSO
+cookie makes that a silent redirect, so it is how a user retries anything that
+looks like a sign-out — and the replaced row kept a live Logto grant no client
+could reach, showing up in the user's own device list until GC took it 190 days
+later.
+
+A rejected `localStorage` write no longer leaves the superseded value readable.
+Another tab would build its own storage area, read a session token this one had
+already rotated away from, and present it — killing the session for every tab
+once the reuse window passed.

--- a/packages/convex-logto/src/session-client.test.ts
+++ b/packages/convex-logto/src/session-client.test.ts
@@ -337,6 +337,30 @@ describe("SessionStorageArea", () => {
     expect(writeAttempts).toBe(1);
   });
 
+  it("drops the superseded copy when a durable session write fails", () => {
+    // A tab that reads a rotated-away session token presents it, and once the
+    // reuse window has passed the component kills the session for every tab.
+    const values = new Map<string, string>();
+    let failWrites = false;
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        if (failWrites) throw new Error("quota exceeded");
+        values.set(key, value);
+      },
+      removeItem: (key: string) => void values.delete(key),
+    });
+    const store = new SessionStorageArea("ns", "session");
+    store.writeSession({ token: "t1", sessionId: "s" });
+    expect([...values.values()].some((raw) => raw.includes("t1"))).toBe(true);
+
+    failWrites = true;
+    store.writeSession({ token: "t2", sessionId: "s" });
+
+    expect(store.readSession()).toEqual({ token: "t2", sessionId: "s" });
+    expect([...values.values()].some((raw) => raw.includes("t1"))).toBe(false);
+  });
+
   it("reports failed durable removal and clears it after a successful retry", async () => {
     const values = new Map<string, string>();
     let removeAttempts = 0;
@@ -804,6 +828,28 @@ describe("callback", () => {
     });
     await vi.waitFor(() => expect(navigate).toHaveBeenCalledWith("/dash"));
     expect(storage.takeTransaction()).toBeNull(); // stash consumed
+  });
+
+  it("revokes the session it signed in over", async () => {
+    // Logto's SSO cookie makes signing in again a silent redirect, so it is how
+    // a user retries anything that looks like a sign-out. The replaced row would
+    // otherwise hold a live Logto grant no client can reach, and show up in the
+    // user's own device list for 190 days.
+    const { engine, storage, handlers } = makeHarness({
+      storedSession: { token: "old-token", sessionId: "old-session" },
+    });
+    setURL("http://localhost:5173/callback?code=c1&state=s1");
+    storage.stashTransaction({ state: "s1" });
+    handlers.callback.mockResolvedValue(sessionResult(1));
+
+    engine.start();
+    expect((await settled(engine)).status).toBe("authenticated");
+
+    await vi.waitFor(() =>
+      expect(handlers.signOut).toHaveBeenCalledWith({
+        sessionToken: "old-token",
+      }),
+    );
   });
 
   it("bound callback captures the device public key in the new session", async () => {

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -365,6 +365,11 @@ export class SessionStorageArea {
       return;
     } catch {
       this.fallBack(kind);
+      // The durable copy is now superseded. Another tab builds its own area,
+      // reads that value, and presents a session token this one has already
+      // rotated away from — which trips reuse detection and kills the session
+      // for every tab. Drop it; the memory copy below is the live one.
+      this.remove(kind, name);
     }
     this.memoryArea().setItem(key, serialized);
   }
@@ -776,6 +781,12 @@ export class SessionAuthEngine {
         await this.revokeAbandonedSession(result.sessionToken);
         return;
       }
+      // Signing in over a live session is ordinary — Logto's SSO cookie makes
+      // it a silent redirect, so it is how a user retries anything that looks
+      // like a sign-out. The row it replaces would otherwise keep a live Logto
+      // grant that no client can reach, and sit in the user's own device list
+      // until GC takes it 190 days later.
+      const superseded = this.options.storage.readSession();
       this.options.storage.writeSession({
         token: result.sessionToken,
         sessionId: result.sessionId,
@@ -788,6 +799,14 @@ export class SessionAuthEngine {
       if (generation !== this.authGeneration) return;
       this.lastServed = null;
       this.setAuthenticated(result.idToken, "callback");
+      if (superseded !== null && superseded.sessionId !== result.sessionId) {
+        // Not awaited: the user is signed in and navigating. A failure here is
+        // reported, never fatal.
+        void this.revokeAbandonedSession(
+          superseded.token,
+          "signed in over an existing session",
+        );
+      }
       const destination =
         result.returnTo !== undefined && isSafeReturnTo(result.returnTo)
           ? result.returnTo
@@ -813,7 +832,17 @@ export class SessionAuthEngine {
    * abandoned. Without this the row — and the Logto grant behind it — would
    * outlive every credential anyone holds for it.
    */
-  private async revokeAbandonedSession(sessionToken: string): Promise<void> {
+  /**
+   * Drop a component session no client holds a credential for any more.
+   *
+   * Never federated and never an RFC 7009 revoke — the component only deletes
+   * its own row, because the Logto grant behind it can be shared with sibling
+   * sessions of the same OP session.
+   */
+  private async revokeAbandonedSession(
+    sessionToken: string,
+    reason = "signed out during sign-in",
+  ): Promise<void> {
     try {
       const deviceProof = await this.options.deviceBinding?.sign(sessionToken);
       await this.options.transport.action(this.options.api.signOut, {
@@ -823,8 +852,8 @@ export class SessionAuthEngine {
     } catch (error) {
       this.reportError(
         new Error(
-          "convex-logto: signed out during sign-in, but the session the server " +
-            "had already created could not be revoked. It expires on its own.",
+          `convex-logto: ${reason}, but the session the server had already ` +
+            "created could not be revoked. It expires on its own.",
           { cause: error },
         ),
       );


### PR DESCRIPTION
Closes #166, closes #167.

**Signing in over a live session orphaned the old one.** `completeCallback` overwrote the stored credential without reading what it replaced, and `createSession` inserts unconditionally with no per-`sid` dedupe — so the previous component session survived, unreachable by any client, still holding a live Logto refresh token, for the full 190-day `SESSION_GC_AFTER_MS`. This compounds with #164: a network blip strands the tab signed-out while the session token stays in storage, the user clicks Sign in, Logto's SSO cookie makes it a silent redirect, and another phantom appears in their own "where am I signed in" list. It now revokes the superseded session through the same path `revokeAbandonedSession` already used for a sign-out that raced the exchange — component-side only, never federated and never an RFC 7009 revoke, because the Logto grant can be shared with sibling sessions.

**A rejected `localStorage` write left the superseded value readable.** `write()` fell back to per-instance memory and returned, so the engine and `flushStorageReporting()` both reported success while localStorage kept the *old* session token. A second tab builds its own `SessionStorageArea`, reads that token, and presents it; past the 10-second reuse window `decideRefresh` returns `reuse` and the session is killed for every tab — from one quota blip. The durable copy is now removed when the write fails, so another tab finds nothing rather than something stale. `remove()` already had the bookkeeping for this, including recording a removal that itself failed.

**Tests** — a callback landing over an existing session asserts the old token is revoked; a storage test asserts the rotated-away token is gone from the browser area after a failed write. Both fail on `main`.