### PR TITLE
chore(ci): scope the npm publish credential and typecheck what CI missed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,17 @@ on:
 
 concurrency: release-${{ github.ref }}
 
+# Deliberately minimal at the workflow level. The verification job below runs
+# the whole workspace's install scripts, tests and builds — every one of them
+# third-party code — and must never do so with the ability to mint an npm
+# publish token. `id-token: write` is granted to the publish job alone.
 permissions:
-  contents: write # changesets opens/updates the "Version Packages" PR
-  pull-requests: write # changesets opens/updates the "Version Packages" PR
-  id-token: write # OIDC trusted publishing to npm (provenance, no token)
+  contents: read
 
 jobs:
-  release:
+  # Same sequence as the `verify` check on pull requests, re-run against the
+  # merge commit. No write permissions and no OIDC.
+  verify:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -25,12 +29,6 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-          registry-url: https://registry.npmjs.org
-
-      # Trusted publishing (OIDC) requires npm >= 11.5.1; the runner ships older.
-      # Pin exactly to avoid a future npm release silently changing publish behavior.
-      - name: Update npm for trusted publishing
-        run: npm install -g npm@11.19.0
 
       - run: pnpm install --frozen-lockfile
 
@@ -52,6 +50,36 @@ jobs:
 
       - run: pnpm lint:package
 
