### PR TITLE
fix(session): never revoke a cookie-mode session on re-sign-in

### DIFF
--- a/.changeset/superseded-revoke-cookie-mode.md
+++ b/.changeset/superseded-revoke-cookie-mode.md
@@ -1,0 +1,9 @@
+---
+"convex-logto": patch
+---
+
+Fix a regression in the previous patch: in cookie transport mode, signing in
+over an existing session revoked the session it had just created. The stored
+value there is a marker rather than a credential, and the same-origin sign-out
+route reads the cookie — which the callback had already replaced — so the user
+was signed straight back out.

--- a/packages/convex-logto/src/session-client.test.ts
+++ b/packages/convex-logto/src/session-client.test.ts
@@ -852,6 +852,26 @@ describe("callback", () => {
     );
   });
 
+  it("never revokes the superseded session in cookie mode", async () => {
+    // The stored value there is a marker, not a credential, and the same-origin
+    // sign-out route reads the *cookie* — which the callback just replaced. A
+    // revoke by marker would sign the user straight back out.
+    const { engine, storage, handlers } = makeHarness({
+      storedSession: { token: "legacy-session-secret", sessionId: "old" },
+      cookieBootstrap: {},
+      serverHeldCredential: true,
+    });
+    setURL("http://localhost:5173/callback?code=c1&state=s1");
+    storage.stashTransaction({ state: "s1" });
+    handlers.callback.mockResolvedValue(sessionResult(1));
+
+    engine.start();
+    expect((await settled(engine)).status).toBe("authenticated");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(handlers.signOut).not.toHaveBeenCalled();
+  });
+
   it("bound callback captures the device public key in the new session", async () => {
     const deviceBinding = fakeDeviceBinding();
     const { engine, storage, handlers } = makeHarness({ deviceBinding });

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -799,7 +799,17 @@ export class SessionAuthEngine {
       if (generation !== this.authGeneration) return;
       this.lastServed = null;
       this.setAuthenticated(result.idToken, "callback");
-      if (superseded !== null && superseded.sessionId !== result.sessionId) {
+      if (
+        // Never in cookie mode. The stored value there is a marker, not a
+        // credential, and the same-origin sign-out route reads the *cookie* —
+        // which the callback just replaced with the new session. Revoking by
+        // marker would sign the user straight back out of the session they just
+        // created.
+        this.options.serverHeldCredential !== true &&
+        superseded !== null &&
+        superseded.sessionId !== "" &&
+        superseded.sessionId !== result.sessionId
+      ) {
         // Not awaited: the user is signed in and navigating. A failure here is
         // reported, never fatal.
         void this.revokeAbandonedSession(


### PR DESCRIPTION
Fixes a regression I introduced in #173.

#173 made `completeCallback` revoke the session it signed in over. In cookie transport mode that is wrong twice:

- The stored value is `COOKIE_SESSION_MARKER`, not a credential (`session-cookie.ts:36-44`), so there is nothing meaningful to present.
- The same-origin `sign-out` route ignores the token in the body and reads the **cookie** (`session-cookie.ts:575`), which the `/callback` route has just replaced with the *new* session — and it answers with `clearCookieHeader()`.

So signing in over an existing cookie-mode session revoked and cleared the session it had just created: the user was signed straight back out, with the phantom the change was meant to prevent still in place.

The revoke is now skipped whenever the credential is server-held, and an empty stored session id (cookie mode's "id not known yet" marker) never counts as a mismatch either.

**Test** — a cookie-mode callback landing over an existing session asserts `signOut` is never called. It fails on `main`.

Caught while reviewing my own merged work; the localStorage half of #173 is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cookie-based sign-in flows so newly created sessions are not incorrectly revoked.
  * Preserved cleanup of superseded local sessions when appropriate.
  * Prevented unnecessary sign-out requests for cookie sessions, including server-held credentials.

* **Tests**
  * Added coverage for authentication with an existing cookie session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->