### PR TITLE
fix(session): bound session requests and re-arm recovery per generation

### DIFF
--- a/.changeset/transport-timeout.md
+++ b/.changeset/transport-timeout.md
@@ -1,0 +1,9 @@
+---
+"convex-logto": patch
+---
+
+Session mode: bound every session request, and let a fresh transient failure
+always arm a fresh recovery. A request that never answered parked the in-flight
+refresh forever — every later token fetch merged into it — and a recovery loop
+left over from before a sign-out could swallow the arming of a new one for up to
+thirty seconds.

--- a/packages/convex-logto/src/session-client.test.ts
+++ b/packages/convex-logto/src/session-client.test.ts
@@ -785,6 +785,32 @@ it("stops recovering once the session is gone", async () => {
   expect(handlers.refresh).toHaveBeenCalledTimes(attempts);
 });
 
+it("arms a fresh recovery after a sign-out interrupts the old one", async () => {
+  // The stale loop sleeps for up to 30s before it notices the generation
+  // changed. A bare in-progress flag would let it swallow the arming of a new
+  // one, stranding the tab for that whole window.
+  let sleeps = 0;
+  const { engine, storage, handlers } = makeHarness({
+    storedSession: { token: "session-token-0", sessionId: "session-id-0" },
+    storedIdToken: staleToken(),
+    recoverySleep: () => {
+      sleeps += 1;
+      return new Promise<void>(() => {});
+    },
+  });
+  handlers.refresh.mockRejectedValue(transientError());
+
+  engine.start();
+  expect((await settled(engine)).status).toBe("unauthenticated");
+  expect(sleeps).toBe(1);
+
+  engine.handleExternalSignOut();
+  storage.writeSession({ token: "session-token-1", sessionId: "session-id-1" });
+  await engine.fetchAccessToken(true);
+
+  expect(sleeps).toBe(2);
+});
+
 it("agrees it is signed out when a forced fetch cannot refresh", async () => {
   // Convex parks at `noAuth` after a single null and only re-arms when
   // `ConvexProviderWithAuth` calls `setAuth` again, which needs this flip.

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -580,7 +580,7 @@ export class SessionAuthEngine {
   private inflightSignIn: Promise<void> | null = null;
   private inflightCompletion: Promise<void> | null = null;
   private inflightRefresh: Promise<string | null> | null = null;
-  private recovering = false;
+  private recoveringFor: number | null = null;
   private storagePreparation: Promise<void> | null = null;
   /** Invalidates async credential work that started before a local sign-out. */
   private authGeneration = 0;
@@ -1570,11 +1570,15 @@ export class SessionAuthEngine {
    * attempt count: a five-minute outage must still end with the tab signed in.
    */
   private scheduleRecovery(): void {
-    if (this.recovering) return;
-    this.recovering = true;
+    // Keyed by generation, not a bare flag: a loop left over from before a
+    // sign-out sleeps for up to 30s before it notices, and a bare flag would
+    // make that stale loop swallow the arming of a fresh one — stranding the tab
+    // in exactly the way this exists to prevent.
+    if (this.recoveringFor === this.authGeneration) return;
     const generation = this.authGeneration;
+    this.recoveringFor = generation;
     void this.recover(generation).finally(() => {
-      this.recovering = false;
+      if (this.recoveringFor === generation) this.recoveringFor = null;
     });
   }
 

--- a/packages/convex-logto/src/session-transport.test.ts
+++ b/packages/convex-logto/src/session-transport.test.ts
@@ -73,6 +73,31 @@ it("keeps the ConvexError payload the session error taxonomy reads", async () =>
   });
 });
 
+it("gives up on a request that never answers", async () => {
+  // A hung request would park `inflightRefresh` forever: every later token fetch
+  // merges into it and the recovery loop waits on it.
+  vi.useFakeTimers();
+  try {
+    vi.stubGlobal("fetch", () => new Promise<never>(() => {}));
+    const client = {
+      url: "https://example.convex.cloud",
+      action: vi.fn(),
+    } as unknown as ConvexReactClient;
+
+    const pending = defaultSessionTransport(client)
+      .action(refresh, { sessionToken: "st" })
+      .then(
+        () => "resolved",
+        (error: unknown) => (error as Error).message,
+      );
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    await expect(pending).resolves.toContain("timed out");
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
 it("falls back to the client when it exposes no deployment URL", async () => {
   // `ConvexReactClient.url` exists on every supported version — a client-shaped
   // stub should still mount rather than throw.

--- a/packages/convex-logto/src/session-transport.ts
+++ b/packages/convex-logto/src/session-transport.ts
@@ -40,10 +40,50 @@ export function createDeploymentSessionTransport(
 ): SessionTransport {
   const client = new ConvexHttpClient(url, {
     skipConvexDeploymentUrlCheck: true,
+    // `ConvexHttpClient` calls `fetch` with no signal of its own. A request that
+    // never answers would park `inflightRefresh` forever — every later token
+    // fetch merges into that promise, and the recovery loop waits on it — which
+    // is the same wedge this module exists to avoid, moved from a stopped socket
+    // to a stalled request.
+    fetch: timeoutFetch,
   });
   return {
-    action: (reference, args) => client.action(reference, args),
+    // Belt and braces: `fetch` is a newer constructor option than this package's
+    // `convex` floor, so an older client would ignore it. The race settles the
+    // caller either way.
+    action: (reference, args) => withDeadline(client.action(reference, args)),
   };
+}
+
+/** Same ceiling the cookie transport applies to its own routes. */
+const SESSION_ACTION_TIMEOUT_MS = 10 * 1000;
+
+function timeoutError(): Error {
+  return new Error("convex-logto: the session request timed out.");
+}
+
+const timeoutFetch: typeof globalThis.fetch = (input, init) => {
+  const controller = new AbortController();
+  const error = timeoutError();
+  const timer = setTimeout(
+    () => controller.abort(error),
+    SESSION_ACTION_TIMEOUT_MS,
+  );
+  return globalThis
+    .fetch(input, { ...init, signal: controller.signal })
+    .finally(() => clearTimeout(timer));
+};
+
+async function withDeadline<T>(operation: Promise<T>): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(timeoutError()), SESSION_ACTION_TIMEOUT_MS);
+  });
+  try {
+    return await Promise.race([operation, deadline]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
 }
 
 /**


### PR DESCRIPTION
Closes #185.

**No timeout on the deployment transport.** `ConvexHttpClient.action` calls `fetch` with no signal of its own, while the cookie transport bounds every route at 10 s. A request that never answers parks `inflightRefresh` — cleared only in `.finally()` — so every later `fetchAccessToken` merges into a promise that will not settle and the recovery loop waits on it forever. That is the same "wedges until a reload" failure `session-transport.ts` was written to remove, relocated from a stopped socket to a stalled request. The client now gets an aborting `fetch`, plus a race as belt and braces: the `fetch` constructor option is newer than this package's `convex >= 1.21.0` floor, so an older client would silently ignore it.

**A stale recovery loop could swallow a fresh one.** `scheduleRecovery` short-circuited on a bare `recovering` flag while capturing the generation at schedule time, so a loop left over from before a sign-out kept the flag set until it woke — up to thirty seconds — and any new transient failure in that window got no recovery at all, stranding the tab in exactly the way #164's fix exists to prevent. The latch is now keyed by auth generation.

**Tests** — a `fetch` that never answers rejects at the deadline under fake timers; a sign-out mid-sleep followed by a new failure arms a second loop. Both fail on `main`.