### PR TITLE
docs: deprecate resources in session mode

### DIFF
--- a/.changeset/deprecate-session-resources.md
+++ b/.changeset/deprecate-session-resources.md
@@ -1,0 +1,10 @@
+---
+"convex-logto": patch
+---
+
+Deprecate `resources` on `logtoSessionApi()`. Session mode keeps the refresh
+token in the component and hands the browser only the ID token, so the
+resource-scoped access token the option buys is discarded — and a resource
+indicator Logto does not have registered breaks sign-in outright. Bridge mode's
+`resources` is unaffected: there the Logto SDK owns the tokens and exposes
+`getAccessToken()`.

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -140,10 +140,13 @@ export const {
 } = logtoSessionApi(components.logto);
 ```
 
-Options: `scopes` / `resources` (server-configured — the browser can't request
-its own), `reuseWindowMs` (default 10s), `endpoint` / `appId` / `clientSecret`
-env overrides, and the same narrowly scoped `allowInsecureHttp` compatibility
-escape hatch described above.
+Options: `scopes` (server-configured — the browser can't request its own),
+`reuseWindowMs` (default 10s), `endpoint` / `appId` / `clientSecret` env
+overrides, and the same narrowly scoped `allowInsecureHttp` compatibility escape
+hatch described above. `resources` is **deprecated** here: the component holds
+the refresh token and hands the browser only the ID token, so the access token a
+resource indicator buys is discarded. (In bridge mode it still works — the Logto
+SDK owns the tokens and exposes `getAccessToken()`.)
 
 `signOutEverywhere({ sessionToken, postLogoutRedirectUri? })` derives the subject
 inside the component and atomically records subject-wide logical revocation.

--- a/docs/content/docs/session-mode.mdx
+++ b/docs/content/docs/session-mode.mdx
@@ -659,8 +659,10 @@ rejects the response and leaves uncommitted remote credentials unreachable.
 | `reactiveRevocation` | `true` | Subscribe to session liveness and drop auth live on revocation. |
 | `onAuthError` | — | Sign-in initiation and callback failures, plus opted-in device-key storage failures. Initiation failures are reported before `signIn()` rejects, so `void signIn()` remains observable. |
 
-`logtoSessionApi(component, opts?)` accepts `scopes`, `resources` (server-set —
-the browser can't request its own), `reuseWindowMs`, and env overrides.
+`logtoSessionApi(component, opts?)` accepts `scopes` (server-set — the browser
+can't request its own), `reuseWindowMs`, and env overrides. `resources` is
+deprecated in session mode: only the ID token reaches the browser, so the access
+token it buys is discarded.
 
 ## Choosing a mode
 

--- a/packages/convex-logto/src/component/lib.ts
+++ b/packages/convex-logto/src/component/lib.ts
@@ -473,6 +473,10 @@ async function tokenEndpoint(
       ...(typeof body.refresh_token === "string"
         ? { refresh_token: body.refresh_token }
         : {}),
+      // Read but never used: session mode exposes the ID token only, and the
+      // deprecated `resources` option is the one thing that would make this
+      // access token interesting. Kept so a future caller that needs it does
+      // not have to re-derive where it lives.
       ...(typeof body.access_token === "string"
         ? { access_token: body.access_token }
         : {}),

--- a/packages/convex-logto/src/session.ts
+++ b/packages/convex-logto/src/session.ts
@@ -344,7 +344,15 @@ export type LogtoSessionApiOptions = LogtoEndpointPolicy & {
    * Server-configured — the browser can't request scopes on its own.
    */
   scopes?: string[];
-  /** API resource indicators to request access for (Logto API resources). */
+  /**
+   * API resource indicators appended to the authorize request.
+   *
+   * @deprecated Session mode has nothing to hand you in return: the component
+   * holds the refresh token and exposes only the ID token, so the resource-
+   * scoped access token this buys is discarded, and the refresh grant never
+   * asks for another. Setting a resource Logto does not have registered breaks
+   * sign-in outright. Kept for compatibility; it will go in the next major.
+   */
   resources?: string[];
   /**
    * How long (ms) recently superseded Session-token generations stay accepted,


### PR DESCRIPTION
Closes #169.

`logtoSessionApi(components.logto, { resources: [...] })` is documented as *"API resource indicators to request access for"*, is accepted, and is appended to the authorize request as one `resource` param per entry — and then the access token it buys is thrown away. `tokenEndpoint` extracts `access_token` and no caller reads it: `exchange` returns `{idToken, sessionToken, sessionId, returnTo}`, `refresh` returns `{idToken, sessionToken, sessionId}`, and the refresh grant sends only `grant_type` + `refresh_token`, so no resource-scoped token is minted after sign-in either. An app that sets it gets a consent screen listing API permissions and then finds there is no access token anywhere in the public surface — and if the indicator is not registered in Logto, the *authorize* request itself is rejected, so the option's only reachable effect is to break sign-in.

The option is now `@deprecated` with the reason, the API reference and session-mode page say the same, and the vestigial `access_token` extraction carries a comment so it stops reading like half-finished wiring. Removing it outright is a breaking change and can wait for the next major.

Bridge mode's `resources` is untouched and still works — there the Logto SDK owns the tokens and exposes `getAccessToken()`.