### PR TITLE
feat: server-side rendering with session mode, in any framework

### DIFF
--- a/.changeset/ssr-id-token-cookie.md
+++ b/.changeset/ssr-id-token-cookie.md
@@ -1,0 +1,18 @@
+---
+"convex-logto": minor
+---
+
+Server-side rendering with session mode, in any framework.
+
+`getInitialToken()` rotates the session cookie, and a framework that forbids writing cookies during render — the Next.js App Router's Server Components, notably — cannot persist that rotation. Dropping it leaves the browser holding a superseded token that later reads as reuse and kills the session, so the documented advice has been "do not seed SSR there", which in practice means no server-side identity at all.
+
+`idTokenCookie: true` on `createLogtoSessionCookieHandler` makes the route handler also write the ID token to an `HttpOnly` `__Host-convex-logto-id-token` cookie, with `Max-Age` taken from the token's own `exp`. Read it with `readLogtoIdTokenCookie(source)`, which accepts a `Request`, a raw `Cookie` header, or a store shaped like Next's `cookies()` — so there is no framework entry point to keep in step:
+
+```tsx
+const token = readLogtoIdTokenCookie(await cookies());
+const preloaded = await preloadQuery(api.me.me, {}, token ? { token } : {});
+```
+
+Nothing is minted and nothing is rotated, so the session token's reuse detection is untouched. It is opt-in because the trade-off is custody: a cookie rides on every same-origin request, reaching access logs and proxies an `Authorization` header does not. A token read this way is a bearer Convex validates, not a claim to trust — revocation is enforced by `assertSubjectHasActiveSession` inside the function you call, exactly as it is everywhere else.
+
+An ID token that is expired, malformed, or too large for a cookie is skipped rather than cleared, so a size problem cannot become a sign-out; sign-out clears the cookie unconditionally, even when the option is off, so turning it off never strands a live token.

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -21,7 +21,10 @@ description: Every export from convex-logto and its web, native, and session-mod
 | `createLogtoSessionCookieHandler(opts)` | `convex-logto` | Five-route standard-fetch handler for the optional same-site HttpOnly cookie transport. |
 | `createLogtoSessionCookieTransport(api, opts?)` | `convex-logto` | Framework-free browser adapter used by the session provider's `cookieTransport` prop. |
 | `assertLogtoSessionCookieCompatibility(opts)` | `convex-logto` | Loud Safari/device-binding compatibility guard. |
-| `LOGTO_SESSION_COOKIE_*`, `LOGTO_SESSION_CSRF_*` | `convex-logto` | Fixed cookie name/base path and CSRF header/value constants. |
+| `readLogtoIdTokenCookie(source)` | `convex-logto` | Reads the opt-in SSR ID token cookie from a `Request`, a `Cookie` header, or a Next-style store. |
+| `LOGTO_SESSION_COOKIE_*`, `LOGTO_ID_TOKEN_COOKIE_NAME`, `LOGTO_SESSION_CSRF_*` | `convex-logto` | Fixed cookie names/base path and CSRF header/value constants. |
+| `assertOrganizationMember` / `assertOrganizationRole` | `convex-logto` | Organization authorization from the ID token Convex already validated. |
+| `logtoOrganizations` / `logtoOrganizationRoles` | `convex-logto` | The same claims, read rather than asserted. |
 | `ConvexLogtoProvider` | `convex-logto/react` | Logto + Convex + auto sign-in callback in one provider. Static `config` or backend `configQuery`. |
 | `useLogtoAuth()` | `convex-logto/react` | `{ isAuthenticated, isLoading, user, signIn, signOut }`. |
 | default | `convex-logto/convex.config` | The session component, for `app.use(logto)` in `convex/convex.config.ts`. |
@@ -194,7 +197,11 @@ as a standard `(Request) => Promise<Response>` handler. Options are:
 - `allowedOrigins` — non-empty exact browser-origin allowlist;
 - `basePath` — default `/api/logto-session`;
 - `deviceBinding` — mirrors the device-binding flag so non-React mounts reject
