### PR TITLE
fix(native): recover Convex auth after a failed token refresh

### DIFF
--- a/.changeset/native-auth-recovery.md
+++ b/.changeset/native-auth-recovery.md
@@ -1,0 +1,9 @@
+---
+"convex-logto": patch
+---
+
+Native: a failed token refresh no longer wedges the app.
+
+Convex stops asking for a token after one `null`, and re-arms only when the `isAuthenticated` the bridge reports goes false→true. `@logto/rn` latches its own flag true and never moves it, so one failed refresh — an expired refresh token, a tunnel hiccup on resume — disarmed Convex for the life of the process, and tapping Sign in changed nothing the provider was watching. The bridge now folds the token failure into what it reports, and clears it once `signIn()` resolves (after, never before: clearing on the way in would re-arm Convex against tokens that are still broken) or when the SDK genuinely goes unauthenticated and back.
+
+Native session storage got two fixes as well. One unreadable SecureStore key no longer fails the whole store — a locked device, or an entry written under a stricter keychain accessibility class, fails only its own read, so it is treated as absent for now and left in place rather than costing the user their session. And a credential delete SecureStore refused is now reported until a later delete actually lands, instead of being consumed by the first `flush()` that saw it: the credential is still on the device, so sign-out has not happened.

--- a/.changeset/session-example-recovery.md
+++ b/.changeset/session-example-recovery.md
@@ -1,0 +1,7 @@
+---
+"convex-logto": patch
+---
+
+Examples: the Expo session example now handles a reclaimed sign-in, and both session examples report auth errors.
+
+`examples/expo-session` wires `expo-linking` into `completeSignIn`, so a sign-in the OS reclaimed while Logto had the browser — routine on a low-memory Android device — finishes from the cold-start deep link instead of leaving the user signed in at Logto and signed out in the app. Both session examples now pass `onAuthError` and swallow the rejection at the call site, matching `examples/expo`.

--- a/examples/expo-session/App.tsx
+++ b/examples/expo-session/App.tsx
@@ -10,6 +10,7 @@ import {
   Unauthenticated,
   useQuery,
 } from "convex/react";
+import * as Linking from "expo-linking";
 import { StatusBar } from "expo-status-bar";
 import { Component, useCallback, useEffect, useState } from "react";
 import type { ReactNode } from "react";
