### PR TITLE
chore(examples): typecheck each example's convex/ directory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Guidance for AI agents and human contributors working in this repository.
   - `src/session-device.ts` — opt-in device binding (non-extractable ECDSA P-256 in IndexedDB); bound sessions must present a proof to refresh or sign out.
   - `src/native.tsx` + `src/native-session.tsx` + `src/native-session-client.ts` — the React Native / Expo entries for bridge and session mode.
 - `docs/` — the documentation site (Fumadocs on TanStack Start; deployed to Vercel).
-- `examples/` — one app per integration. Their `convex/_generated` stubs and framework-generated files (`next-env.d.ts`, `routeTree.gen.ts`) are **committed**: CI has no Convex deployment, so a clean checkout must typecheck and build without running `convex dev`.
+- `examples/` — one app per integration. Their `convex/_generated` stubs and framework-generated files (`next-env.d.ts`, `routeTree.gen.ts`) are **committed**: CI has no Convex deployment, so a clean checkout must typecheck and build without running `convex dev`. Each example's `check-types` runs `tsc --noEmit` **twice** — once for the app, once for `convex/` — because that second project is the only place the component's public type boundary (`logtoSessionApi(components.logto)`, the shape in `_generated/component.d.ts`) is checked against a consumer.
 - `scripts/audit-dependencies.mjs` — the fail-closed dependency gate. Advisories are allowed only by exact version *and* dependency path, recorded in `SECURITY.md` with a review date. Never silence one with a `pnpm.overrides` entry.
 - `.changeset/` — Changesets config + pending release notes (workspace-level).
 

--- a/examples/expo-session/package.json
+++ b/examples/expo-session/package.json
@@ -7,7 +7,7 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit && tsc --noEmit -p convex",
     "typecheck": "pnpm check-types"
   },
   "dependencies": {

--- a/examples/expo/package.json
+++ b/examples/expo/package.json
@@ -7,7 +7,7 @@
     "start": "expo start",
     "android": "expo start --android",
     "ios": "expo start --ios",
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit && tsc --noEmit -p convex",
     "typecheck": "pnpm check-types"
   },
   "dependencies": {

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit && tsc --noEmit -p convex",
     "typecheck": "pnpm check-types"
   },
   "dependencies": {

--- a/examples/tanstack-router-spa/package.json
+++ b/examples/tanstack-router-spa/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit && tsc --noEmit -p convex",
     "typecheck": "pnpm check-types",
     "test": "vitest run"
   },

--- a/examples/tanstack-start/package.json
+++ b/examples/tanstack-start/package.json
@@ -6,7 +6,7 @@
     "dev": "vite dev",
     "build": "vite build && tsc --noEmit",
     "start": "node .output/server/index.mjs",
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit && tsc --noEmit -p convex",
     "typecheck": "pnpm check-types"
   },
   "dependencies": {

--- a/examples/vite-react-session/package.json
+++ b/examples/vite-react-session/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit && tsc --noEmit -p convex",
     "typecheck": "pnpm check-types"
   },
   "dependencies": {

--- a/examples/vite-react/package.json
+++ b/examples/vite-react/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
-    "check-types": "tsc --noEmit",
+    "check-types": "tsc --noEmit && tsc --noEmit -p convex",
     "typecheck": "pnpm check-types"
   },
   "dependencies": {


### PR DESCRIPTION
Closes #193.

The component ships its schema and function signatures inside the npm package. An app consumes them through `logtoSessionApi(components.logto)` in its own `convex/` directory — that is the boundary where a signature change actually breaks users.

Every example has a `convex/tsconfig.json`, and none of them ran it: each example's `check-types` was `tsc --noEmit`, whose `include` covers only `src`. So a change to `src/component/lib.ts` that broke `logtoSessionApi`'s consumers passed `pnpm check-types` cleanly, and the failure would have surfaced on a user's next `convex dev` push.

All seven examples now run `tsc --noEmit && tsc --noEmit -p convex`. No new stubs were needed — `convex/_generated/api.d.ts` already declares `components.logto` as `ComponentApi<"logto">` from the built package, so the check resolves the real shipped types.

Verified it discriminates: adding a `notAFunction` name to the destructured `logtoSessionApi(...)` in `examples/vite-react-session/convex/auth.ts` fails with the full list of what the component actually exports, and passes again once reverted.

`pnpm check-types` green across the workspace.