-  the incompatible combination through the shared loud error.
+  the incompatible combination through the shared loud error;
+- `idTokenCookie` — off by default. Also writes the ID token to
+  `__Host-convex-logto-id-token`, so a server that cannot rotate the session
+  cookie during render can still read an identity. See
+  [`readLogtoIdTokenCookie`](#readlogtoidtokencookiesource).
 
 The five final path segments are `sign-in`, `callback`, `token`, `sign-out`, and
 `sessions`.
@@ -217,11 +224,87 @@ document request and always forward `headers` to the SSR response so the rotated
 seed returns empty without changing the cookie, while the browser `/token` route
 authoritatively clears a genuinely dead session.
 
+### `readLogtoIdTokenCookie(source)`
+
+Reads the ID token the route handler stored when `idTokenCookie: true`, for
+server-side rendering. `source` may be a `Request`, a raw `Cookie` header string,
+or a store shaped like Next.js's `cookies()` — so there is no framework entry
+point to keep in step, and the same call works in the Next.js App Router,
+TanStack Start, or a bare handler.
+
+```tsx
+const token = readLogtoIdTokenCookie(await cookies());
+const preloaded = await preloadQuery(api.me.me, {}, token ? { token } : {});
+```
+
+Returns `null` when the cookie is absent — including once the token has expired,
+because the cookie's `Max-Age` comes from the token's own `exp`. A cookie that
+outlived its token would server-render a page as signed in for a bearer Convex
+refuses.
+
+This mints nothing and rotates nothing, so it costs the session token's
+rotation-based theft detection nothing. What it does cost is custody: a cookie
+rides on every same-origin request, reaching access logs and proxies that an
+`Authorization` header does not — which is why it is opt-in. A token read here
+is a bearer Convex validates, not a claim to trust; revocation is enforced by
+`assertSubjectHasActiveSession` inside the function you call, exactly as it is
+everywhere else.
+
+An ID token that is already expired, is not a JWT, or is too large for a cookie
+(over 3 KiB encoded) is **skipped rather than cleared** — the previous cookie
+expires on its own instead of a size problem becoming a sign-out. Sign-out clears
+it unconditionally, even when the option is off, so turning it off never strands
+a live token.
+
 Cookie transport and device binding cannot be combined: HttpOnly makes the
 session token unavailable to the JavaScript-held signing key, and cookie
 transport already removes the off-device token-exfiltration path. The
 compatibility error applies on every browser; Safari ITP key eviction is an
 additional reason for the same exclusion.
+
+### Organization authorization
+
+Logto maps `urn:logto:scope:organizations` to an `organizations` claim and
+`urn:logto:scope:organization_roles` to an `organization_roles` claim **in the ID
+token**, and Convex passes claims it does not recognise through to
+`ctx.auth.getUserIdentity()`. So membership and roles are already inside the
+request Convex authenticated — no token exchange, no second round trip. Add the
+scopes (`ORGANIZATIONS_SCOPE`, `ORGANIZATION_ROLES_SCOPE` are exported) to the
+provider's `scopes` in bridge mode, or to `logtoSessionApi({ scopes })` in
+session mode.
+
+```ts
+import { assertOrganizationRole } from "convex-logto";
+
+export const deleteInvoice = mutation({
+  args: { organizationId: v.string(), id: v.id("invoices") },
+  handler: async (ctx, { organizationId, id }) => {
+    await assertOrganizationRole(ctx, organizationId, ["admin", "billing"]);
+    await ctx.db.delete(id);
+  },
+});
+```
+
+- `assertOrganizationMember(ctx, organizationId)` — throws a terminal
+  `organization_forbidden` unless the caller belongs to it.
+- `assertOrganizationRole(ctx, organizationId, roles)` — one role or a list; any
+  match passes. Matches on the organization **and** the role, so one
+  organization's `viewer` cannot authorize another's.
+- `logtoOrganizations(ctx)` / `logtoOrganizationRoles(ctx, organizationId)` — the
+  same claims, read rather than asserted.
+- `parseOrganizationRole(entry)` — splits Logto's `{organizationId}:{roleName}`
+  on the first colon, so a role name may contain one.
+
+A **missing scope authorizes nothing**, not everything: absent and empty are the
+same answer, because a deployment that never requested the scope is
+indistinguishable from a user who belongs to nothing, and only one reading is
+safe. The failure names the scope so a configuration gap does not read as a
+denial.
+
+Organization **permissions** are out of scope: Logto issues those only in an
+organization token, audienced `urn:logto:organization:{id}` and typed `at+jwt`,
+which Convex rejects as a request credential. See
+[ADR 0002](https://github.com/Fanzzzd/convex-logto/blob/main/docs/adr/0002-token-custody.md).
 
 ### `assertSubjectHasActiveSession(ctx, component)`
 

--- a/docs/content/docs/nextjs.mdx
+++ b/docs/content/docs/nextjs.mdx
@@ -104,13 +104,87 @@ handler module and its `allowedOrigins` are in
 [the cookie transport section](/docs/session-mode#httponly-cookie-transport-optional).
 
 <Callout type="warn">
-Do **not** call `getInitialToken()` from a layout or page to seed SSR in the App
-Router. It rotates the session cookie, and a Server Component cannot set cookies —
-Next.js only allows that in Route Handlers, Server Actions, and middleware. The
-rotated cookie would be dropped, leaving the browser holding a superseded token
-that is eventually presented outside the reuse window and read as token reuse,
-which kills the session. Skip seeding here: the provider fetches a fresh ID token
-from `/api/logto/token` right after hydration.
+Do **not** call `getInitialToken()` from a layout or page. It rotates the session
+cookie, and a Server Component cannot set cookies — Next.js only allows that in
+Route Handlers, Server Actions, and middleware. The rotated cookie would be
+dropped, leaving the browser holding a superseded token that is eventually
+presented outside the reuse window and read as token reuse, which kills the
+session. Use `readLogtoIdTokenCookie` below instead; `getInitialToken()` is still
+the right call **inside** a Route Handler, Server Action, or middleware, where
+you can forward its headers.
 </Callout>
+
+### Server-side rendering
+
+To render authenticated content on the server you need an ID token, and the only
+credential a Server Component can reach is a cookie it does not have to rotate.
+Turn on the companion cookie:
+
+```ts title="server/logto-cookie.ts"
+export const logtoCookieHandler = createLogtoSessionCookieHandler({
+  sessionApi: api.auth,
+  action: (reference, args) => client.action(reference, args),
+  allowedOrigins: ["https://app.example.com"],
+  basePath: "/api/logto",
+  idTokenCookie: true, // [!code highlight]
+});
+```
+
+The route handler now writes the ID token to an `HttpOnly` cookie alongside the
+session cookie, with `Max-Age` set from the token's own `exp`. Nothing new is
+minted and nothing is rotated, so the reuse detection that protects the session
+token is untouched. Read it anywhere:
+
+```tsx title="app/page.tsx"
+import { readLogtoIdTokenCookie } from "convex-logto";
+import { preloadQuery } from "convex/nextjs";
+import { cookies } from "next/headers";
+import { api } from "@/convex/_generated/api";
+
+export default async function Page() {
+  const token = readLogtoIdTokenCookie(await cookies());
+  const preloaded = await preloadQuery(api.me.me, {}, token ? { token } : {});
+  return <Me preloaded={preloaded} />;
+}
+```
+
+`readLogtoIdTokenCookie` takes a `Request`, a raw `Cookie` header, or a store
+shaped like Next's `cookies()` — there is no `convex-logto/nextjs` entry to keep
+in step with Next's release train, and the same call works in TanStack Start or a
+bare handler.
+
+<Callout>
+A token read here proves nothing on its own — it is a bearer Convex validates,
+and `null` simply means "render the signed-out view and let the client take
+over". **Revocation is enforced where it always is**: by
+`assertSubjectHasActiveSession` inside the function you call, not by this read.
+A cookie whose token has expired is gone with it, so the worst case is an
+unauthenticated first paint.
+</Callout>
+
+Two consequences worth knowing before you turn it on:
+
+- A cookie is attached to **every** same-origin request, so the ID token reaches
+  access logs and proxies that an `Authorization` header does not. That is the
+  custody trade-off, and it is why this is opt-in — see
+  [ADR 0002](https://github.com/Fanzzzd/convex-logto/blob/main/docs/adr/0002-token-custody.md).
+- The cookie is only as fresh as the last client-side refresh. If you want every
+  server render to have a live token, refresh in **middleware**, which *can* set
+  cookies:
+
+```ts title="middleware.ts"
+import { logtoCookieHandler } from "@/server/logto-cookie";
+
+export async function middleware(request: Request) {
+  const seed = await logtoCookieHandler.getInitialToken(request);
+  const response = NextResponse.next();
+  for (const cookie of seed.headers.getSetCookie()) {
+    response.headers.append("Set-Cookie", cookie);
+  }
+  return response;
+}
+
+export const config = { matcher: ["/((?!_next|api).*)"] };
+```
 
 Full walkthrough: [Session mode](/docs/session-mode).

--- a/packages/convex-logto/src/index.ts
+++ b/packages/convex-logto/src/index.ts
@@ -46,6 +46,7 @@ export {
   type LogtoSessionSummary,
 } from "./session";
 export {
+  LOGTO_ID_TOKEN_COOKIE_NAME,
   LOGTO_SESSION_COOKIE_BASE_PATH,
   LOGTO_SESSION_COOKIE_NAME,
   LOGTO_SESSION_CSRF_HEADER,
@@ -53,6 +54,8 @@ export {
   assertLogtoSessionCookieCompatibility,
   createLogtoSessionCookieHandler,
   createLogtoSessionCookieTransport,
+  readLogtoIdTokenCookie,
+  type LogtoCookieSource,
   type LogtoSessionAction,
   type LogtoSessionCookieHandler,
   type LogtoSessionCookieHandlerOptions,

--- a/packages/convex-logto/src/session-cookie.test.ts
+++ b/packages/convex-logto/src/session-cookie.test.ts
@@ -5,12 +5,14 @@ import { SESSION_GC_AFTER_MS } from "./component/core";
 import type { LogtoSessionApi } from "./session";
 import {
   COOKIE_SESSION_MARKER,
+  LOGTO_ID_TOKEN_COOKIE_NAME,
   LOGTO_SESSION_COOKIE_NAME,
   LOGTO_SESSION_CSRF_HEADER,
   LOGTO_SESSION_CSRF_VALUE,
   assertLogtoSessionCookieCompatibility,
   createLogtoSessionCookieHandler,
   createLogtoSessionCookieTransport,
+  readLogtoIdTokenCookie,
   type LogtoSessionAction,
 } from "./session-cookie";
 
@@ -30,19 +32,23 @@ type HandlerName =
   | "revokeSession";
 type Handlers = Record<HandlerName, ReturnType<typeof vi.fn>>;
 
-function makeHarness(options?: { deviceBinding?: boolean }) {
+function makeHarness(options?: {
+  deviceBinding?: boolean;
+  idTokenCookie?: boolean;
+  idToken?: string;
+}) {
   const handlers: Handlers = {
     signIn: vi.fn().mockResolvedValue({
       url: "https://auth.example.com/oidc/auth?state=state-1",
     }),
     callback: vi.fn().mockResolvedValue({
-      idToken: "id-token-1",
+      idToken: options?.idToken ?? "id-token-1",
       sessionToken: "session-token-1",
       sessionId: "session-id-1",
       returnTo: "/dashboard",
     }),
     refresh: vi.fn().mockResolvedValue({
-      idToken: "id-token-2",
+      idToken: options?.idToken ?? "id-token-2",
       sessionToken: "session-token-2",
       sessionId: "session-id-1",
     }),
@@ -84,6 +90,7 @@ function makeHarness(options?: { deviceBinding?: boolean }) {
     allowedOrigins: [APP_ORIGIN],
     basePath: BASE_PATH,
     deviceBinding: options?.deviceBinding,
+    idTokenCookie: options?.idTokenCookie,
   });
   return { handler, handlers, action };
 }
@@ -369,9 +376,12 @@ describe("cookie session flows", () => {
       sessionToken: "session-token-2",
       postLogoutRedirectUri: APP_ORIGIN,
     });
-    expect(response.headers.get("set-cookie")).toBe(
+    // Both cookies are expired, even though `idTokenCookie` is off here:
+    // turning the option off must not strand a live ID token in the browser.
+    expect(response.headers.getSetCookie()).toEqual([
       `${LOGTO_SESSION_COOKIE_NAME}=; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0`,
-    );
+      `${LOGTO_ID_TOKEN_COOKIE_NAME}=; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0`,
+    ]);
     await expect(response.json()).resolves.toEqual({
       endSessionUrl: "https://auth.example.com/oidc/session/end",
     });
@@ -1372,5 +1382,146 @@ describe("browser transport session management", () => {
         targetSessionId: "session-id-2",
       }),
     ).rejects.toThrow(/convex-logto/);
+  });
+});
+
+// --- SSR ID token cookie -----------------------------------------------------
+//
+// `getInitialToken` rotates the session cookie, and a framework that forbids
+// writing cookies during render cannot persist that rotation — which is why the
+// documented advice for the Next.js App Router has been to skip SSR seeding
+// entirely. This companion cookie is written only where cookies *can* be set,
+// and read anywhere.
+
+/** An ID token that expires `seconds` from now. */
+function tokenExpiringIn(seconds: number, padding = 0): string {
+  const enc = (value: unknown) =>
+    btoa(JSON.stringify(value))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  return [
+    enc({ alg: "RS256" }),
+    enc({
+      sub: "user-1",
+      exp: Math.floor(Date.now() / 1000) + seconds,
+      ...(padding > 0 ? { pad: "x".repeat(padding) } : {}),
+    }),
+    "sig",
+  ].join(".");
+}
+
+describe("SSR ID token cookie", () => {
+  it("is not written unless asked for", async () => {
+    const { handler } = makeHarness({ idToken: tokenExpiringIn(3600) });
+    const response = await handler(
+      request("token", { cookie: cookie("session-token-1") }),
+    );
+    const cookies = response.headers.getSetCookie();
+    expect(cookies).toHaveLength(1);
+    expect(cookies[0]).toContain(LOGTO_SESSION_COOKIE_NAME);
+  });
+
+  it("rides alongside the session cookie on callback and refresh", async () => {
+    const idToken = tokenExpiringIn(3600);
+    const { handler } = makeHarness({ idTokenCookie: true, idToken });
+
+    for (const route of ["callback", "token"] as const) {
+      const response = await handler(
+        request(route, {
+          cookie: cookie("session-token-1"),
+          body:
+            route === "callback"
+              ? {
+                  code: "code-1",
+                  state: "state-1",
+                  redirectUri: `${APP_ORIGIN}/callback`,
+                }
+              : {},
+        }),
+      );
+      const cookies = response.headers.getSetCookie();
+      expect(cookies).toHaveLength(2);
+      expect(cookies[1]).toContain(
+        `${LOGTO_ID_TOKEN_COOKIE_NAME}=${encodeURIComponent(idToken)}`,
+      );
+      // HttpOnly, so the credential is less reachable here than in the JSON body
+      // the same response already carries.
+      expect(cookies[1]).toContain("HttpOnly");
+      expect(cookies[1]).toContain("Secure");
+    }
+  });
+
+  it("expires with the token it holds", async () => {
+    const { handler } = makeHarness({
+      idTokenCookie: true,
+      idToken: tokenExpiringIn(120),
+    });
+    const response = await handler(
+      request("token", { cookie: cookie("session-token-1") }),
+    );
+    const idCookie = response.headers.getSetCookie()[1] ?? "";
+    const maxAge = Number(/Max-Age=(\d+)/.exec(idCookie)?.[1]);
+    // A cookie that outlived its token would server-render a page as signed in
+    // for a bearer Convex refuses.
+    expect(maxAge).toBeGreaterThan(100);
+    expect(maxAge).toBeLessThanOrEqual(120);
+  });
+
+  it("is skipped, not cleared, when the token cannot be stored", async () => {
+    // Too large for a cookie, already expired, or not a JWT at all: leave the
+    // previous cookie to expire on its own rather than turn a size problem into
+    // a sign-out.
+    for (const idToken of [
+      tokenExpiringIn(3600, 4096),
+      tokenExpiringIn(-60),
+      "not-a-jwt",
+    ]) {
+      const { handler } = makeHarness({ idTokenCookie: true, idToken });
+      const response = await handler(
+        request("token", { cookie: cookie("session-token-1") }),
+      );
+      const cookies = response.headers.getSetCookie();
+      expect(cookies).toHaveLength(1);
+      expect(cookies[0]).toContain(LOGTO_SESSION_COOKIE_NAME);
+    }
+  });
+
+  it("getInitialToken emits both cookies for the caller to forward", async () => {
+    const idToken = tokenExpiringIn(3600);
+    const { handler } = makeHarness({ idTokenCookie: true, idToken });
+    const seed = await handler.getInitialToken(
+      new Request(`${APP_ORIGIN}/`, {
+        headers: { cookie: cookie("session-token-1") },
+      }),
+    );
+    expect(seed.initialToken).toBe(idToken);
+    expect(seed.headers.getSetCookie()).toHaveLength(2);
+  });
+
+  it("reads back from a Request, a raw header, or a Next-style store", () => {
+    const idToken = tokenExpiringIn(3600);
+    const header = `${LOGTO_ID_TOKEN_COOKIE_NAME}=${encodeURIComponent(idToken)}`;
+    expect(readLogtoIdTokenCookie(header)).toBe(idToken);
+    expect(
+      readLogtoIdTokenCookie(
+        new Request(`${APP_ORIGIN}/`, { headers: { cookie: header } }),
+      ),
+    ).toBe(idToken);
+    expect(
+      readLogtoIdTokenCookie({
+        get: (name) =>
+          name === LOGTO_ID_TOKEN_COOKIE_NAME ? { value: idToken } : undefined,
+      }),
+    ).toBe(idToken);
+  });
+
+  it("reads null when the cookie is absent or empty", () => {
+    expect(readLogtoIdTokenCookie("")).toBeNull();
+    expect(
+      readLogtoIdTokenCookie(`${LOGTO_SESSION_COOKIE_NAME}=abc`),
+    ).toBeNull();
+    expect(readLogtoIdTokenCookie({ get: () => undefined })).toBeNull();
+    expect(readLogtoIdTokenCookie({ get: () => ({ value: "" }) })).toBeNull();
   });
 });

--- a/packages/convex-logto/src/session-cookie.ts
+++ b/packages/convex-logto/src/session-cookie.ts
@@ -68,6 +68,20 @@ export type LogtoSessionCookieHandlerOptions = {
    * non-React configurations fail through the same assertion.
    */
   deviceBinding?: boolean;
+  /**
+   * Also write the ID token to {@link LOGTO_ID_TOKEN_COOKIE_NAME}, so a server
+   * that cannot rotate the session cookie during render can still read an
+   * identity. Off by default.
+   *
+   * The trade-off is custody, the same one
+   * `docs/adr/0002-token-custody.md` describes: the ID token is already a
+   * request credential the browser holds, and an `HttpOnly` cookie is a *safer*
+   * place for it than script-reachable memory — but a cookie is attached to
+   * every same-origin request, so it reaches access logs and proxies that the
+   * `Authorization` header does not. Turn it on when you server-render
+   * authenticated content; leave it off otherwise.
+   */
+  idTokenCookie?: boolean;
 };
 
 export type LogtoSessionCookieSeed = {
@@ -186,6 +200,84 @@ function cookieHeader(sessionToken: string): string {
   );
 }
 
+/**
+ * Companion cookie holding the ID token itself, for server-side rendering.
+ *
+ * `getInitialToken` is the full-fidelity SSR path, but it *rotates* the session
+ * token, and a framework that forbids writing cookies during render — Next.js
+ * App Router Server Components, notably — cannot persist that rotation. Dropping
+ * it would leave the browser holding a superseded token that later reads as
+ * reuse and kills the session, so the documented advice has been "do not seed
+ * SSR there at all", which means no server-side identity at all.
+ *
+ * This cookie is written only from places that *can* set cookies (the route
+ * handler), and read anywhere. It mints nothing and rotates nothing, so it costs
+ * the rotation-based theft detection nothing either.
+ */
+export const LOGTO_ID_TOKEN_COOKIE_NAME = "__Host-convex-logto-id-token";
+
+/**
+ * Cookies are capped near 4 KB per the RFC 6265 recommendation, and a browser
+ * that refuses an oversized one gives no signal. A token this large means a
+ * tenant is putting an unusual amount into the ID token; degrade to no SSR seed
+ * rather than emit a header that silently does nothing.
+ */
+const MAX_ID_TOKEN_COOKIE_BYTES = 3 * 1024;
+
+/** Remaining lifetime of an ID token, in whole seconds, or 0 when it is unusable. */
+function idTokenMaxAge(idToken: string): number {
+  const parts = idToken.split(".");
+  const payload = parts.length === 3 ? parts[1] : undefined;
+  if (payload === undefined) return 0;
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(
+      new TextDecoder().decode(decodeBase64Url(payload)),
+    ) as unknown;
+  } catch {
+    return 0;
+  }
+  const exp = isRecord(decoded) ? decoded.exp : undefined;
+  if (typeof exp !== "number") return 0;
+  const remaining = Math.floor(exp - Date.now() / 1000);
+  return remaining > 0 ? remaining : 0;
+}
+
+function decodeBase64Url(segment: string): Uint8Array {
+  const padded = segment.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(padded.padEnd(Math.ceil(padded.length / 4) * 4, "="));
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index++) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+/**
+ * `Set-Cookie` for the ID token, or `null` when it should not be written.
+ *
+ * The cookie expires with the token it holds, so a stale one is never read back:
+ * an expired ID token would render a server page as signed in for a user Convex
+ * would refuse.
+ */
+function idTokenCookieHeader(idToken: string): string | null {
+  const maxAge = idTokenMaxAge(idToken);
+  if (maxAge === 0) return null;
+  const value = encodeURIComponent(idToken);
+  if (value.length > MAX_ID_TOKEN_COOKIE_BYTES) return null;
+  return (
+    `${LOGTO_ID_TOKEN_COOKIE_NAME}=${value}; ` +
+    `Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${maxAge}`
+  );
+}
+
+function clearIdTokenCookieHeader(): string {
+  return (
+    `${LOGTO_ID_TOKEN_COOKIE_NAME}=; Path=/; HttpOnly; Secure; ` +
+    "SameSite=Lax; Max-Age=0"
+  );
+}
+
 function clearCookieHeader(): string {
   return (
     `${LOGTO_SESSION_COOKIE_NAME}=; Path=/; HttpOnly; Secure; ` +
@@ -193,14 +285,12 @@ function clearCookieHeader(): string {
   );
 }
 
-function readCookie(request: Request): string | null {
-  const header = request.headers.get("cookie");
+function readCookieHeader(header: string | null, name: string): string | null {
   if (!header) return null;
   for (const part of header.split(";")) {
     const index = part.indexOf("=");
     if (index < 0) continue;
-    const name = part.slice(0, index).trim();
-    if (name !== LOGTO_SESSION_COOKIE_NAME) continue;
+    if (part.slice(0, index).trim() !== name) continue;
     try {
       return decodeURIComponent(part.slice(index + 1).trim()) || null;
     } catch {
@@ -208,6 +298,60 @@ function readCookie(request: Request): string | null {
     }
   }
   return null;
+}
+
+function readCookie(request: Request): string | null {
+  return readCookieHeader(
+    request.headers.get("cookie"),
+    LOGTO_SESSION_COOKIE_NAME,
+  );
+}
+
+/**
+ * Anything a server framework hands you that can produce cookies: a `Request`,
+ * a raw `Cookie` header, or a store shaped like Next.js's `cookies()`.
+ *
+ * Taking all three keeps this package free of any framework dependency — there
+ * is no `convex-logto/nextjs` entry to keep in step with Next's release train,
+ * and the same call works in TanStack Start, Remix, or a bare handler.
+ */
+export type LogtoCookieSource =
+  | Request
+  | string
+  | { get(name: string): { value: string } | undefined };
+
+/**
+ * Read the ID token a route handler stored for server-side rendering.
+ *
+ * Requires `idTokenCookie: true` on {@link createLogtoSessionCookieHandler};
+ * returns `null` otherwise, and whenever the token has expired out of its own
+ * cookie. Pair it with Convex's `preloadQuery` / `fetchQuery`:
+ *
+ * @example
+ * // app/page.tsx — a Server Component, which cannot set cookies
+ * const token = readLogtoIdTokenCookie(await cookies());
+ * const preloaded = await preloadQuery(api.me.me, {}, token ? { token } : {});
+ *
+ * The token is a bearer Convex validates, not a claim to trust here: a `null`
+ * means render the signed-out view and let the client take over, and a non-null
+ * one still proves nothing until Convex accepts it. Revocation is enforced the
+ * same way it is everywhere else — by `assertSubjectHasActiveSession` inside the
+ * function you call, not by this read.
+ */
+export function readLogtoIdTokenCookie(
+  source: LogtoCookieSource,
+): string | null {
+  if (typeof source === "string") {
+    return readCookieHeader(source, LOGTO_ID_TOKEN_COOKIE_NAME);
+  }
+  if (source instanceof Request) {
+    return readCookieHeader(
+      source.headers.get("cookie"),
+      LOGTO_ID_TOKEN_COOKIE_NAME,
+    );
+  }
+  const entry = source.get(LOGTO_ID_TOKEN_COOKIE_NAME);
+  return entry === undefined || entry.value === "" ? null : entry.value;
 }
 
 function routeFor(request: Request, basePath: string): CookieRoute | null {
@@ -473,6 +617,29 @@ export function createLogtoSessionCookieHandler(
   );
   const allowedOrigins = normalizeAllowedOrigins(options.allowedOrigins);
 
+  /**
+   * Every `Set-Cookie` a successful exchange or refresh should emit.
+   *
+   * The session cookie always; the ID token only when asked for, and only when
+   * it fits and has time left — an ID token cookie that outlives its token would
+   * server-render a page as signed in for a bearer Convex refuses.
+   */
+  const sessionCookieHeaders = (result: {
+    sessionToken: string;
+    idToken: string;
+  }): Headers => {
+    const headers = new Headers();
+    headers.append("Set-Cookie", cookieHeader(result.sessionToken));
+    if (options.idTokenCookie === true) {
+      const header = idTokenCookieHeader(result.idToken);
+      // A token too large to store, or already expired, leaves the previous
+      // cookie in place rather than clearing it: the old one expires on its own,
+      // and clearing would turn a size problem into a sign-out.
+      if (header !== null) headers.append("Set-Cookie", header);
+    }
+    return headers;
+  };
+
   const refreshFromCookie = async (request: Request) => {
     const sessionToken = readCookie(request);
     if (sessionToken === null) {
@@ -552,7 +719,7 @@ export function createLogtoSessionCookieHandler(
               sessionId: result.sessionId,
               returnTo: result.returnTo,
             },
-            { headers: { "Set-Cookie": cookieHeader(result.sessionToken) } },
+            { headers: sessionCookieHeaders(result) },
             origin,
           );
         }
@@ -560,14 +727,17 @@ export function createLogtoSessionCookieHandler(
           const result = await refreshFromCookie(request);
           return jsonResponse(
             { idToken: result.idToken, sessionId: result.sessionId },
-            { headers: { "Set-Cookie": cookieHeader(result.sessionToken) } },
+            { headers: sessionCookieHeaders(result) },
             origin,
           );
         }
         case "sign-out": {
-          const headers = new Headers({
-            "Set-Cookie": clearCookieHeader(),
-          });
+          const headers = new Headers();
+          headers.append("Set-Cookie", clearCookieHeader());
+          // Always cleared, even when the companion cookie was never enabled:
+          // turning the option off must not leave a live ID token behind, and a
+          // clear for a cookie that does not exist is inert.
+          headers.append("Set-Cookie", clearIdTokenCookieHeader());
           const postLogoutRedirectUri = optionalString(
             body,
             "postLogoutRedirectUri",
@@ -818,7 +988,9 @@ export function createLogtoSessionCookieHandler(
       }
       try {
         const result = await refreshFromCookie(request);
-        headers.set("Set-Cookie", cookieHeader(result.sessionToken));
+        for (const value of sessionCookieHeaders(result).getSetCookie()) {
+          headers.append("Set-Cookie", value);
+        }
         return {
           initialToken: result.idToken,
           initialSessionId: result.sessionId,


### PR DESCRIPTION
Closes the last confirmed "would make someone give up on this package" gap: **session mode has no server-side identity.**

## The problem, precisely

`getInitialToken()` is the SSR seed, and it works — in a Route Handler. It cannot work in a Next.js App Router Server Component, because it **rotates the session cookie** and Server Components cannot set cookies. Dropping the rotation leaves the browser holding a superseded token that is eventually presented outside the reuse window, read as token reuse, and kills the session. The docs said so, and concluded: don't seed SSR here. Which means `preloadQuery` / `fetchQuery` never get a token, and nothing authenticated renders on the server.

## The fix

The route handler already runs where cookies *can* be set. With `idTokenCookie: true` it also writes the ID token to `__Host-convex-logto-id-token`, `HttpOnly`, with `Max-Age` taken from the token's own `exp`. A Server Component only ever **reads** it:

```tsx
const token = readLogtoIdTokenCookie(await cookies());
const preloaded = await preloadQuery(api.me.me, {}, token ? { token } : {});
```

Nothing new is minted and nothing is rotated, so the reuse detection protecting the session token is untouched — that was the constraint that ruled out the obvious alternative (a non-rotating mint action, which would remove theft *detection* for anyone who used it).

`readLogtoIdTokenCookie` takes a `Request`, a raw `Cookie` header, or a store shaped like Next's `cookies()`. So there is **no `convex-logto/nextjs` entry** to keep in step with Next's release train, and the same call works in TanStack Start or a bare handler.

## Why it is opt-in

Per ADR 0002, custody is a setting. An `HttpOnly` cookie is a *safer* place for the ID token than the script-reachable memory it already lives in — but a cookie rides on every same-origin request, so it reaches access logs and proxies that an `Authorization` header does not. Worth it when you server-render authenticated content; not worth it otherwise.

Two things the docs are explicit about:

- A token read this way **proves nothing**. It is a bearer Convex validates, and `null` just means render the signed-out view. Revocation is enforced where it always is — `assertSubjectHasActiveSession` inside the function you call — so SSR inherits it rather than bypassing it.
- The cookie is only as fresh as the last client refresh. The docs show the middleware pattern for making every server render live, since middleware *can* set cookies.

## Failure modes, decided deliberately

- Expired, malformed, or over 3 KiB encoded → **skipped, not cleared**. The previous cookie expires on its own; a size problem must not become a sign-out.
- `Max-Age` from `exp` → a cookie never outlives its token, so SSR can't render "signed in" for a bearer Convex refuses.
- Sign-out clears it **unconditionally**, even when the option is off, so turning the option off never strands a live token.

## Tests

7 new (78 in the cookie suite, 607 total). They cover both directions of every decision above, including a check that the two `Set-Cookie` values survive the `Headers` → `Response` → CORS round trip — a merge there would have silently dropped one.

Full sequence green: `lint`, `format:check`, `check-types`, `test`, `build`, `lint:package`.

## Follow-up

No example exercises the cookie transport at all, so neither the transport nor this path is covered end-to-end by a runnable app. Filing that separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added opt-in SSR ID-token cookie support for improved server-side authentication preloading.
  - Added utilities for reading ID-token cookies from requests, headers, and framework cookie stores.
  - ID-token cookies are validated, expire with the token, reject invalid or oversized values, and are cleared on sign-out.
  - Added organization membership, role, claim-reading, and authorization helpers.

- **Documentation**
  - Expanded API and Next.js guidance covering SSR usage, security considerations, cookie freshness, and organization authorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->