### PR TITLE
perf(component): size GC to the rows it actually drains

### DIFF
--- a/.changeset/gc-sizing.md
+++ b/.changeset/gc-sizing.md
@@ -1,0 +1,9 @@
+---
+"convex-logto": patch
+---
+
+Component: GC drains abandoned sign-ins 128 at a time instead of 4, and sweeps
+revocation watermarks once per run rather than once per chained batch. The old
+batch size was sized against a near-1 MiB `transactions` row that
+`SIGN_IN_URL_MAX_LENGTH` has since made impossible, and every extra sweep
+re-reads session documents.

--- a/packages/convex-logto/src/component/core.ts
+++ b/packages/convex-logto/src/component/core.ts
@@ -25,7 +25,7 @@ export const SESSION_LABEL_MAX_LENGTH = 64;
  * `signIn` is necessarily unauthenticated, and both strings are stored verbatim
  * in a `transactions` row for the transaction TTL. Unbounded, anyone who knows
  * the deployment URL can park documents near Convex's 1 MiB limit in a loop, and
- * GC only drains four transaction documents per mutation. Every other
+ * GC would have to drain them a handful per mutation. Every other
  * caller-supplied string in this component is bounded; these are generous by
  * comparison — a redirect URI that does not fit in 2048 code points is not a
  * redirect URI anyone registered with Logto.

--- a/packages/convex-logto/src/component/lib.ts
+++ b/packages/convex-logto/src/component/lib.ts
@@ -113,10 +113,12 @@ type SignOutConsumptionResult =
 // their tiny, bounded generation rows stays below the 16 MiB transaction limits.
 export const REVOCATION_BATCH_SIZE = 8;
 const MAX_REVOCATION_BATCHES = 512;
-// Transactions contain caller-provided redirect URLs and, like sessions, can
-// approach Convex's 1 MiB document limit. GC processes both in one mutation,
-// so reserve four of the 16 MiB read/write budget for transaction documents.
-const GC_TRANSACTION_BATCH_SIZE = 4;
+// A transaction row is `state` + `codeVerifier` (43 each) plus two strings
+// bounded at SIGN_IN_URL_MAX_LENGTH — under 5 KB, not the near-1 MiB document
+// this batch was originally sized for. 128 of them is well inside the share of
+// the 16 MiB budget this mutation can spare, and abandoned sign-ins are the one
+// table an unauthenticated caller can fill.
+export const GC_TRANSACTION_BATCH_SIZE = 128;
 const GC_SMALL_DOCUMENT_BATCH_SIZE = 500;
 // A watermark row is tiny, but proving it governs nothing reads a *session*
 // document, which can approach Convex's 1 MiB limit. Bound the batch by that
@@ -1934,15 +1936,8 @@ export const gc = internalMutation({
       )
       .take(GC_SMALL_DOCUMENT_BATCH_SIZE);
     for (const d of staleDeliveries) await ctx.db.delete(d._id);
-    // Revocation watermarks outlive the rows they killed on purpose, but not
-    // forever: back-channel logout writes one per OP session that ever ends,
-    // including logouts that matched nothing, and nothing else ever deletes
-    // them. They sweep in their own transaction because proving a marker
-    // governs nothing reads session documents, which this mutation has already
-    // spent most of its budget on.
-    await ctx.scheduler.runAfter(0, internal.lib.gcRevocationMarkers, {});
     // A full batch might have more rows behind it. Continue durably instead of
-    // reducing a daily cron to four abandoned sign-ins or eight dead sessions.
+    // reducing a daily cron to one batch of each table.
     if (
       expiredTransactions.length === GC_TRANSACTION_BATCH_SIZE ||
       deadSessions.length === REVOCATION_BATCH_SIZE ||
@@ -1950,7 +1945,16 @@ export const gc = internalMutation({
       staleDeliveries.length === GC_SMALL_DOCUMENT_BATCH_SIZE
     ) {
       await ctx.scheduler.runAfter(0, internal.lib.gc, {});
+      return null;
     }
+    // Revocation watermarks outlive the rows they killed on purpose, but not
+    // forever: back-channel logout writes one per OP session that ever ends,
+    // including logouts that matched nothing, and nothing else ever deletes
+    // them. They sweep in their own transaction because proving a marker
+    // governs nothing reads session documents, which this mutation has already
+    // spent most of its budget on — and once per `gc` run, not once per chained
+    // batch, since each sweep re-reads those documents.
+    await ctx.scheduler.runAfter(0, internal.lib.gcRevocationMarkers, {});
     return null;
   },
 });

