### PR TITLE
fix(native-session): make completeSignIn work on a cold start

### DIFF
--- a/.changeset/complete-sign-in-cold-start.md
+++ b/.changeset/complete-sign-in-cold-start.md
@@ -1,0 +1,11 @@
+---
+"convex-logto": patch
+---
+
+Native session mode: `completeSignIn(url)` now works on the cold start it was
+added for. It waits for SecureStore to hydrate before touching the OIDC stash —
+the deep link normally arrives before the provider's mount effect, and reading
+the stash too early deleted the transaction it came to spend. A duplicate
+delivery of the same URL now completes once instead of reporting a replayed
+callback, and a link that matches the redirect prefix but carries no OIDC
+response leaves an in-flight sign-in alone.

--- a/docs/content/docs/react-native.mdx
+++ b/docs/content/docs/react-native.mdx
@@ -286,8 +286,10 @@ useEffect(() => {
 }, [completeSignIn]);
 ```
 
-Pass every deep link through — anything that is not this app's `redirectUri` is
-ignored. A user who *cancelled* in the browser is deliberately not recoverable
+Pass every deep link through. Anything that is not this app's `redirectUri`, or
+that carries no OIDC response, is ignored without disturbing a sign-in already in
+progress, and delivering the same URL twice (both entry points fire on some
+Android returns) completes it once. A user who *cancelled* in the browser is deliberately not recoverable
 this way: cancelling discards the OIDC state so a later deep link cannot replay
 it. Tapping Sign in again is instant, since Logto's browser SSO session is still
 there.

--- a/packages/convex-logto/src/native-session.provider.test.tsx
+++ b/packages/convex-logto/src/native-session.provider.test.tsx
@@ -20,9 +20,15 @@ import { ConvexLogtoSessionProvider, useLogtoAuth } from "./native-session";
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
 const store = new Map<string, string>();
+// Held open to model a cold start: SecureStore reads are two bridge round trips,
+// and `Linking.getInitialURL()` is one, so the deep link normally arrives first.
+let readGate: Promise<void> | null = null;
 vi.mock("expo-secure-store", () => ({
   isAvailableAsync: () => Promise.resolve(true),
-  getItemAsync: (key: string) => Promise.resolve(store.get(key) ?? null),
+  getItemAsync: async (key: string) => {
+    if (readGate) await readGate;
+    return store.get(key) ?? null;
+  },
   setItemAsync: (key: string, value: string) => {
     store.set(key, value);
     return Promise.resolve();
@@ -108,6 +114,7 @@ async function render() {
 
 beforeEach(() => {
   store.clear();
+  readGate = null;
   signInAction.mockClear();
   callbackAction.mockClear();
   openAuthSessionAsync.mockClear();
@@ -126,6 +133,58 @@ it("finishes a sign-in whose deep link outlived the browser promise", async () =
   });
   await vi.waitFor(() => expect(openAuthSessionAsync).toHaveBeenCalled());
 
+  await act(async () => {
+    await capturedApi!.completeSignIn("myapp://callback?code=c&state=st");
+  });
+
+  expect(callbackAction).toHaveBeenCalledWith(
+    expect.objectContaining({ code: "c", state: "st" }),
+  );
+});
+
+it("completes a cold-start deep link that beats storage preparation", async () => {
+  // The stash lives in SecureStore and reads as absent until `prepare()` has
+  // run, so without awaiting it this deletes the transaction it came to spend.
+  await render();
+  await act(async () => {
+    void capturedApi!.signIn();
+  });
+  await vi.waitFor(() => expect(openAuthSessionAsync).toHaveBeenCalled());
+  await act(async () => root!.unmount());
+  root = null;
+
+  // A new process: the engine is fresh, SecureStore still holds the stash.
+  let release = () => {};
+  readGate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await render();
+  let completed: Promise<void>;
+  await act(async () => {
+    completed = capturedApi!.completeSignIn("myapp://callback?code=c&state=st");
+  });
+  await act(async () => {
+    release();
+    await completed;
+  });
+
+  expect(callbackAction).toHaveBeenCalledWith(
+    expect.objectContaining({ code: "c", state: "st" }),
+  );
+});
+
+it("leaves the stash alone for a deep link carrying no OIDC response", async () => {
+  // Apps forward every link they receive, and the guard is a prefix match — so
+  // `myapp://callback/done` must not destroy an in-flight sign-in.
+  await render();
+  await act(async () => {
+    void capturedApi!.signIn();
+  });
+  await vi.waitFor(() => expect(openAuthSessionAsync).toHaveBeenCalled());
+
+  await act(async () => {
+    await capturedApi!.completeSignIn("myapp://callback/done");
+  });
   await act(async () => {
     await capturedApi!.completeSignIn("myapp://callback?code=c&state=st");
   });

