### PR TITLE
docs: add the page a stranger reads first

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,28 +4,88 @@
 [![CI](https://github.com/Fanzzzd/convex-logto/actions/workflows/ci.yml/badge.svg)](https://github.com/Fanzzzd/convex-logto/actions/workflows/ci.yml)
 [![license](https://img.shields.io/npm/l/convex-logto.svg)](./LICENSE)
 
-Use [Logto](https://logto.io) (self-hosted or cloud) as the auth provider for [Convex](https://convex.dev) React apps — an ID-token OIDC bridge plus a signed webhook user-sync, with the least setup possible.
-
-## Install
+Use [Logto](https://logto.io) — self-hosted or cloud — as the auth provider for a
+[Convex](https://convex.dev) app. React, React Native and Expo, on the web and on
+device.
 
 ```bash
 npm i convex-logto @logto/react
 ```
 
-`convex` and `react` are peers you already have.
+**[Documentation](https://convex-logto-docs.vercel.app)** · **[Quick
+start](https://convex-logto-docs.vercel.app/docs/quick-start)** · **[Why this
+package](https://convex-logto-docs.vercel.app/docs/why)** (including when to use
+something else)
+
+## What you get
+
+- **One provider on the frontend.** `<ConvexLogtoProvider>` wires Logto, Convex,
+  and the sign-in callback. No hand-rolled `useAuth` bridge.
+- **One line on the backend.** `logtoAuthConfig()` reads your environment. No JWT
+  template, no signing algorithm, no JWKS URL — it validates Logto's **ID token**
+  over OIDC, so Convex discovers the key itself.
+- **One source of truth per environment.** The frontend can pull its Logto config
+  from the Convex deployment, so you configure Logto in exactly one place.
+
+## Two modes, one identity model
+
+**Bridge mode** — Logto's SDK signs in the browser and the package bridges its ID
+token into Convex. Zero server-side state.
+
+**[Session mode](https://convex-logto-docs.vercel.app/docs/session-mode)** — a Convex
+component holds the Logto refresh token in tables your app code cannot read, and
+rotates a short-lived application session token with the browser. Live
+revocation, a "where am I signed in" device list, and nothing long-lived in
+browser storage — including on a static CDN deploy, where no same-site HttpOnly
+cookie is reachable at all. Optional same-site cookie transport and non-extractable
+device binding on top.
+
+Both present the same ID token to Convex, so identity, webhook sync and
+environment handling are identical and moving between them is an import change.
+
+## Also included
+
+- **[Webhook user sync](https://convex-logto-docs.vercel.app/docs/webhook-sync)** —
+  signature-verified Logto events into a queryable Convex `users` table.
+- **[Back-channel logout](https://convex-logto-docs.vercel.app/docs/backchannel-logout)**
+  — the OIDC endpoint, JWKS-verified, bounded and deduplicated.
+- **Organization authorization** — membership and organization roles read
+  straight out of the ID token, so `assertOrganizationRole(ctx, orgId, "admin")`
+  costs no extra round trip.
+
+## Examples
+
+Runnable apps, one per integration. Each is a full wiring you can copy.
+
+| | |
+|---|---|
+| [Vite + React](examples/vite-react) | Minimal: one provider, declarative gating |
+| [Vite + React, session mode](examples/vite-react-session) | Server-held refresh token, device list, live revocation |
+| [TanStack Router (SPA)](examples/tanstack-router-spa) | Route guards in `beforeLoad`, webhook-synced users + RBAC |
+| [TanStack Start (SSR)](examples/tanstack-start) | One SSR-safe provider, `beforeLoad` guards |
+| [Next.js App Router](examples/nextjs) | Client provider boundary + callback route |
+| [Expo](examples/expo) | Native bridge auth, deep-link sign-in, no callback route |
+| [Expo, session mode](examples/expo-session) | SecureStore credentials, reclaimed-sign-in recovery |
+
+## Status
+
+Pre-1.0. Breaking changes land in minor versions until 1.0; [issue
+#35](https://github.com/Fanzzzd/convex-logto/issues/35) tracks what 1.0 means and
+what is still missing.
 
 ## Repository
 
-This is a pnpm + Turborepo monorepo.
+A pnpm + Turborepo monorepo.
 
-- **[`packages/convex-logto`](packages/convex-logto)** — the published library. See its [README](packages/convex-logto/README.md) for full docs and quick start.
-- **[`examples/`](examples)** — runnable examples across Vite, TanStack Router/Start, and Next.js (one with role-based access).
-- **[`docs/`](docs)** — the documentation site source (Fumadocs).
+- **[`packages/convex-logto`](packages/convex-logto)** — the published library
+  (the only published package). Its [README](packages/convex-logto/README.md) is
+  the full reference.
+- **[`examples/`](examples)** — the apps in the table above.
+- **[`docs/`](docs)** — the documentation site (Fumadocs).
+- **[`CONTEXT.md`](CONTEXT.md)** — the vocabulary this codebase is written in.
+- **[`docs/adr/`](docs/adr)** — the decisions that are hard to reverse, and why.
 
-## Links
-
-- npm: <https://www.npmjs.com/package/convex-logto>
-- GitHub: <https://github.com/Fanzzzd/convex-logto>
+Contributor and agent guidance lives in [`AGENTS.md`](./AGENTS.md).
 
 ## License
 

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -16,6 +16,10 @@ Use [Logto](https://logto.io) (self-hosted or cloud) as the auth provider for a
   config from the backend, so you configure Logto in exactly one place per
   environment — the Convex deployment.
 
+Not sure this is the right package for you? [Why this package](/docs/why) is the
+honest comparison — including the cases where `@convex-dev/auth`, Clerk, or
+wiring Logto by hand is the better answer.
+
 ## Two modes
 
 - **Bridge mode** (the default everywhere below): Logto's SPA SDK signs in the

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "---Get started---",
     "index",
+    "why",
     "quick-start",
     "---Integrations---",
     "vite",

--- a/docs/content/docs/why.mdx
+++ b/docs/content/docs/why.mdx
@@ -1,0 +1,94 @@
+---
+title: Why this package
+description: What it does that hand-rolling doesn't, and when you should use something else instead.
+---
+
+If you already run Logto, this page is the honest version of "should I install
+this". It is written to be useful when the answer is no.
+
+## When you should use something else
+
+**You have no auth provider yet, and no reason to want Logto.** Use
+[`@convex-dev/auth`](https://labs.convex.dev/auth). It lives in your Convex
+deployment, owns the users table, and does OAuth, magic links, OTP and passwords
+without a second system to run. This package assumes Logto already exists — it
+does not make a case for adopting Logto.
+
+**You want a hosted provider and don't need self-hosting.** Convex ships
+first-party integrations for Clerk (`convex/react-clerk`) and Auth0
+(`convex/react-auth0`). Both are better supported than anything a single
+maintainer publishes. Logto's argument against them is that you can run it
+yourself, on your own data; if that is not an argument you need, take the
+first-party path.
+
+**You need organization *permissions*, not just roles.** Logto issues
+fine-grained organization permissions only in an organization token, audienced
+`urn:logto:organization:{id}`, which Convex will not accept as a request
+credential. Membership and organization roles work here (they ride in the ID
+token); permissions do not. See [the token custody
+ADR](https://github.com/Fanzzzd/convex-logto/blob/main/docs/adr/0002-token-custody.md).
+
+## What bridge mode actually saves you
+
+Not that much, and it is worth being clear about it. Convex accepts any OIDC
+provider through `auth.config.ts`, so wiring Logto by hand is a real option. What
+you would write yourself:
+
+- A `useAuth` bridge from `@logto/react` to `ConvexProviderWithAuth` — including
+  the force-refresh path, which has to clear the access token to make Logto
+  rotate the **ID** token, and the one-render loading pulse that otherwise shows
+  every user a logged-out flash right after sign-in.
+- `{ domain, applicationID }` in `auth.config.ts` — genuinely two lines.
+- The discovery that Logto's default OIDC signing algorithm is **ES384**, which
+  Convex rejects. This costs an afternoon the first time; the package cannot fix
+  it either, but it tells you up front (see [Quick start](/docs/quick-start)).
+
+If bridge mode were all this package did, "just write it yourself" would be
+reasonable advice.
+
+## What is actually hard to write yourself
+
+**[Session mode](/docs/session-mode).** The Logto refresh token lives in a Convex
+component, in tables your own app code cannot read; the browser holds a
+short-lived ID token and a rotating application session token. That buys live
+revocation, a "where am I signed in" list, and a browser that holds nothing
+long-lived — on a static CDN deploy, where no same-site HttpOnly cookie is
+reachable at all.
+
+The reason this is not a weekend project is the failure modes, not the happy
+path. A Logto refresh token must never be presented twice — reuse detection
+destroys the whole grant, including sibling sessions that share it. So a refresh
+whose outcome is *unknown* cannot be retried and cannot be discarded; a
+deployment misconfiguration must never be classified as a dead session, or one
+wrong environment variable deletes every session in the deployment, one refresh
+at a time; and a token that was rotated has to be persisted before the failure
+that reported it is raised. Those rules are written down as
+[invariants](https://github.com/Fanzzzd/convex-logto/blob/main/AGENTS.md#conventions),
+each with a regression test.
+
+**Revocation that arrives before the token expires.** An ID token stays valid
+until it expires no matter what you do at the provider. Session mode subscribes
+to session liveness, so a revoked session drops the client live rather than up to
+an hour later.
+
+**[Webhook sync](/docs/webhook-sync)** and **[back-channel
+logout](/docs/backchannel-logout)** — signature verification, replay containment,
+bounded bodies, and the specific decision to *tolerate* Logto payload drift
+rather than reject it, because Logto retries a 5xx and not a 4xx, so a strict
+validator turns a schema change into silent event loss.
+
+## The shape of the promise
+
+- **One provider on the frontend.** No hand-rolled `useAuth`.
+- **One line on the backend.** No JWT template, no algorithm, no JWKS URL.
+- **One source of truth per environment** — the Convex deployment serves its own
+  Logto config to the frontend.
+- **Bridge and session mode present the same ID token to Convex**, so everything
+  downstream — identity, webhook sync, environments — is identical, and moving
+  between them is an import change.
+
+## Status
+
+Pre-1.0 and honest about it: breaking changes land in minor versions until 1.0.
+The [roadmap issue](https://github.com/Fanzzzd/convex-logto/issues/35) tracks
+what "1.0" means and what is still missing.


### PR DESCRIPTION
Adoption groundwork, per the design session: 703 npm downloads last month against 0 stars and 0 forks — people are installing this without any way to judge whether they should.

## `/docs/why`

The page that did not exist: **why this package, and when to use something else.** It leads with the cases where the answer is no —

- No auth provider yet and no reason to want Logto → `@convex-dev/auth`.
- Want hosted and don't need self-hosting → Clerk / Auth0, both first-party in Convex.
- Need organization *permissions* → not possible here; Convex will not accept an organization-audienced token.

Then it is honest about bridge mode: Convex accepts any OIDC provider through `auth.config.ts`, so hand-rolling is a real option, and the page says so — listing exactly what you would write (the `useAuth` bridge, the force-refresh path, the logged-out flash, and the ES384 discovery that costs an afternoon). If bridge mode were all this package did, "write it yourself" would be reasonable advice.

What is *not* reasonable to write yourself is session mode, and the page argues that from the failure modes rather than the feature list: a refresh token that must never be presented twice, an unknown outcome that can neither be retried nor discarded, and a misconfiguration that must never be classified as a dead session or one wrong environment variable deletes every session in the deployment.

## Root README

Still described a React-only ID-token bridge with three examples, no session mode, no native, no back-channel logout — and it is the first thing a GitHub visitor sees. Rewritten: the two modes, the full seven-example table, a status section that says pre-1.0 in as many words, and pointers to `CONTEXT.md` and `docs/adr/`.

Docs-site URLs verified live (`convex-logto-docs.vercel.app`, not the `convex-logto.vercel.app` I first assumed — that one 404s). Docs build green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the README with setup guidance, supported platforms, authentication modes, webhooks, logout, authorization, examples, and project status.
  * Added a “Why this package” guide covering supported use cases, bridge and session modes, revocation behavior, and pre-1.0 status.
  * Added navigation and comparison links to help readers evaluate authentication alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->