### PR TITLE
fix(session): never delete a credential another tab owns

### DIFF
--- a/.changeset/cross-tab-credential-ownership.md
+++ b/.changeset/cross-tab-credential-ownership.md
@@ -1,0 +1,9 @@
+---
+"convex-logto": patch
+---
+
+Session mode: a revoked session no longer signs every other tab out.
+
+The session credential is shared by every tab on an origin, but the session id an engine watches is its own. When another tab signed in it replaced that credential, and a revocation of the *previous* session then cleared storage — deleting the credential the new session was reached by, signing every tab out and orphaning the row that was just created. An engine now checks the stored session id against the one it is holding and adopts a newer credential instead of destroying it.
+
+The revoke of a session that a fresh sign-in replaced is also awaited before the post-callback navigation. With no `navigate` prop that navigation is `location.replace`, which tears down the in-flight request, so the cleanup was unreliable in exactly the default configuration; it is bounded by the transport deadline and still reported rather than thrown.

--- a/packages/convex-logto/src/session-client.test.ts
+++ b/packages/convex-logto/src/session-client.test.ts
@@ -878,6 +878,28 @@ describe("callback", () => {
     );
   });
 
+  it("waits for the superseded revoke before navigating away", async () => {
+    // With no `navigate` prop the navigation is `location.replace`, which tears
+    // down the in-flight request — so a fire-and-forget revoke would be lost in
+    // exactly the default configuration.
+    const { engine, storage, handlers, navigate } = makeHarness({
+      storedSession: { token: "old-token", sessionId: "old-session" },
+    });
+    setURL("http://localhost:5173/callback?code=c1&state=s1");
+    storage.stashTransaction({ state: "s1" });
+    handlers.callback.mockResolvedValue(sessionResult(1));
+    const revoke = deferred<Record<string, never>>();
+    handlers.signOut.mockReturnValue(revoke.promise);
+
+    engine.start();
+    expect((await settled(engine)).status).toBe("authenticated");
+    await vi.waitFor(() => expect(handlers.signOut).toHaveBeenCalled());
+    expect(navigate).not.toHaveBeenCalled();
+
+    revoke.resolve({});
+    await vi.waitFor(() => expect(navigate).toHaveBeenCalledWith("/"));
+  });
+
   it("never revokes the superseded session in cookie mode", async () => {
     // The stored value there is a marker, not a credential, and the same-origin
     // sign-out route reads the *cookie* — which the callback just replaced. A
@@ -1815,6 +1837,26 @@ describe("external events", () => {
     expect(storage.readSession()).toBeNull();
     expect(storage.readIdToken()).toBeNull();
     expect(engine.getSnapshot().status).toBe("unauthenticated");
+  });
+
+  it("handleRevoked adopts a credential another tab wrote instead of deleting it", async () => {
+    // The credential is shared by every tab on the origin, but the session id
+    // this engine watches is its own. Another tab signing in replaces that
+    // credential without telling us; revoking the session we *used* to hold must
+    // not delete the one that took its place.
+    const { engine, storage } = makeHarness();
+    storage.writeSession({ token: "t1", sessionId: "s1" });
+    storage.writeIdToken(freshToken());
+    engine.start();
+    await settled(engine);
+    storage.writeSession({ token: "t2", sessionId: "s2" });
+
+    engine.handleRevoked();
+
+    await vi.waitFor(() => expect(engine.getSnapshot().sessionId).toBe("s2"));
+    expect(storage.readSession()).toEqual({ token: "t2", sessionId: "s2" });
+    expect(storage.readIdToken()).not.toBeNull();
+    expect(engine.getSnapshot().status).toBe("authenticated");
   });
 
   it("handleExternalSignOut clears this tab's bearer and flips unauthenticated", async () => {

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -811,9 +811,13 @@ export class SessionAuthEngine {
         superseded.sessionId !== "" &&
         superseded.sessionId !== result.sessionId
       ) {
-        // Not awaited: the user is signed in and navigating. A failure here is
-        // reported, never fatal.
-        void this.revokeAbandonedSession(
+        // Awaited, and before the navigation: with no `navigate` prop the next
+        // line is `location.replace`, which tears down an in-flight request —
+        // so fire-and-forget would make the cleanup unreliable in exactly the
+        // default configuration. Bounded by the transport's own deadline, and
+        // reported rather than thrown, so it can delay a sign-in but never fail
+        // one.
+        await this.revokeAbandonedSession(
           superseded.token,
           "signed in over an existing session",
         );
@@ -839,15 +843,13 @@ export class SessionAuthEngine {
   }
 
   /**
-   * Kill a session the server minted for a sign-in the client has since
-   * abandoned. Without this the row — and the Logto grant behind it — would
-   * outlive every credential anyone holds for it.
-   */
-  /**
-   * Drop a component session no client holds a credential for any more.
+   * Drop a component session no client holds a credential for any more — one the
+   * server minted for a sign-in that was abandoned, or one a fresh sign-in
+   * replaced. Without this the row, and the Logto grant behind it, outlive every
+   * credential anyone holds for them.
    *
-   * Never federated and never an RFC 7009 revoke — the component only deletes
-   * its own row, because the Logto grant behind it can be shared with sibling
+   * Never federated and never an RFC 7009 revoke: the component only deletes its
+   * own row, because the Logto grant behind it can be shared with sibling
    * sessions of the same OP session.
    */
   private async revokeAbandonedSession(
@@ -1621,19 +1623,37 @@ export class SessionAuthEngine {
     this.events("convex_authenticated");
   }
 
-  /** The reactive `sessionValid` subscription pushed `false`: the session was revoked. */
   /**
    * Surface a failure the provider detected rather than the engine — today a
    * broken `sessionValid` subscription. Routed through the same observer as
-   * every other auth error, and deduped by Error identity, so a re-render that
-   * hands back the same object stays quiet.
+   * every other auth error.
    */
   reportWatchFailure(error: Error): void {
     this.reportError(error);
   }
 
+  /** The reactive `sessionValid` subscription pushed `false`: the session was revoked. */
   handleRevoked(): void {
     this.authGeneration += 1;
+    // The credential in storage is shared with every tab on this origin, and the
+    // session id this engine watches is its own. Another tab signing in replaces
+    // that credential without telling us, so a revocation of the session we
+    // *used* to hold must not delete the one that took its place — that would
+    // sign every tab out and orphan the session just created. Adopt it instead.
+    const stored = this.options.storage.readSession();
+    const watched = this.snapshot.sessionId;
+    if (
+      this.options.serverHeldCredential !== true &&
+      stored !== null &&
+      watched !== null &&
+      stored.sessionId !== "" &&
+      stored.sessionId !== watched
+    ) {
+      void this.restore().catch((error: unknown) => {
+        this.reportError(this.asError(error));
+      });
+      return;
+    }
     this.events("revoked");
     this.options.storage.clearAll();
     void this.flushStorage().catch((error: unknown) => {


### PR DESCRIPTION
Closes #184.

## The bug

The session credential lives in storage shared by every tab on the origin, but the session id an engine watches is its own. When another tab signs in it replaces that credential without telling this one. `handleRevoked()` then cleared storage outright — so a revocation of the session this tab *used* to hold deleted the credential the new session was reached by. Every tab signed out, and the row that had just been created was orphaned until GC took it 190 days later.

An engine now compares the stored session id against the one it is holding, and adopts the newer credential (`restore()`) instead of destroying it. Cookie mode is excluded: the stored value there is a marker, not a credential.

## Secondary

The revoke of a session that a fresh sign-in replaced was fire-and-forget immediately before `navigateReplace`. With no `navigate` prop that is `location.replace`, which tears down the in-flight request — so the cleanup was unreliable in exactly the default configuration. It is now awaited, bounded by the transport deadline landed in #189, and still reported rather than thrown, so it can delay a sign-in but never fail one.

## Tests

Two regression tests, both verified to fail on `main` and pass here:

- `handleRevoked adopts a credential another tab wrote instead of deleting it`
- `waits for the superseded revoke before navigating away`

Full sequence green locally: `lint`, `format:check`, `check-types`, `test`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-tab session handling to preserve newer credentials when an older session is revoked.
  * Prevented users from being unexpectedly signed out when another tab replaces the active session.
  * Sign-in navigation now waits for superseded-session cleanup to complete, while cleanup failures are reported without blocking sign-in.
* **Tests**
  * Added coverage for cross-tab credential replacement and sign-in cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->