@@ -178,11 +179,11 @@ function SignedIn() {
     <View style={styles.stack}>
       <Button
         title={`Sign out (${user?.email ?? user?.sub ?? "user"})`}
-        onPress={() => void signOut()}
+        onPress={() => void signOut().catch(() => {})}
       />
       <Button
         title="Sign out everywhere"
-        onPress={() => void signOutEverywhere()}
+        onPress={() => void signOutEverywhere().catch(() => {})}
       />
       <SessionBoundary>
         <Me />
@@ -196,7 +197,29 @@ function SignIn() {
   // No callback route: `signIn()` opens the system browser and resolves when the
   // deep link returns to the provider's `redirectUri`.
   const { signIn } = useLogtoAuth();
-  return <Button title="Sign in" onPress={() => void signIn()} />;
+  // The provider's `onAuthError` reports the failure; swallowing the rejection
+  // here just keeps it from also surfacing unhandled.
+  return <Button title="Sign in" onPress={() => void signIn().catch(() => {})} />;
+}
+
+// The sign-in flow lives in one in-memory promise. If the OS reclaims the app
+// while Logto has the browser — routine on a low-memory Android device — that
+// promise dies with the process and the redirect arrives as a cold-start deep
+// link instead. Handing every link to `completeSignIn` finishes the exchange;
+// anything that is not this app's redirect, or carries no OIDC response, is
+// ignored without disturbing a sign-in already in progress.
+function DeepLinkBridge() {
+  const { completeSignIn } = useLogtoAuth();
+  useEffect(() => {
+    void Linking.getInitialURL().then((url) => {
+      if (url) void completeSignIn(url);
+    });
+    const subscription = Linking.addEventListener("url", ({ url }) => {
+      void completeSignIn(url);
+    });
+    return () => subscription.remove();
+  }, [completeSignIn]);
+  return null;
 }
 
 export default function App() {
@@ -208,7 +231,14 @@ export default function App() {
       // Advisory, app-supplied device description shown by listSessions(). The
       // library never inspects the device — this is exactly what you pass.
       clientDescriptor={{ platform: "native", os: Platform.OS }}
+      // `signIn` / `signOut` reject rather than storing the error, so without
+      // this a dismissed browser sheet or an offline sign-out is an unhandled
+      // rejection and nothing else.
+      onAuthError={(error) => {
+        console.error("auth error", error);
+      }}
     >
+      <DeepLinkBridge />
       <SafeAreaView style={styles.screen}>
         <Text style={styles.title}>convex-logto native session mode</Text>
         {/* Convex's own auth state: a cold start with a live SecureStore ID

--- a/examples/expo-session/package.json
+++ b/examples/expo-session/package.json
@@ -14,6 +14,7 @@
     "convex": "^1.44.0",
     "convex-logto": "workspace:*",
     "expo": "~56.0.12",
+    "expo-linking": "~56.0.4",
     "expo-secure-store": "~56.0.4",
     "expo-status-bar": "~56.0.4",
     "expo-web-browser": "~56.0.5",

--- a/examples/vite-react-session/src/App.tsx
+++ b/examples/vite-react-session/src/App.tsx
@@ -134,10 +134,12 @@ function SignedIn() {
   const { user, signOut, signOutEverywhere } = useLogtoAuth();
   return (
     <>
-      <button onClick={() => void signOut()}>
+      {/* The provider's `onAuthError` reports the failure; swallowing the
+          rejection here just keeps it from also surfacing unhandled. */}
+      <button onClick={() => void signOut().catch(() => {})}>
         Sign out ({String(user?.email ?? user?.sub ?? "user")})
       </button>{" "}
-      <button onClick={() => void signOutEverywhere()}>
+      <button onClick={() => void signOutEverywhere().catch(() => {})}>
         Sign out everywhere
       </button>
       <SessionBoundary>
@@ -150,7 +152,9 @@ function SignedIn() {
 
 function SignIn() {
   const { signIn } = useLogtoAuth();
-  return <button onClick={() => void signIn()}>Sign in</button>;
+  return (
+    <button onClick={() => void signIn().catch(() => {})}>Sign in</button>
+  );
 }
 
 export function App() {

--- a/examples/vite-react-session/src/main.tsx
+++ b/examples/vite-react-session/src/main.tsx
@@ -19,6 +19,11 @@ createRoot(document.getElementById("root")!).render(
       // Advisory, app-supplied device description shown by listSessions(). The
       // library never sniffs a User-Agent — this is exactly what you pass.
       clientDescriptor={{ platform: "web", browser: "this browser" }}
+      // Sign-in and sign-out reject rather than storing the error, so without
+      // this an offline sign-out is an unhandled rejection and nothing else.
+      onAuthError={(error) => {
+        console.error("auth error", error);
+      }}
     >
       <App />
     </ConvexLogtoSessionProvider>

--- a/packages/convex-logto/src/native-session-client.test.ts
+++ b/packages/convex-logto/src/native-session-client.test.ts
@@ -654,3 +654,71 @@ describe("native session adapters", () => {
     expect(webBrowser.openAuthSessionAsync).not.toHaveBeenCalled();
   });
 });
+
+describe("native storage faults", () => {
+  it("one unreadable key does not lose the whole store", async () => {
+    // A locked device, or an entry written under a stricter keychain
+    // accessibility class, fails only its own read. Failing the load would sign
+    // the user out over a condition that clears on the next unlock.
+    const secureStore = fakeSecureStore();
+    await seedSession(secureStore, freshToken());
+    const readable = secureStore.getItemAsync;
+    secureStore.getItemAsync = vi.fn((key: string) =>
+      key.endsWith(".txn")
+        ? Promise.reject(new Error("keychain item is not accessible"))
+        : readable(key),
+    );
+
+    const storage = new NativeSessionStorageArea(
+      "https://native.convex.cloud",
+      secureStore,
+    );
+    await expect(storage.prepare()).resolves.toBeUndefined();
+    expect(storage.readSession()?.token).toBe("session-token-old");
+    // Never deleted: the value is unreadable now, not gone.
+    expect(secureStore.deleteItemAsync).not.toHaveBeenCalled();
+  });
+
+  it("still refuses SecureStore that reports itself unavailable", async () => {
+    const secureStore = fakeSecureStore();
+    secureStore.isAvailableAsync = vi.fn().mockResolvedValue(false);
+    const storage = new NativeSessionStorageArea(
+      "https://native.convex.cloud",
+      secureStore,
+    );
+    await expect(storage.prepare()).rejects.toBeInstanceOf(
+      NativeSessionStorageError,
+    );
+  });
+
+  it("keeps reporting a credential that survived its delete", async () => {
+    // Unlike a write fault, this one is not consumed by the flush that reports
+    // it: the credential is still on the device, so sign-out has not happened
+    // and every later flush must keep saying so.
+    const secureStore = fakeSecureStore();
+    await seedSession(secureStore, freshToken());
+    const storage = new NativeSessionStorageArea(
+      "https://native.convex.cloud",
+      secureStore,
+    );
+    await storage.prepare();
+    secureStore.deleteItemAsync = vi.fn(() =>
+      Promise.reject(new Error("keychain delete failed")),
+    );
+
+    storage.clearAll();
+    await expect(storage.flush()).rejects.toBeInstanceOf(
+      NativeSessionStorageError,
+    );
+    await expect(storage.flush()).rejects.toBeInstanceOf(
+      NativeSessionStorageError,
+    );
+
+    secureStore.deleteItemAsync = vi.fn((key: string) => {
+      secureStore.data.delete(key);
+      return Promise.resolve();
+    });
+    storage.clearAll();
+    await expect(storage.flush()).resolves.toBeUndefined();
+  });
+});

--- a/packages/convex-logto/src/native-session-client.ts
+++ b/packages/convex-logto/src/native-session-client.ts
@@ -7,6 +7,9 @@ import type {
 type StoredTransaction = { state: string };
 type StoredName = "session" | "idToken" | "txn";
 
+/** Artifacts whose durable removal failure must keep reaching the caller. */
+const CREDENTIAL_NAMES = new Set<StoredName>(["session", "idToken"]);
+
 /** Structural subset of expo-secure-store used by native session mode. */
 export type NativeSecureStore = {
   isAvailableAsync?(): Promise<boolean>;
@@ -56,6 +59,15 @@ export class NativeSessionStorageArea implements SessionStorageAdapter {
   private preparation: Promise<void> | null = null;
   private pendingWrites: Promise<void> = Promise.resolve();
   private pendingWriteError: unknown;
+  /**
+   * Credential deletes SecureStore refused, kept until one actually lands.
+   *
+   * A write fault is consumed by the flush that reports it — the engine reacts
+   * once and moves on. A *removal* fault is a different thing: the credential is
+   * still on the device, so sign-out has not happened, and forgetting it after
+   * one report would let every later flush claim success.
+   */
+  private pendingRemovals = new Map<StoredName, unknown>();
   private prefix: string;
 
   constructor(
@@ -81,6 +93,18 @@ export class NativeSessionStorageArea implements SessionStorageAdapter {
 
   async flush(): Promise<void> {
     await this.pendingWrites;
+    if (this.pendingRemovals.size > 0) {
+      // Fold any write fault into the same report and consume it. Reporting the
+      // removals first is right — a credential still on the device is the worse
+      // failure — but leaving the write error queued behind them would surface
+      // it much later, long after the flush it belonged to.
+      const causes: unknown[] = [...this.pendingRemovals.values()];
+      if (this.pendingWriteError !== undefined) {
+        causes.push(this.pendingWriteError);
+        this.pendingWriteError = undefined;
+      }
+      throw storageError(causes);
+    }
     if (this.pendingWriteError !== undefined) {
       const cause = this.pendingWriteError;
       this.pendingWriteError = undefined;
@@ -151,7 +175,18 @@ export class NativeSessionStorageArea implements SessionStorageAdapter {
     }
     const names = ["session", "idToken", "txn"] as const;
     const stored = await Promise.all(
-      names.map((name) => this.secureStore.getItemAsync(this.key(name))),
+      names.map(async (name) => {
+        try {
+          return await this.secureStore.getItemAsync(this.key(name));
+        } catch {
+          // One unreadable key is not a broken store. A locked device, or an
+          // entry written under a stricter keychain accessibility class, fails
+          // only its own read. Treat it as absent for now and leave it in place:
+          // failing the whole load, or deleting the key, would cost the user a
+          // session over a condition that clears by itself on the next unlock.
+          return null;
+        }
+      }),
     );
     for (let index = 0; index < names.length; index++) {
       const name = names[index];
@@ -185,7 +220,18 @@ export class NativeSessionStorageArea implements SessionStorageAdapter {
 
   private remove(name: StoredName): void {
     this.values.delete(name);
-    this.enqueue(() => this.secureStore.deleteItemAsync(this.key(name)));
+    this.enqueue(async () => {
+      try {
+        await this.secureStore.deleteItemAsync(this.key(name));
+        this.pendingRemovals.delete(name);
+      } catch (error) {
+        // A spent `txn` stash holds the OIDC `state` string, not a bearer, so it
+        // stays on the ordinary write-fault path. A credential that survived its
+        // delete is the case that has to keep being reported.
+        if (!CREDENTIAL_NAMES.has(name)) throw error;
+        this.pendingRemovals.set(name, error);
+      }
+    });
   }
 
   private enqueue(operation: () => Promise<void>): void {

--- a/packages/convex-logto/src/native.bridge.test.tsx
+++ b/packages/convex-logto/src/native.bridge.test.tsx
@@ -32,8 +32,28 @@ vi.mock("@logto/rn", () => ({
   useLogto: () => mockLogto,
   UserScope: { Email: "email" },
 }));
+type ReportedAuth = {
+  isLoading: boolean;
+  isAuthenticated: boolean;
+  fetchAccessToken: (args: {
+    forceRefreshToken: boolean;
+  }) => Promise<string | null>;
+};
+let reportedAuth: ReportedAuth | null = null;
+
 vi.mock("convex/react", () => ({
-  ConvexProviderWithAuth: ({ children }: { children: unknown }) => children,
+  // The real provider calls `useAuth` and stops asking for a token after one
+  // `null`. Calling it here is what makes the bridge's own contract observable.
+  ConvexProviderWithAuth: ({
+    children,
+    useAuth,
+  }: {
+    children: unknown;
+    useAuth: () => ReportedAuth;
+  }) => {
+    reportedAuth = useAuth();
+    return children;
+  },
   useConvexAuth: () => ({ isLoading: false, isAuthenticated: false }),
 }));
 
@@ -64,6 +84,10 @@ async function renderProvider(onAuthError?: (error: Error) => void) {
 beforeEach(() => {
   mockLogto.signIn.mockReset().mockResolvedValue(undefined);
   mockLogto.signOut.mockReset().mockResolvedValue(undefined);
+  mockLogto.getIdToken.mockReset().mockResolvedValue(undefined);
+  mockLogto.getAccessToken.mockReset().mockResolvedValue(undefined);
+  mockLogto.isAuthenticated = false;
+  reportedAuth = null;
 });
 
 afterEach(async () => {
@@ -123,4 +147,49 @@ it("still logs when no onAuthError is provided", async () => {
   } finally {
     consoleError.mockRestore();
   }
+});
+
+it("a failed token fetch disarms Convex, and signing in re-arms it", async () => {
+  // Convex stops asking after one `null`, and re-arms only when the reported
+  // `isAuthenticated` goes false→true. `@logto/rn` latches its own flag true and
+  // never moves it, so a single failed refresh used to wedge the app for the
+  // life of the process: tapping Sign in changed nothing the provider watched.
+  mockLogto.isAuthenticated = true;
+  mockLogto.getIdToken.mockResolvedValue("id-token-1");
+  await renderProvider();
+  expect(reportedAuth?.isAuthenticated).toBe(true);
+
+  mockLogto.getIdToken.mockRejectedValue(new Error("refresh token expired"));
+  let token: string | null = "unset";
+  await act(async () => {
+    token = await reportedAuth!.fetchAccessToken({ forceRefreshToken: true });
+  });
+  expect(token).toBeNull();
+  expect(reportedAuth?.isAuthenticated).toBe(false);
+
+  mockLogto.getIdToken.mockResolvedValue("id-token-2");
+  await act(async () => {
+    await capturedApi!.signIn();
+  });
+  expect(reportedAuth?.isAuthenticated).toBe(true);
+});
+
+it("a sign-in that fails leaves Convex disarmed", async () => {
+  // `onRetry` runs only after `signIn` resolves. Clearing the failure on the way
+  // in would re-arm Convex against tokens that are still broken.
+  mockLogto.isAuthenticated = true;
+  mockLogto.getIdToken.mockResolvedValue("id-token-1");
+  await renderProvider(() => {});
+
+  mockLogto.getIdToken.mockRejectedValue(new Error("refresh token expired"));
+  await act(async () => {
+    await reportedAuth!.fetchAccessToken({ forceRefreshToken: false });
+  });
+  expect(reportedAuth?.isAuthenticated).toBe(false);
+
+  mockLogto.signIn.mockRejectedValue(new Error("auth_session_failed"));
+  await act(async () => {
+    await capturedApi!.signIn().catch(() => {});
+  });
+  expect(reportedAuth?.isAuthenticated).toBe(false);
 });

--- a/packages/convex-logto/src/native.tsx
+++ b/packages/convex-logto/src/native.tsx
@@ -44,6 +44,7 @@ import { normalizeLogtoPublicConfig } from "./component/endpoint";
 function useAuthFromLogto() {
   const { isAuthenticated, isInitialized, getIdToken, getAccessToken, client } =
     useLogto();
+  const tokenFailure = useContext(TokenFailureContext);
 
   // One loading frame on the render Logto first authenticates, reported as
   // not-yet-authenticated, so Convex resets cleanly instead of surfacing the
@@ -58,26 +59,76 @@ function useAuthFromLogto() {
           // Clearing the access token forces a token-endpoint round-trip that also
           // rotates the ID token; bail if it fails rather than return a stale token.
           await client.clearAccessToken();
-          if (!(await getAccessToken())) return null;
+          if (!(await getAccessToken())) {
+            tokenFailure?.onFailed();
+            return null;
+          }
         }
-        return (await getIdToken()) ?? null;
+        const idToken = (await getIdToken()) ?? null;
+        if (idToken === null) tokenFailure?.onFailed();
+        return idToken;
       } catch {
         // The refresh token expired or Logto is unreachable: report "no token" so
         // Convex transitions cleanly to unauthenticated instead of surfacing a
         // rejection (which is how a returning user's stale session should resolve).
+        tokenFailure?.onFailed();
         return null;
       }
     },
-    [client, getIdToken, getAccessToken],
+    [client, getIdToken, getAccessToken, tokenFailure],
   );
+
+  // Convex stops asking for a token after one `null`, and re-arms only when the
+  // `isAuthenticated` we report goes false→true. `@logto/rn` latches its own
+  // flag true and never moves it, so without folding the failure in here the
+  // provider stays disarmed for the life of the process and Sign in cannot
+  // recover it — the token never fails *again*, so nothing re-triggers.
+  const failed = tokenFailure?.failed ?? false;
+
+  // The SDK genuinely going unauthenticated and back (a sign-out, then a fresh
+  // sign-in) is a recovery too, and it happens without anyone calling `onRetry`.
+  const previouslyAuthenticated = useRef(isAuthenticated);
+  useEffect(() => {
+    const recovered = !previouslyAuthenticated.current && isAuthenticated;
+    previouslyAuthenticated.current = isAuthenticated;
+    if (recovered) tokenFailure?.onRetry();
+  }, [isAuthenticated, tokenFailure]);
 
   return useMemo(
     () => ({
       isLoading,
-      isAuthenticated: reportedAuthenticated,
+      isAuthenticated: reportedAuthenticated && !failed,
       fetchAccessToken,
     }),
-    [isLoading, reportedAuthenticated, fetchAccessToken],
+    [isLoading, reportedAuthenticated, failed, fetchAccessToken],
+  );
+}
+
+/**
+ * Whether the last token fetch failed, and the two ways out of it.
+ *
+ * Lives above `<ConvexProviderWithAuth>` so `useAuthFromLogto` (which runs
+ * inside it) can fold the failure into what it reports, and `useLogtoAuth`
+ * (which runs inside the app) can clear it when the user signs in again.
+ */
+type TokenFailureState = {
+  failed: boolean;
+  onFailed: () => void;
+  onRetry: () => void;
+};
+const TokenFailureContext = createContext<TokenFailureState | undefined>(
+  undefined,
+);
+
+function useTokenFailureState(): TokenFailureState {
+  const [failed, setFailed] = useState(false);
+  return useMemo(
+    () => ({
+      failed,
+      onFailed: () => setFailed(true),
+      onRetry: () => setFailed(false),
+    }),
+    [failed],
   );
 }
 
@@ -233,6 +284,8 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
   // configQuery mode.
   const [fetched, setFetched] = useState<ConfigState>({ status: "loading" });
 
+  const tokenFailure = useTokenFailureState();
+
   useEffect(() => {
     if (!configQuery) return undefined;
     let active = true;
@@ -291,12 +344,14 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
   return (
     <RedirectUriContext.Provider value={redirectUri}>
       <AuthErrorContext.Provider value={onAuthError}>
-        <LogtoProvider config={logtoConfig}>
-          <ConvexProviderWithAuth client={client} useAuth={useAuthFromLogto}>
-            <ConvexAuthPhaseWatcher events={events} />
-            {children}
-          </ConvexProviderWithAuth>
-        </LogtoProvider>
+        <TokenFailureContext.Provider value={tokenFailure}>
+          <LogtoProvider config={logtoConfig}>
+            <ConvexProviderWithAuth client={client} useAuth={useAuthFromLogto}>
+              <ConvexAuthPhaseWatcher events={events} />
+              {children}
+            </ConvexProviderWithAuth>
+          </LogtoProvider>
+        </TokenFailureContext.Provider>
       </AuthErrorContext.Provider>
     </RedirectUriContext.Provider>
   );
@@ -349,6 +404,7 @@ export function useLogtoAuth(): LogtoAuth {
   const { signIn, signOut, getIdTokenClaims } = useLogto();
   const defaultRedirectUri = useContext(RedirectUriContext);
   const onAuthError = useContext(AuthErrorContext);
+  const tokenFailure = useContext(TokenFailureContext);
   const [user, setUser] = useState<IdTokenClaims>();
 
   useEffect(() => {
@@ -382,6 +438,11 @@ export function useLogtoAuth(): LogtoAuth {
           );
         }
         await signIn(uri);
+        // After, never before: a background fetch racing the browser sheet could
+        // re-arm Convex against a token that is still broken, and setting it back
+        // to failed would then be the *stale* write. Once `signIn` resolves the
+        // SDK holds fresh tokens, so this is the point where retrying is honest.
+        tokenFailure?.onRetry();
       } catch (caught) {
         // Dismissing the system browser rejects with `auth_session_failed`.
         // Report it so an app's "signing in…" state has something to clear on.
@@ -393,7 +454,7 @@ export function useLogtoAuth(): LogtoAuth {
         throw failure;
       }
     },
-    [signIn, defaultRedirectUri, onAuthError],
+    [signIn, defaultRedirectUri, onAuthError, tokenFailure],
   );
   const doSignOut = useCallback(async () => {
     try {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       expo:
         specifier: ~56.0.12
         version: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.8(react@19.2.8))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
+      expo-linking:
+        specifier: ~56.0.4
+        version: 56.0.17(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)
       expo-secure-store:
         specifier: ~56.0.4
         version: 56.0.4(expo@56.0.12)
@@ -1247,6 +1250,10 @@ packages:
 
   '@expo/env@2.3.0':
     resolution: {integrity: sha512-9HnnIbzwTTdbwSjNLXTk0fPm9ZwMJ7c1/31tsni8HZ8Q62KzYCyspahH+V365vg5J6lr001DzNwBxVWSaYCQLg==}
+    engines: {node: '>=20.12.0'}
+
+  '@expo/env@2.3.1':
+    resolution: {integrity: sha512-JvBdZa5OkTd+dGEtt3fLW9OF6RlIp9SNu9VyMSiWPV5szMDTSAYbX8Uj3cRvZcU1zzaRbqnTSsHk2AE8WXHfxQ==}
     engines: {node: '>=20.12.0'}
 
   '@expo/expo-modules-macros-plugin@0.2.2':
@@ -3899,6 +3906,12 @@ packages:
       expo: '*'
       react-native: '*'
 
+  expo-constants@56.0.24:
+    resolution: {integrity: sha512-DxlaB0pb0Cy0QEnd7WnKVy4L5nCRQY58ePCWCTvbIVbZZ4zTt1Y1xFHeAjT+2p4PGXJ87bjWskscajyXUopP2g==}
+    peerDependencies:
+      expo: '*'
+      react-native: '*'
+
   expo-crypto@56.0.4:
     resolution: {integrity: sha512-fRNEhoXRXgAWBpe3/hq5X+KXTit3OZqdiAGts1YvNEUHQb+H5591mpPac0Yw+sZg9pXcrjRnzo5AxvZaENpc7g==}
     peerDependencies:
@@ -3922,6 +3935,12 @@ packages:
     peerDependencies:
       expo: '*'
       react: '*'
+
+  expo-linking@56.0.17:
+    resolution: {integrity: sha512-+i2VaJlD2eamBIBetpOAkfFGYPEn01kZfRF73bbjlNiI8AkTqWWClZuJqxqHy3/R8dCCbwTTq/dJqI5dskuDvQ==}
+    peerDependencies:
+      react: '*'
+      react-native: '*'
 
   expo-modules-autolinking@56.0.16:
     resolution: {integrity: sha512-9JnL4N46P8ubDpDIfWolDn7nxU2j1rY67xY/dNVuyH0m+HG+r/JI16VYtjIf4COpZtEuFo4D3h3MBeFzGucMnw==}
@@ -7310,6 +7329,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@expo/env@2.3.1':
+    dependencies:
+      chalk: 4.1.2
+      debug: 4.4.3
+      getenv: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@expo/expo-modules-macros-plugin@0.2.2': {}
 
   '@expo/fingerprint@0.19.4':
@@ -9938,9 +9965,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  expo-constants@56.0.24(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8)):
+    dependencies:
+      '@expo/env': 2.3.1
+      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.8(react@19.2.8))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
+      react-native: 0.85.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8)
+    transitivePeerDependencies:
+      - supports-color
+
   expo-crypto@56.0.4(expo@56.0.12):
     dependencies:
-      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.8(react@19.2.8))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
+      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.8(react@19.2.8))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
 
   expo-file-system@56.0.8(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8)):
     dependencies:
@@ -9970,6 +10005,16 @@ snapshots:
     dependencies:
       expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.8(react@19.2.8))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
       react: 19.2.8
+
+  expo-linking@56.0.17(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8):
+    dependencies:
+      expo-constants: 56.0.24(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))
+      invariant: 2.2.4
+      react: 19.2.8
+      react-native: 0.85.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8)
+    transitivePeerDependencies:
+      - expo
+      - supports-color
 
   expo-modules-autolinking@56.0.16(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
Closes #179. Closes #180. Closes #181. Closes #182.

## #179 — the bridge wedge

Convex stops asking for a token after one `null`, and re-arms only when the `isAuthenticated` the bridge reports goes false→true. `@logto/rn` latches its own flag true and never moves it, so a single failed refresh — an expired refresh token, a tunnel hiccup on resume — disarmed Convex for the life of the process. Tapping Sign in changed nothing the provider was watching, so there was no way back short of restarting the app.

A `TokenFailureContext` above `<ConvexProviderWithAuth>` now carries `{ failed, onFailed, onRetry }`. `useAuthFromLogto` reports `reportedAuthenticated && !failed` and marks the failure whenever `fetchAccessToken` has to return `null`. `useLogtoAuth().signIn()` clears it **after** `signIn(uri)` resolves — clearing on the way in would re-arm Convex against tokens that are still broken — and a genuine SDK false→true transition clears it too.

## #181 / #182 — native session storage

- `load()` no longer fails the whole store on one unreadable key. A locked device, or an entry written under a stricter keychain accessibility class, fails only its own read: treat it as absent for now and **leave it in place**. Deleting it, or failing the load, would cost a user their session over a condition that clears on the next unlock. `isAvailableAsync() === false` still fails loudly.
- A credential delete SecureStore refused is kept in `pendingRemovals` until a later delete actually lands, mirroring the browser area. A write fault is consumed by the flush that reports it; a removal fault must not be, because the credential is still on the device and sign-out has not happened. A queued write fault is folded into that same report rather than surfacing much later.

## #180 — examples

`examples/expo-session` wires `expo-linking` into `completeSignIn` (the reclaimed-sign-in path documented in `react-native.mdx`), and both session examples now pass `onAuthError` and swallow the rejection at the call site, matching `examples/expo`.

## Tests

Four regression tests, all verified to fail on `main`:

- `a failed token fetch disarms Convex, and signing in re-arms it`
- `a sign-in that fails leaves Convex disarmed`
- `one unreadable key does not lose the whole store`
- `keeps reporting a credential that survived its delete`

The `convex/react` mock in `native.bridge.test.tsx` now calls `useAuth`, which is what makes the bridge's contract observable at all.

Full sequence green locally: `lint`, `format:check`, `check-types`, `test`.