### PR TITLE
fix(component): bound the device public key

### DIFF
--- a/.changeset/bound-device-key.md
+++ b/.changeset/bound-device-key.md
@@ -1,0 +1,9 @@
+---
+"convex-logto": patch
+---
+
+Session mode: a device public key is now checked before the authorization code
+is spent, and counted against the session-list scan budget. `x` and `y` were the
+only caller-supplied strings the component stored without a bound of their own —
+and the one field `sessionReadCost` did not count — so a hand-driven `callback`
+could store near-1 MiB session rows that the list scan measured at ~512 bytes.

--- a/packages/convex-logto/src/component/core.test.ts
+++ b/packages/convex-logto/src/component/core.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_REUSE_WINDOW_MS,
   assertDeviceProof,
+  assertUsableDevicePublicKey,
   buildAuthorizeUrl,
   buildEndSessionUrl,
   classifyTokenEndpointFailure,
@@ -20,6 +21,7 @@ import {
   normalizeClientDescriptor,
   normalizeSignInTargets,
   normalizeSessionLabel,
+  sessionReadCost,
   rotateTokenHashes,
   terminal,
   toBase64Url,
@@ -650,5 +652,53 @@ describe("session labels and client descriptors", () => {
     ).toEqual({ platform: "web", browser: "y".repeat(32) });
     expect(normalizeClientDescriptor({})).toBeUndefined();
     expect(normalizeClientDescriptor(undefined)).toBeUndefined();
+  });
+});
+
+describe("assertUsableDevicePublicKey", () => {
+  // `x` and `y` are the only caller-supplied strings the component stores
+  // without a bound of their own, and the key is otherwise parsed only at verify
+  // time inside a try/catch — so nothing on the write path would notice.
+  const coordinate = "a".repeat(43);
+
+  it("accepts a real P-256 coordinate pair", () => {
+    expect(() =>
+      assertUsableDevicePublicKey({
+        kty: "EC",
+        crv: "P-256",
+        x: coordinate,
+        y: coordinate,
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects a coordinate that is not 43 base64url characters", () => {
+    for (const bad of [
+      "a".repeat(500_000),
+      "a".repeat(42),
+      `${"a".repeat(42)}+`,
+    ]) {
+      expect(() =>
+        assertUsableDevicePublicKey({
+          kty: "EC",
+          crv: "P-256",
+          x: bad,
+          y: coordinate,
+        }),
+      ).toThrow(ConvexError);
+    }
+  });
+
+  it("counts the key against the list scan budget", () => {
+    const row = {
+      logtoRefreshToken: "r",
+      lastIdToken: "i",
+    };
+    expect(
+      sessionReadCost({
+        ...row,
+        devicePublicKey: { x: coordinate, y: coordinate },
+      }),
+    ).toBe(sessionReadCost(row) + coordinate.length * 2);
   });
 });

--- a/packages/convex-logto/src/component/core.ts
+++ b/packages/convex-logto/src/component/core.ts
@@ -62,11 +62,15 @@ export function sessionReadCost(session: {
   logtoRefreshToken: string;
   lastIdToken: string;
   label?: string;
+  devicePublicKey?: { x: string; y: string };
 }): number {
   return (
     session.logtoRefreshToken.length +
     session.lastIdToken.length +
     (session.label?.length ?? 0) +
+    (session.devicePublicKey === undefined
+      ? 0
+      : session.devicePublicKey.x.length + session.devicePublicKey.y.length) +
     512
   );
 }
@@ -139,6 +143,40 @@ export function normalizeSessionLabel(
     );
   }
   return label;
+}
+
+/**
+ * A base64url P-256 coordinate: 32 bytes, so always exactly 43 characters.
+ */
+const DEVICE_KEY_COORDINATE = /^[\w-]{43}$/;
+
+/**
+ * Reject a device public key the component could never verify with.
+ *
+ * `x` and `y` are the only caller-supplied strings this component stores
+ * without a bound of their own, and {@link sessionReadCost} does not count
+ * them — so an unbounded key is a session row the list scan under-measures by
+ * however much the caller chose to send. The key is otherwise parsed only at
+ * verify time, inside a `try/catch` that returns `false`, so nothing on the
+ * write path would notice.
+ *
+ * Called before the authorization code is spent, like the label: a key that can
+ * never produce a valid proof should fail the sign-in it was offered to, not
+ * one refresh later.
+ */
+export function assertUsableDevicePublicKey(
+  key: DevicePublicKey | undefined,
+): void {
+  if (key === undefined) return;
+  if (
+    !DEVICE_KEY_COORDINATE.test(key.x) ||
+    !DEVICE_KEY_COORDINATE.test(key.y)
+  ) {
+    throw terminal(
+      "device_key_malformed",
+      "The device public key is not a P-256 JWK: `x` and `y` must each be 43 base64url characters.",
+    );
+  }
 }
 
 /**

--- a/packages/convex-logto/src/component/lib.test.ts
+++ b/packages/convex-logto/src/component/lib.test.ts
@@ -903,6 +903,33 @@ describe("bounded token endpoint", () => {
     }
   });
 
+  it("rejects a malformed device key before spending the code", async () => {
+    // A key that can never produce a valid proof should fail the sign-in it was
+    // offered to, not one refresh later — and never after the authorization code
+    // has bought a grant no one would hold.
+    const runMutation = vi.fn();
+    await expect(
+      exchangeActionHandler(
+        { runQuery: () => Promise.resolve(null), runMutation },
+        {
+          ...refreshArgs,
+          code: "code",
+          state: "state",
+          redirectUri: "https://app.example.com/callback",
+          devicePublicKey: {
+            kty: "EC" as const,
+            crv: "P-256" as const,
+            x: "A".repeat(500_000),
+            y: "A".repeat(400_000),
+          },
+        },
+      ),
+    ).rejects.toMatchObject({
+      data: { kind: "terminal", code: "device_key_malformed" },
+    });
+    expect(runMutation).not.toHaveBeenCalled();
+  });
+
   it("reports Logto's own rejection on the sign-in path, terminally", async () => {
     // `classifyTokenEndpointFailure` calls this transient for refresh's sake.
     // Here the transaction is already consumed, so a retry can only report

--- a/packages/convex-logto/src/component/lib.ts
+++ b/packages/convex-logto/src/component/lib.ts
@@ -19,6 +19,7 @@ import {
   TRANSACTION_TTL_MS,
   WEBHOOK_DELIVERY_GC_AFTER_MS,
   asDeploymentFault,
+  assertUsableDevicePublicKey,
   asSpentAuthorizationCode,
   assertDeviceProof,
   buildAuthorizeUrl,
@@ -569,6 +570,7 @@ export const exchange = action({
     // grant no one would ever hold.
     const label = normalizeSessionLabel(args.label);
     const client = normalizeClientDescriptor(args.client);
+    assertUsableDevicePublicKey(args.devicePublicKey);
     const transaction: ConsumedTransaction = await ctx.runMutation(
       internal.lib.consumeTransaction,
       {

--- a/packages/convex-logto/src/session.ts
+++ b/packages/convex-logto/src/session.ts
@@ -223,11 +223,6 @@ export type LogtoSessionComponent = {
 
 // --- public function surface -------------------------------------------------
 
-/**
- * The six public functions {@link logtoSessionApi} registers, as the frontend
- * sees them. `ConvexLogtoSessionProvider` takes a reference to the module that
- * re-exports them (e.g. `api.auth`).
- */
 /** Coarse, self-reported description of a signing-in client. */
 export type LogtoSessionClientDescriptor = {
   platform?: string;
@@ -248,6 +243,11 @@ export type LogtoSessionSummary = {
   deviceBound: boolean;
 };
 
+/**
+ * The nine public functions {@link logtoSessionApi} registers, as the frontend
+ * sees them. `ConvexLogtoSessionProvider` takes a reference to the module that
+ * re-exports them (e.g. `api.auth`).
+ */
 export type LogtoSessionApi = {
   signIn: FunctionReference<
     "action",


### PR DESCRIPTION
Closes #174.

`devicePublicKeyValidator` took `x` and `y` as bare `v.string()` (`session.ts:54-59`) even though a P-256 coordinate is always exactly 43 base64url characters, and `exchange` normalized the label and client descriptor before spending the code but never touched the key. The key is otherwise parsed only at *verify* time, inside a `try/catch` that returns `false`, so nothing on the write path could reject it — making `x`/`y` the one caller-supplied string this component stores without a bound of its own, against the rule `core.ts:22-31` states for everything else.

It was also the one field `sessionReadCost` forgot, and that function is the entire basis of the 4 MiB `SESSION_LIST_SCAN_BYTES` bound `listSubjectSessions` relies on. An account holder driving the public actions by hand — real `code`/`state`, then `callback` with a 900 KB "key" — could store session rows near Convex's 1 MiB ceiling that the list scan measured at ~512 bytes each. After about seventeen of them, `listSessions` is a permanently failing query for that subject, and `hasActiveSessionForSubject` takes nine such rows in one transaction.

`assertUsableDevicePublicKey` now rejects a coordinate that is not 43 base64url characters, alongside the label check and *before* `consumeTransaction` — a key that can never produce a valid proof should fail the sign-in it was offered to, not one refresh later, and never after the code has bought a grant no one would hold. `sessionReadCost` counts the key too, so the accounting stops under-measuring what it stores.

Drive-by from the same audit: the JSDoc block describing "the six public functions `logtoSessionApi` registers" was attached to `LogtoSessionClientDescriptor`, which has its own comment right after it — so it documented nothing, while `LogtoSessionApi` (the type app authors hover when wiring `sessionApi={api.auth}`) had none. Moved, and corrected to nine.

**Tests** — the exchange rejects an oversized key with `runMutation` never called (the code is not spent), plus unit coverage for the coordinate check and the read-cost accounting. All four fail on `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation for device public keys, rejecting malformed or oversized coordinates.
  - Invalid device keys are now detected before authorization codes or sign-in transactions are consumed.
  - Device key data is included in session size calculations to prevent oversized session records.

- **Documentation**
  - Updated API descriptions to accurately reflect the available session functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->