+  release:
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # changesets opens/updates the "Version Packages" PR
+      pull-requests: write # changesets opens/updates the "Version Packages" PR
+      id-token: write # OIDC trusted publishing to npm (provenance, no token)
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      # Trusted publishing (OIDC) requires npm >= 11.5.1; the runner ships older.
+      # Pin exactly to avoid a future npm release silently changing publish behavior.
+      - name: Update npm for trusted publishing
+        run: npm install -g npm@11.19.0
+
+      - run: pnpm install --frozen-lockfile
+
+      # No build step: the package's own `prepublishOnly` builds it, and only if
+      # changesets actually publishes. Nothing else in the workspace is touched
+      # while the OIDC credential is live.
       - name: Create "Version Packages" PR or publish to npm
         uses: changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a # v2.1.0
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,8 @@ clean clone (`git clone --no-hardlinks . /tmp/x && cd /tmp/x && pnpm install
 
 - **Lint/format:** OXC — `oxlint` + `oxfmt`. Run `format` before committing; CI enforces `lint` + `format:check`. oxfmt is scoped to `src/` (never reformats `package.json` / `CHANGELOG.md` / lockfiles).
 - **Runtime:** the library must run in Convex's **V8 runtime** — use Web APIs (e.g. `crypto.subtle`), not Node-only APIs.
-- **TypeScript:** strict, `verbatimModuleSyntax`.
+- **TypeScript:** strict, `verbatimModuleSyntax`. `check-types` runs **two** projects: `tsconfig.json` (the library, `types: []` — no ambient Node globals, because it runs in Convex's V8 runtime) and `tsconfig.test.json` (the same options plus `@types/node` and ES2023, over the test files the base config excludes so tsup and the component build never emit them). A new test file is covered automatically; a test that needs a Node API belongs in the second project only.
+- **Build verification:** `packages/convex-logto/scripts/verify-build-artifacts.mjs` runs at the end of every build. It asserts every path in `package.json#exports` exists, and — since nothing else ever loads them — that every relative specifier under `dist/component/` resolves and `dist/component/convex.config.js` imports. Without it a broken component emit surfaces on a *user's* next `convex dev` push.
 - **`convex-logto/react` is ESM-only** because it depends on `@logto/react@4` (ESM-only). The root `convex-logto` entry is dual ESM+CJS.
 - **Auth model:** validate Logto's **ID token** over OIDC (Convex rejects `at+jwt` access tokens). No manual JWT config — the signing algorithm and JWKS are auto-discovered.
 - **Component schema evolution:** new fields on existing component tables must be `v.optional(...)`. There is no migration mechanism — the schema ships inside the npm package and is validated against existing rows on the app's next push. A brand-new table may have required fields.
@@ -85,7 +86,14 @@ clean clone (`git clone --no-hardlinks . /tmp/x && cd /tmp/x && pnpm install
 
 ## Releasing
 
-Changesets + npm **OIDC trusted publishing** (provenance, no tokens):
+Changesets + npm **OIDC trusted publishing** (provenance, no tokens). The
+Release workflow is split in two jobs on purpose: `verify` runs the whole
+workspace's install scripts, tests and builds with `contents: read` only, and
+`release` — the single job granted `id-token: write` — does nothing but check
+out, install, and hand off to `changesets/action`. Never move `id-token: write`
+back to the workflow level; it would put an npm publish credential within reach
+of every dependency's build script.
+
 
 1. `pnpm changeset` — describe the change (patch/minor/major); commit the generated `.changeset/*.md`.
 2. Merge to `main` → a **"Version Packages" PR** opens automatically (bumps version + updates `CHANGELOG.md`).

--- a/packages/convex-logto/package.json
+++ b/packages/convex-logto/package.json
@@ -82,7 +82,7 @@
   },
   "scripts": {
     "build": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\" && tsup && tsc -p tsconfig.component.json && node scripts/verify-build-artifacts.mjs",
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
     "test": "vitest run",
     "lint": "oxlint --deny-warnings src",
     "format": "oxfmt src",
@@ -119,6 +119,7 @@
     "@arethetypeswrong/cli": "^0.18.5",
     "@logto/react": "^4.0.14",
     "@logto/rn": "^1.2.0",
+    "@types/node": "^22.20.1",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "convex": "^1.44.0",

--- a/packages/convex-logto/scripts/verify-build-artifacts.mjs
+++ b/packages/convex-logto/scripts/verify-build-artifacts.mjs
@@ -7,7 +7,7 @@
 // new export added without a matching tsup entry.
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const manifest = JSON.parse(
@@ -81,3 +81,75 @@ if (missing.length > 0) {
   );
   process.exit(1);
 }
+
+/**
+ * The component half is not bundled: the Convex CLI walks `dist/component/` and
+ * bundles the modules it finds there, so every relative specifier in the emitted
+ * tree has to resolve on disk. `publint` and `attw` only look at the exports map,
+ * and nothing else ever loads these files — so a missing emit, or a specifier
+ * `tsc` rewrote in a way Node cannot resolve, would ship and surface on the
+ * *user's* next `convex dev` push instead of here.
+ */
+const componentDir = resolve(packageDir, "dist/component");
+
+function componentModules(directory, found = []) {
+  let entries;
+  try {
+    entries = readdirSync(directory, { withFileTypes: true });
+  } catch {
+    return found;
+  }
+  for (const entry of entries) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) componentModules(path, found);
+    else if (entry.name.endsWith(".js")) found.push(path);
+  }
+  return found;
+}
+
+/** Relative `import`/`export ... from` specifiers, as emitted (quotes included). */
+const RELATIVE_SPECIFIER = /\bfrom\s*["'](\.[^"']*)["']/g;
+
+const modules = componentModules(componentDir);
+if (modules.length === 0) {
+  console.error(
+    "convex-logto: the build produced no modules under dist/component/. " +
+      "The Convex CLI bundles that directory; an empty one ships a broken component.",
+  );
+  process.exit(1);
+}
+
+const unresolved = [];
+for (const modulePath of modules) {
+  const source = readFileSync(modulePath, "utf8");
+  for (const [, specifier] of source.matchAll(RELATIVE_SPECIFIER)) {
+    const target = resolve(dirname(modulePath), specifier);
+    // tsc emits extensionless specifiers under `moduleResolution: Bundler`;
+    // accept either form, since the CLI's bundler resolves both.
+    if (isFile(target) || isFile(`${target}.js`) || isFile(join(target, "index.js"))) {
+      continue;
+    }
+    unresolved.push(
+      `${modulePath.slice(packageDir.length + 1)} -> ${specifier}`,
+    );
+  }
+}
+
+if (unresolved.length > 0) {
+  console.error(
+    `convex-logto: ${unresolved.length} relative specifier(s) in dist/component/ ` +
+      `do not resolve to a file:\n  ${unresolved.join("\n  ")}`,
+  );
+  process.exit(1);
+}
+
+// The component's entry point must also actually load.
+await import(pathToFileURL(resolve(componentDir, "convex.config.js")).href).catch(
+  (error) => {
+    console.error(
+      "convex-logto: dist/component/convex.config.js could not be imported.",
+      error,
+    );
+    process.exit(1);
+  },
+);