--- a/packages/convex-logto/src/native-session.tsx
+++ b/packages/convex-logto/src/native-session.tsx
@@ -282,6 +282,10 @@ export type LogtoSessionAuth = {
    * }, [completeSignIn]);
    * ```
    *
+   * Safe to call with any link: one that is not this app's `redirectUri`, or
+   * that carries no OIDC response, is ignored without disturbing a sign-in in
+   * progress, and a duplicate delivery of the same URL waits for the first.
+   *
    * A user who cancelled in the browser is not recoverable this way, by design:
    * cancelling discards the OIDC state so a later deep link cannot replay it.
    */

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -578,6 +578,7 @@ export class SessionAuthEngine {
   /** The first settle is the one that answers "how long until the app could query". */
   private settleReported = false;
   private inflightSignIn: Promise<void> | null = null;
+  private inflightCompletion: Promise<void> | null = null;
   private inflightRefresh: Promise<string | null> | null = null;
   private recovering = false;
   private storagePreparation: Promise<void> | null = null;
@@ -1133,25 +1134,90 @@ export class SessionAuthEngine {
       await this.flushStorage();
       return;
     }
-    await this.completeSignIn(callbackUrl, redirectUri);
+    await this.runCompletion(callbackUrl, redirectUri, {
+      spendOnUnrecognized: true,
+    });
   }
 
-  /** Complete a native system-browser return. Public for deep-link adapters/tests. */
+  /**
+   * Complete a native sign-in from a deep link that arrived outside the
+   * system-browser promise. Public for deep-link adapters.
+   *
+   * Two things this has to do that the in-flow path gets for free.
+   *
+   * Storage is prepared first. The cold start this exists for delivers the link
+   * *before* the provider's mount effect — React commits child effects before
+   * parent ones — and the OIDC stash lives in SecureStore, which reads as absent
+   * until `prepare()` has run. Without the await, the deep link normally loses
+   * that race and deletes the very transaction it came to spend.
+   *
+   * And it shares `signIn`'s single flight, because the documented wiring hands
+   * the same URL to both `Linking.getInitialURL()` and the `url` listener, and
+   * on Android `openAuthSessionAsync` resolving *and* Linking emitting is
+   * routine. One transaction slot, one flow.
+   */
   async completeSignIn(
     callbackUrl: string,
     redirectUri: string,
+  ): Promise<void> {
+    try {
+      await this.prepareStorage();
+    } catch (error) {
+      this.reportError(this.asError(error));
+      return;
+    }
+    await this.runCompletion(callbackUrl, redirectUri, {
+      spendOnUnrecognized: false,
+    });
+  }
+
+  /**
+   * One completion at a time, whichever door the return came through.
+   *
+   * Deliberately not `inflightSignIn`: the case this whole path exists for is a
+   * browser promise that never settles, so waiting on it would hang. This latch
+   * only spans a completion, which always finishes.
+   */
+  private runCompletion(
+    callbackUrl: string,
+    redirectUri: string,
+    options: { spendOnUnrecognized: boolean },
+  ): Promise<void> {
+    const existing = this.inflightCompletion;
+    // The owner reports; a duplicate delivery only needs to wait for it.
+    if (existing !== null) return existing.catch(() => {});
+    const run = this.completeSignInInner(callbackUrl, redirectUri, options);
+    this.inflightCompletion = run.finally(() => {
+      this.inflightCompletion = null;
+    });
+    return this.inflightCompletion;
+  }
+
+  /**
+   * `spendOnUnrecognized` separates the two callers. A URL handed back by the
+   * system browser *is* this sign-in's return, so anything unusable about it
+   * still spends the login-CSRF state — there is no callback route to revisit on
+   * native. A deep link is only a candidate: the app forwards every link it
+   * receives, and one that carries no OIDC response must leave an in-flight
+   * sign-in alone.
+   */
+  private async completeSignInInner(
+    callbackUrl: string,
+    redirectUri: string,
+    options: { spendOnUnrecognized: boolean },
   ): Promise<void> {
     let url: URL;
     try {
       url = new URL(callbackUrl);
     } catch (error) {
-      this.options.storage.takeTransaction();
-      await this.flushStorageReporting();
       this.reportError(
         new Error("convex-logto: the native sign-in return URL is invalid.", {
           cause: error,
         }),
       );
+      if (!options.spendOnUnrecognized) return;
+      this.options.storage.takeTransaction();
+      await this.flushStorageReporting();
       await this.restore();
       this.navigateReplace(this.options.afterSignIn);
       return;
@@ -1161,19 +1227,20 @@ export class SessionAuthEngine {
       await this.completeCallback(url.searchParams, redirectUri);
       return;
     }
+    if (outcome.kind === "none" && !options.spendOnUnrecognized) return;
 
-    // A returned browser session spends the state even when Logto returned an
-    // OAuth error or a malformed callback. This keeps the login-CSRF binding
-    // single-use on native, where there is no callback route to revisit.
     this.options.storage.takeTransaction();
     await this.flushStorageReporting();
-    this.reportError(
-      new Error(
-        outcome.kind === "error"
-          ? outcome.message
-          : "convex-logto: the native sign-in return did not include an authorization code and state.",
-      ),
-    );
+    // `benign` is the user declining at Logto — a completed flow, not a fault.
+    if (outcome.kind === "error") {
+      this.reportError(new Error(outcome.message));
+    } else if (outcome.kind === "none") {
+      this.reportError(
+        new Error(
+          "convex-logto: the native sign-in return did not include an authorization code and state.",
+        ),
+      );
+    }
     await this.restore();
     this.navigateReplace(this.options.afterSignIn);
   }


### PR DESCRIPTION
Closes #183. Fixes a regression in #162, found by adversarially reviewing that batch.

**Storage preparation.** Every other public engine entry starts with `await this.prepareStorage()`; `completeSignIn` called `storage.takeTransaction()` synchronously. `NativeSessionStorageArea` serves that from a map populated only by `prepare()`, so on the cold start this method exists for the stash read as absent and `remove("txn")` **deleted it** — the user got *"this sign-in callback doesn't match a sign-in started in this browser tab"* and retrying the same URL could not work either. The race is the expected interleaving, not an edge case: React commits child effects before parent effects, so the app's `Linking.getInitialURL()` is issued before the provider's `engine.start()`, and `prepare()` needs two sequential bridge round trips against `getInitialURL`'s one.

**One completion at a time.** The docs tell apps to wire both `getInitialURL()` and `addEventListener("url")`, and on some Android returns `openAuthSessionAsync` resolving *and* Linking emitting is routine. A new `inflightCompletion` latch spans both doors, so a duplicate delivery waits for the first instead of finding a spent stash and reporting a replayed callback. Deliberately not `inflightSignIn`: the case this path exists for is a browser promise that never settles, so waiting on that would hang.

**Only spend the stash for an actual OIDC response.** The provider's guard is `url.startsWith(redirectUri)`, and the old code consumed the transaction for anything that was not `pending` — so `myapp://callback/done` or `myapp://callbacks` silently destroyed an in-flight sign-in. `spendOnUnrecognized` now separates the two callers: a URL handed back by the system browser *is* this sign-in's return and still spends the login-CSRF state, while a forwarded deep link with no OIDC response is ignored. A `benign` return (the user declining at Logto) also stops being reported as a fault, matching web.

**Tests** — a cold start where the deep link beats a gated SecureStore read, and a prefix-matching link with no OIDC response followed by the real one. Both fail on `main`. Docs and the method's JSDoc now describe what "ignored" actually covers.