--- a/packages/convex-logto/src/component/revocation.test.ts
+++ b/packages/convex-logto/src/component/revocation.test.ts
@@ -1,6 +1,7 @@
 import { getFunctionName } from "convex/server";
 import { describe, expect, it } from "vitest";
 import {
+  GC_TRANSACTION_BATCH_SIZE,
   REVOCATION_BATCH_SIZE,
   beginRefresh,
   beginSidRevocation,
@@ -269,16 +270,48 @@ describe("bounded session revocation", () => {
     };
 
     await expect(handler({ db, scheduler }, {})).resolves.toBeNull();
-    expect(transactionTakeLimit).toBe(4);
+    expect(transactionTakeLimit).toBe(GC_TRANSACTION_BATCH_SIZE);
     expect(sessionTakeLimit).toBe(REVOCATION_BATCH_SIZE);
     expect(deleted).toHaveLength(REVOCATION_BATCH_SIZE);
-    // The watermark sweep runs in its own transaction — proving a watermark
-    // governs nothing reads session documents, and this budget is spent.
-    expect(scheduled.map((entry) => entry.name)).toEqual([
-      "lib:gcRevocationMarkers",
-      "lib:gc",
-    ]);
+    // A full batch continues the chain; the watermark sweep waits for the last
+    // one, because every sweep re-reads session documents.
+    expect(scheduled.map((entry) => entry.name)).toEqual(["lib:gc"]);
     expect(scheduled.every((entry) => entry.delay === 0)).toBe(true);
+  });
+
+  it("sweeps watermarks once, after the last GC batch", async () => {
+    // Every sweep re-reads session documents to prove a marker governs nothing.
+    // Scheduling one per chained batch multiplies that by the length of the
+    // chain — which an unauthenticated caller controls, since anyone who knows
+    // the deployment URL can create `transactions` rows in a loop.
+    const scheduled: string[] = [];
+    const db = {
+      query: () => ({
+        withIndex: () => ({
+          take: () => Promise.resolve([]),
+          collect: () => Promise.resolve([]),
+        }),
+      }),
+      delete: () => Promise.resolve(),
+    };
+    const handler = handlerOf<Record<string, never>, null>(gc);
+
+    await expect(
+      handler(
+        {
+          db,
+          scheduler: {
+            runAfter: (_delay: number, reference: unknown) => {
+              scheduled.push(getFunctionName(reference as never));
+              return Promise.resolve("scheduled");
+            },
+          },
+        },
+        {},
+      ),
+    ).resolves.toBeNull();
+
+    expect(scheduled).toEqual(["lib:gcRevocationMarkers"]);
   });
 
   it("includes a session committed after the action sampled its clock", async () => {


### PR DESCRIPTION
Closes #170.

**The transaction batch was sized against a document that can no longer exist.** `GC_TRANSACTION_BATCH_SIZE = 4` was justified by *"Transactions contain caller-provided redirect URLs and, like sessions, can approach Convex's 1 MiB document limit."* Since `SIGN_IN_URL_MAX_LENGTH` landed, both caller-controlled strings are bounded at 2048 code points, so a row is `state` (43) + `codeVerifier` (43) + `redirectUri` + `returnTo` + `expiresAt` — under 5 KB, about 230× below the limit. The reasoning had become circular: the length bound's own comment cited "GC only drains four transaction documents per mutation" as its justification. Now 128, with the comment stating the real arithmetic; the length-bound comment no longer cites a number that will drift.

**The watermark sweep ran once per chained batch.** `gc` scheduled `gcRevocationMarkers` unconditionally, before the continuation check, so a chain of N/4 mutations also scheduled N/4 sweeps — each of which re-reads session documents to prove a marker governs nothing. It now runs on the last iteration only, so once per `gc` run. `gcRevocationMarkers` still self-chains when its own batch fills (#151).

This matters because `signIn` is unauthenticated by necessity and writes one `transactions` row per call before the authorize URL is even built, so the length of that chain is something anyone who knows the deployment URL can choose.

**Tests** — the existing budget test now asserts the new batch size and that a full batch schedules only the continuation; a new test asserts the sweep is scheduled exactly once, on the batch that ends the chain. The former fails on `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Garbage collection now processes up to 128 abandoned sign-ins per batch, improving cleanup throughput.
  * Revocation markers are swept once after all cleanup batches complete, reducing unnecessary repeated work.

* **Bug Fixes**
  * Improved chained cleanup behavior to ensure large cleanup operations continue reliably across batches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->