--- a/packages/convex-logto/src/backchannel-logout.test.ts
+++ b/packages/convex-logto/src/backchannel-logout.test.ts
@@ -179,12 +179,12 @@ function harness(options?: {
   const runMutation = vi.fn((ref: unknown, args: unknown) => {
     const fn = (ref as { fn: string }).fn;
     calls.push({ fn, args });
-    return handlers[fn]!(args);
+    return (handlers[fn] as unknown as (a: unknown) => Promise<unknown>)(args);
   });
   const runAction = vi.fn((ref: unknown, args: unknown) => {
     const fn = (ref as { fn: string }).fn;
     calls.push({ fn, args });
-    return handlers[fn]!(args);
+    return (handlers[fn] as unknown as (a: unknown) => Promise<unknown>)(args);
   });
   const http = httpRouter();
   registerLogtoBackchannelLogout(http, {

--- a/packages/convex-logto/src/component/lib.test.ts
+++ b/packages/convex-logto/src/component/lib.test.ts
@@ -84,7 +84,8 @@ function subjectSessionHarness(
             first: () =>
               Promise.resolve(
                 [...matching()].toSorted(
-                  (left, right) => right.createdAt - left.createdAt,
+                  (left, right) =>
+                    Number(right.createdAt) - Number(left.createdAt),
                 )[0] ?? null,
               ),
           }),
@@ -483,6 +484,8 @@ const exchangeActionHandler = internalHandler<
     code: string;
     state: string;
     redirectUri: string;
+    devicePublicKey?: { kty: "EC"; crv: "P-256"; x: string; y: string };
+    client?: { platform?: string; os?: string; browser?: string };
   },
   {
     idToken: string;
@@ -2527,9 +2530,11 @@ describe("listSubjectSessions", () => {
       { subject: "subject-1", callerSessionId: "session-live" },
     );
 
-    expect(result.sessions.map((session) => session.sessionId)).toEqual([
-      "session-live",
-    ]);
+    expect(
+      result.sessions.map(
+        (session) => (session as { sessionId: string }).sessionId,
+      ),
+    ).toEqual(["session-live"]);
     expect(result.truncated).toBe(false);
   });
 

--- a/packages/convex-logto/src/component/revocation.test.ts
+++ b/packages/convex-logto/src/component/revocation.test.ts
@@ -201,7 +201,7 @@ describe("bounded session revocation", () => {
         },
       };
       const handler = handlerOf<
-        Record<string, string | number>,
+        Record<string, string | number | undefined>,
         { deleted: number; done: boolean }
       >(test.mutation);
 

--- a/packages/convex-logto/src/native-session-client.test.ts
+++ b/packages/convex-logto/src/native-session-client.test.ts
@@ -116,7 +116,11 @@ function makeHarness(options?: {
   };
   const transport = {
     action: (reference: unknown, args: unknown) =>
-      handlers[(reference as { fn: keyof Handlers }).fn](args),
+      (
+        handlers[(reference as { fn: keyof Handlers }).fn] as unknown as (
+          a: unknown,
+        ) => Promise<unknown>
+      )(args),
   } as SessionTransport;
   const onAuthError = vi.fn();
   const navigate = vi.fn();

--- a/packages/convex-logto/src/session-client.test.ts
+++ b/packages/convex-logto/src/session-client.test.ts
@@ -126,7 +126,11 @@ function makeHarness(options?: {
   };
   const transport = {
     action: (ref: unknown, args: unknown) =>
-      handlers[(ref as { fn: keyof Handlers }).fn](args),
+      (
+        handlers[(ref as { fn: keyof Handlers }).fn] as unknown as (
+          a: unknown,
+        ) => Promise<unknown>
+      )(args),
   } as SessionTransport;
   const storage =
     options?.storage ??
@@ -993,7 +997,7 @@ describe("callback", () => {
     setURL("http://localhost:5173/callback?code=c1&state=s1");
     storage.stashTransaction({ state: "s1" });
     const flushed = deferred<void>();
-    const realFlush = storage.flush.bind(storage);
+    const realFlush = storage.flush!.bind(storage);
     let signOutDuringFlush: Promise<void> | undefined;
     storage.flush = () => {
       if (signOutDuringFlush === undefined && storage.readSession() !== null) {

--- a/packages/convex-logto/src/session-cookie.test.ts
+++ b/packages/convex-logto/src/session-cookie.test.ts
@@ -74,7 +74,9 @@ function makeHarness(options?: { deviceBinding?: boolean }) {
     const name = getFunctionName(
       reference as FunctionReference<"action">,
     ).split(":")[1] as HandlerName;
-    return handlers[name](args);
+    return (handlers[name] as unknown as (a: unknown) => Promise<unknown>)(
+      args,
+    );
   }) as unknown as LogtoSessionAction;
   const handler = createLogtoSessionCookieHandler({
     sessionApi: api,

--- a/packages/convex-logto/src/webhooks.test.ts
+++ b/packages/convex-logto/src/webhooks.test.ts
@@ -352,12 +352,12 @@ function sessionsHarness(overrides?: {
   const runMutation = vi.fn((ref: unknown, args: unknown) => {
     const fn = (ref as { fn?: string }).fn ?? "sync";
     calls.push({ fn, args });
-    return handlers[fn]!(args);
+    return (handlers[fn] as unknown as (a: unknown) => Promise<unknown>)(args);
   });
   const runAction = vi.fn((ref: unknown, args: unknown) => {
     const fn = (ref as { fn?: string }).fn ?? "kill";
     calls.push({ fn, args });
-    return handlers[fn]!(args);
+    return (handlers[fn] as unknown as (a: unknown) => Promise<unknown>)(args);
   });
   const http = httpRouter();
   registerLogtoWebhook(http, SYNC_REF as never, {

--- a/packages/convex-logto/tsconfig.json
+++ b/packages/convex-logto/tsconfig.json
@@ -13,6 +13,10 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "verbatimModuleSyntax": true,
+    // No ambient @types packages. `@types/node` is a devDependency for the test
+    // typecheck (tsconfig.test.json), and the library must not see Node globals:
+    // it runs in Convex's V8 runtime, where `Buffer` and `node:*` do not exist.
+    "types": [],
     "noEmit": true
   },
   "include": ["src"],

--- a/packages/convex-logto/tsconfig.test.json
+++ b/packages/convex-logto/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  // The base config excludes `src/**/*.test.ts` so tsup and the component build
+  // never emit test files. That exclude also meant nothing typechecked them:
+  // vitest transpiles without checking, so type drift in a test was invisible.
+  // This config is the missing half — same options, tests included, emit off.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // Tests may use Node APIs (the webhook signature fixtures) and newer library
+    // methods; neither is available to the library itself.
+    "types": ["node"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "noEmit": true
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -367,6 +367,9 @@ importers:
       '@logto/rn':
         specifier: ^1.2.0
         version: 1.2.0(@react-native-async-storage/async-storage@2.2.0(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8)))(expo-crypto@56.0.4(expo@56.0.12))(expo-secure-store@56.0.4(expo@56.0.12))(expo-web-browser@56.0.5(expo@56.0.12)(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8)))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))
+      '@types/node':
+        specifier: ^22.20.1
+        version: 22.20.1
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -411,7 +414,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@edge-runtime/vm@5.0.0)(@types/node@26.2.0)(happy-dom@20.11.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+        version: 4.1.10(@edge-runtime/vm@5.0.0)(@types/node@22.20.1)(happy-dom@20.11.2)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
 
 packages:
 
@@ -7432,7 +7435,7 @@ snapshots:
       postcss: 8.5.26
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.8(react@19.2.8))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
+      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.8(react@19.2.8))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -9196,6 +9199,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
+  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.1(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
+
   '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
@@ -9436,7 +9447,7 @@ snapshots:
       react-refresh: 0.14.2
     optionalDependencies:
       '@babel/runtime': 7.29.7
-      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.8(react@19.2.8))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
+      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.8(react@19.2.8))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -10003,7 +10014,7 @@ snapshots:
 
   expo-keep-awake@56.0.3(expo@56.0.12)(react@19.2.8):
     dependencies:
-      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.8(react@19.2.8))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
+      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.8(react@19.2.8))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
       react: 19.2.8
 
   expo-linking@56.0.17(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8):
@@ -10052,7 +10063,7 @@ snapshots:
 
   expo-secure-store@56.0.4(expo@56.0.12):
     dependencies:
-      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.8(react@19.2.8))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
+      expo: 56.0.12(@babel/core@7.29.7)(@expo/dom-webview@56.0.5)(react-dom@19.2.8(react@19.2.8))(react-native@0.86.0(@babel/core@7.29.7)(@types/react@19.2.18)(react@19.2.8))(react@19.2.8)(typescript@5.9.3)
 
   expo-server@56.0.5: {}
 
@@ -12720,6 +12731,21 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.2.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.20.1
+      esbuild: 0.28.1
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      terser: 5.48.0
+      yaml: 2.9.0
+
   vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
@@ -12738,6 +12764,35 @@ snapshots:
   vitefu@1.1.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)):
     optionalDependencies:
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
+
+  vitest@4.1.10(@edge-runtime/vm@5.0.0)(@types/node@22.20.1)(happy-dom@20.11.2)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.1(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@edge-runtime/vm': 5.0.0
+      '@types/node': 22.20.1
+      happy-dom: 20.11.2
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.10(@edge-runtime/vm@5.0.0)(@types/node@26.2.0)(happy-dom@20.11.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
Closes #191. Closes #192. Closes #194.

## #191 — the publish credential's blast radius

`release.yml` declared `id-token: write` at the workflow level and ran the entire verification sequence in the same job. Every install script, test and build in the workspace — library, docs and five examples, all third-party code — executed with the ambient ability to mint an npm publish token. A compromised transitive dependency never had to reach the publish step; it only had to run.

Split into two jobs. `verify` has `contents: read` and no OIDC. `release` needs it, grants `contents: write` / `pull-requests: write` / `id-token: write` at the *job* level, and does nothing but check out, install and hand off to `changesets/action` — the package's own `prepublishOnly` builds it, and only if changesets actually publishes.

## #192 — nothing typechecked the tests

`tsconfig.json` excludes `src/**/*.test.ts` so tsup and the component build never emit them. That exclude also meant **no** test file was typechecked by anything, and vitest transpiles without checking.

`tsconfig.test.json` is the missing half: same options, tests included, emit off, plus `@types/node` and ES2023 for what tests legitimately use. The base config now pins `types: []`, so the library still cannot see Node globals — it runs in Convex's V8 runtime.

It surfaced 26 errors. The one that mattered: `exchangeActionHandler`'s harness type never declared `devicePublicKey`, so the test added in #175 was checking a call the types said could not happen. The rest were harness noise (`vi.fn()` inferring a non-callable union, an `unknown` row in a sort comparator, an optional `flush`), all fixed rather than suppressed.

## #194 — nothing loaded `dist/component/`

The Convex CLI walks `dist/component/` and bundles what it finds; `publint` and `attw` only read the exports map. A missing emit, or a specifier `tsc` rewrote in a way the bundler cannot resolve, would ship and surface on the *user's* next `convex dev` push.

`verify-build-artifacts.mjs` now walks the emitted tree, resolves every relative specifier, and imports `dist/component/convex.config.js`. Verified by appending a bad specifier to `dist/component/lib.js` — the build fails with the offending file and specifier named — and passing again once reverted.

Full sequence green locally: `audit:dependencies`, `lint`, `format:check`, `check-types`, `test`, `build`, `lint:package`.