### PR TITLE
feat(session): organization and API-resource tokens, fetchUserInfo, getIdToken

### DIFF
--- a/.changeset/organization-resource-tokens.md
+++ b/.changeset/organization-resource-tokens.md
@@ -1,0 +1,34 @@
+---
+"convex-logto": minor
+---
+
+Session mode: organization and API-resource tokens, `fetchUserInfo`, `getIdToken`
+
+`useLogtoAuth()` gains `getOrganizationTokenClaims(organizationId)`,
+`getAccessTokenClaims(resource)`, `fetchUserInfo()` and `getIdToken()`, closing
+the last gap against `@logto/react`'s `useLogto()`. The component mints the
+token from the session's Logto refresh token and returns **what it authorizes**
+— nothing long-lived enters `window`. `exposeAccessTokens: true` on
+`logtoSessionApi()` opts into the token string itself, for a caller that must
+reach a non-Convex API from the browser; without it the token-returning methods
+reject by name rather than quietly returning nothing.
+
+Re-export the two new actions (`exchangeToken`, `fetchUserInfo`) from your
+`logtoSessionApi(...)` module to enable them. A module that has not been
+updated keeps working — the methods report the missing export instead.
+
+Organization membership and *roles* still need none of this: Logto puts them in
+the ID token, so `assertOrganizationRole` costs no round trip. This is for
+fine-grained organization permissions and registered API resources.
+
+`resources` on `logtoSessionApi()` is no longer a no-op. It is the input to the
+resource exchange — and it has to be set before sign-in, because Logto refuses
+to issue a token for a resource the grant never named.
+
+The exchange runs inside the same claim as `refresh`, so it can answer the
+transient `refresh_in_flight` and must be retried like any other. That is not
+caution: Logto rotates the refresh token on a rule blind to what the grant was
+for, and only past 70% of its lifetime, so an exchange outside the claim would
+look correct until real tokens aged and then start tripping reuse detection on a
+grant sibling sessions share. Verified against a live deployment and against
+Logto's source; `docs/adr/0003-organization-token-exchange.md` records it.

--- a/.changeset/organization-resource-tokens.md
+++ b/.changeset/organization-resource-tokens.md
@@ -25,10 +25,17 @@ fine-grained organization permissions and registered API resources.
 resource exchange — and it has to be set before sign-in, because Logto refuses
 to issue a token for a resource the grant never named.
 
-The exchange runs inside the same claim as `refresh`, so it can answer the
-transient `refresh_in_flight` and must be retried like any other. That is not
-caution: Logto rotates the refresh token on a rule blind to what the grant was
-for, and only past 70% of its lifetime, so an exchange outside the claim would
-look correct until real tokens aged and then start tripping reuse detection on a
-grant sibling sessions share. Verified against a live deployment and against
-Logto's source; `docs/adr/0003-organization-token-exchange.md` records it.
+The exchange runs inside the same claim as `refresh`. The client serializes the
+two behind the same lock and retries, so an app does not have to — but a second
+tab or device can still see the transient `refresh_in_flight`.
+
+That sharing is not caution. Logto rotates the refresh token on a rule blind to
+what the grant was for, and for a confidential client only once the token is
+past 70% of its lifetime — so an exchange outside the claim would look correct
+until real tokens aged, then start tripping reuse detection on a grant sibling
+sessions share. Measured on a public client, where the same rule rotates every
+time: a plain refresh, an organization token and a resource token all rotate.
+`docs/adr/0003-organization-token-exchange.md` records it.
+
+The optional same-site cookie transport gains a sixth route (`tokens`) so both
+new methods work there too.

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -139,6 +139,8 @@ export const {
   listSessions,
   renameSession,
   revokeSession,
+  exchangeToken,
+  fetchUserInfo,
   sessionValid,
 } = logtoSessionApi(components.logto);
 ```
@@ -146,11 +148,15 @@ export const {
 Options: `scopes` (server-configured — the browser can't request its own),
 `reuseWindowMs` (default 10s), `endpoint` / `appId` / `clientSecret` env
 overrides, and the same narrowly scoped `allowInsecureHttp` compatibility escape
-hatch described above. `resources` **currently buys nothing** here: the component
-holds the refresh token and hands the browser only the ID token, so the access
-token a resource indicator requests is discarded — while a resource Logto does
-not have registered breaks sign-in outright. Leave it unset. (In bridge mode it
-works — the Logto SDK owns the tokens and exposes `getAccessToken()`.)
+hatch described above.
+
+`resources` is the input to
+[the token exchange](#organization-and-api-resource-tokens): Logto refuses to
+issue a token for a resource the grant never named, so the set is fixed before
+sign-in and every indicator must be registered — an unregistered one breaks
+sign-in outright. The scopes you want *from* those resources go in `scopes`;
+naming the resource alone yields a token with none. `exposeAccessTokens` lets
+the token string reach the browser at all, and is off by default.
 
 `signOutEverywhere({ sessionToken, postLogoutRedirectUri? })` derives the subject
 inside the component and atomically records subject-wide logical revocation.
@@ -203,13 +209,14 @@ as a standard `(Request) => Promise<Response>` handler. Options are:
   cookie during render can still read an identity. See
   [`readLogtoIdTokenCookie`](#readlogtoidtokencookiesource).
 
-The five final path segments are `sign-in`, `callback`, `token`, `sign-out`, and
-`sessions`.
+The six final path segments are `sign-in`, `callback`, `token`, `sign-out`,
+`sessions`, and `tokens`.
 Actual calls require POST, `x-convex-logto-csrf: 1`, and an allowed `Origin`;
 approved preflights receive credentialed CORS headers. Bodies are streamed
 through a 64 KiB limit; oversized requests return `413`. `signOutEverywhere` uses
 an internal selector on the existing `sign-out` route rather than a route of its
-own; `sessions` multiplexes `list` / `rename` / `revoke` on an `op` field the same
+own; `sessions` multiplexes `list` / `rename` / `revoke`, and `tokens`
+multiplexes `exchange` / `userinfo`, on an `op` field the same
 way. The `sessions` route never clears the cookie — revoking another device must
 not sign this one out. The cookie is fixed to
 `__Host-convex-logto-session=<encoded-token>; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=16416000`

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -18,7 +18,7 @@ description: Every export from convex-logto and its web, native, and session-mod
 | `logtoSessionApi(component, opts?)` | `convex-logto` | [Session mode](/docs/session-mode): builds the eleven public auth functions backed by the session component. |
 | `assertSubjectHasActiveSession(ctx, component)` | `convex-logto` | Session mode: require at least one active component Session for the authenticated subject; does not bind this bearer to one Session. |
 | `assertUserHasActiveSession(ctx, component)` | `convex-logto` | Deprecated compatibility alias for `assertSubjectHasActiveSession`. |
-| `createLogtoSessionCookieHandler(opts)` | `convex-logto` | Five-route standard-fetch handler for the optional same-site HttpOnly cookie transport. |
+| `createLogtoSessionCookieHandler(opts)` | `convex-logto` | Six-route standard-fetch handler for the optional same-site HttpOnly cookie transport. |
 | `createLogtoSessionCookieTransport(api, opts?)` | `convex-logto` | Framework-free browser adapter used by the session provider's `cookieTransport` prop. |
 | `assertLogtoSessionCookieCompatibility(opts)` | `convex-logto` | Loud Safari/device-binding compatibility guard. |
 | `readLogtoIdTokenCookie(source)` | `convex-logto` | Reads the opt-in SSR ID token cookie from a `Request`, a `Cookie` header, or a Next-style store. |

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -15,7 +15,7 @@ description: Every export from convex-logto and its web, native, and session-mod
 | `registerLogtoBackchannelLogout(http, opts)` | `convex-logto` | Registers the verified OIDC back-channel logout route for session mode. |
 | `createLogtoBackchannelLogoutHandler(opts)` | `convex-logto` | Builds the same Convex HTTP action without registering a path. |
 | `verifyLogtoLogoutToken(token, opts?)` | `convex-logto` | Low-level Web Crypto/JWKS validation for an OIDC Logout Token. |
-| `logtoSessionApi(component, opts?)` | `convex-logto` | [Session mode](/docs/session-mode): builds the nine public auth functions backed by the session component. |
+| `logtoSessionApi(component, opts?)` | `convex-logto` | [Session mode](/docs/session-mode): builds the eleven public auth functions backed by the session component. |
 | `assertSubjectHasActiveSession(ctx, component)` | `convex-logto` | Session mode: require at least one active component Session for the authenticated subject; does not bind this bearer to one Session. |
 | `assertUserHasActiveSession(ctx, component)` | `convex-logto` | Deprecated compatibility alias for `assertSubjectHasActiveSession`. |
 | `createLogtoSessionCookieHandler(opts)` | `convex-logto` | Five-route standard-fetch handler for the optional same-site HttpOnly cookie transport. |
@@ -29,11 +29,11 @@ description: Every export from convex-logto and its web, native, and session-mod
 | `useLogtoAuth()` | `convex-logto/react` | `{ isAuthenticated, isLoading, user, signIn, signOut }`. |
 | default | `convex-logto/convex.config` | The session component, for `app.use(logto)` in `convex/convex.config.ts`. |
 | `ConvexLogtoSessionProvider` | `convex-logto/react-session` | Session mode's provider — no Logto SDK; talks to your `logtoSessionApi` functions. |
-| `useLogtoAuth()` | `convex-logto/react-session` | Session auth plus `signOutEverywhere({ postLogoutRedirectUri? })` and `listSessions()` / `renameSession()` / `revokeSession()`. |
+| `useLogtoAuth()` | `convex-logto/react-session` | Session auth plus `signOutEverywhere({ postLogoutRedirectUri? })`, `listSessions()` / `renameSession()` / `revokeSession()`, and `getIdToken()` / `getOrganizationTokenClaims()` / `getAccessTokenClaims()` / `fetchUserInfo()`. |
 | `ConvexLogtoProvider` | `convex-logto/native` | React Native / Expo provider (on `@logto/rn`). Same `config` / `configQuery` model; no callback route. |
 | `useLogtoAuth()` | `convex-logto/native` | Native `{ isAuthenticated, isLoading, user, signIn, signOut }`; `signIn({ redirectUri? })` / `signOut({ postLogoutRedirectUri? })`. |
 | `ConvexLogtoSessionProvider` | `convex-logto/native-session` | React Native / Expo session provider using SecureStore + the system browser. |
-| `useLogtoAuth()` | `convex-logto/native-session` | Native session `{ isAuthenticated, isLoading, user, signIn, completeSignIn, signOut, signOutEverywhere, listSessions, renameSession, revokeSession }`; no device-binding surface. |
+| `useLogtoAuth()` | `convex-logto/native-session` | Native session `{ isAuthenticated, isLoading, user, signIn, completeSignIn, signOut, signOutEverywhere, listSessions, renameSession, revokeSession }` plus the same token-exchange methods; no device-binding surface. |
 
 ## Backend
 
@@ -123,7 +123,7 @@ tokens. It does not mutate or deduplicate sessions.
 ### `logtoSessionApi(component, opts?)`
 
 [Session mode](/docs/session-mode)'s server surface: pass `components.logto`
-(after `app.use(logto)`), re-export the nine functions it returns. Reads
+(after `app.use(logto)`), re-export the eleven functions it returns. Reads
 `LOGTO_ENDPOINT`, `LOGTO_APP_ID`, and `LOGTO_CLIENT_SECRET`.
 
 ```ts title="convex/auth.ts"
@@ -301,10 +301,68 @@ indistinguishable from a user who belongs to nothing, and only one reading is
 safe. The failure names the scope so a configuration gap does not read as a
 denial.
 
-Organization **permissions** are out of scope: Logto issues those only in an
+Organization **permissions** are the one part Logto puts nowhere but an
 organization token, audienced `urn:logto:organization:{id}` and typed `at+jwt`,
-which Convex rejects as a request credential. See
-[ADR 0002](https://github.com/Fanzzzd/convex-logto/blob/main/docs/adr/0002-token-custody.md).
+which Convex rejects as a request credential. Session mode can mint one for you
+— see [Organization and API-resource tokens](#organization-and-api-resource-tokens).
+
+### Organization and API-resource tokens
+
+<Callout type="info">Session mode only. In bridge mode the Logto SDK is already
+in the bundle: use `useLogto().getOrganizationToken(...)` directly.</Callout>
+
+Reach for this **only** for fine-grained organization permissions, or for a
+non-Convex API you registered with Logto. Membership and organization roles are
+already in the ID token (above) and cost nothing.
+
+```ts
+const {
+  getOrganizationTokenClaims,
+  getAccessTokenClaims,
+  fetchUserInfo,
+  getIdToken,
+} = useLogtoAuth();
+
+const { scopes } = await getOrganizationTokenClaims("org-id");
+if (scopes.includes("invoice:delete")) {
+  /* ... */
+}
+```
+
+The component mints the token from the Session's Logto refresh token and hands
+back **what it authorizes**, not the token itself — nothing long-lived enters
+`window`. For a caller that must reach a non-Convex API from the browser, pass
+`exposeAccessTokens: true` to `logtoSessionApi()` and use
+`getOrganizationToken(organizationId)` / `getAccessToken(resource)`, which
+return the string. Without the opt-in those reject by name rather than quietly
+returning nothing.
+
+Both need the app to re-export the new actions:
+
+```ts title="convex/auth.ts"
+export const { /* ... */ exchangeToken, fetchUserInfo } = logtoSessionApi(
+  components.logto,
+  { resources: ["https://api.example.com"] },
+);
+```
+
+- **A resource must be declared before sign-in.** Logto refuses to issue a token
+  for a resource the grant never named (`invalid_target`), so `resources` on
+  `logtoSessionApi()` is the input, and widening it means signing the user in
+  again. Organizations need nothing there.
+- **Minted tokens are cached** per session, audience and requested scope set, so
+  a permission check on render does not cost a grant. A revoked session's cache
+  is invisible immediately and deleted with it.
+- **The exchange queues behind a refresh.** It spends the same Logto refresh
+  token, so it takes the same claim and can answer the transient
+  `refresh_in_flight` — retry it.
+- `fetchUserInfo()` is Logto's live `/oidc/me`, unlike `user`, which is the copy
+  the last ID token froze. `getIdToken()` returns that Short bearer itself.
+
+See [ADR 0002](https://github.com/Fanzzzd/convex-logto/blob/main/docs/adr/0002-token-custody.md)
+for the custody decision and
+[ADR 0003](https://github.com/Fanzzzd/convex-logto/blob/main/docs/adr/0003-organization-token-exchange.md)
+for why the exchange shares the refresh claim.
 
 ### `assertSubjectHasActiveSession(ctx, component)`
 
@@ -523,7 +581,7 @@ device-binding option.
 | Prop | Required | Purpose |
 | --- | --- | --- |
 | `client` | yes | Your `ConvexReactClient`. |
-| `sessionApi` | yes | The module re-exporting all nine `logtoSessionApi(...)` functions. |
+| `sessionApi` | yes | The module re-exporting all eleven `logtoSessionApi(...)` functions. |
 | `redirectUri` | yes | Custom-scheme or universal-link callback registered as both a Redirect URI and Post sign-out redirect URI in Logto. |
 | `reactiveRevocation` | — | Subscribe to `sessionValid` and clear SecureStore immediately when revoked. Default `true`. |
 | `onAuthError` | — | Receives sign-in initiation failures plus recoverable OAuth, SecureStore, and system-browser failures; initiation failures are reported before `signIn()` rejects and all errors are logged. |

--- a/docs/content/docs/react-native.mdx
+++ b/docs/content/docs/react-native.mdx
@@ -175,7 +175,7 @@ Everything else — `logtoAuthConfig`, `logtoConfigQuery`, the webhook
 ## Native session mode
 
 Use **`convex-logto/native-session`** when the Logto refresh token should remain
-inside the Convex session component. The server setup and nine public functions
+inside the Convex session component. The server setup and eleven public functions
 are the same as [web session mode](/docs/session-mode); only the storage and
 OAuth adapters differ on the device.
 
@@ -201,7 +201,7 @@ in both lists:
 Keep the `"scheme": "io.logto"` app configuration shown above. As with web
 session mode, set `LOGTO_ENDPOINT`, `LOGTO_APP_ID`, and
 `LOGTO_CLIENT_SECRET` on the Convex deployment, install the component, and
-export all nine functions:
+export all eleven functions:
 
 ```ts title="convex/convex.config.ts"
 import { defineApp } from "convex/server";
@@ -225,6 +225,8 @@ export const {
   listSessions,
   renameSession,
   revokeSession,
+  exchangeToken,
+  fetchUserInfo,
   sessionValid,
 } = logtoSessionApi(components.logto);
 ```
@@ -325,7 +327,7 @@ Logto browser session.
 | Software device binding | optional on web | intentionally absent; SecureStore uses the OS keystore |
 
 Full runnable app: [`examples/expo-session`](https://github.com/Fanzzzd/convex-logto/tree/main/examples/expo-session)
-— the native counterpart of `vite-react-session`, with the same nine-function
+— the native counterpart of `vite-react-session`, with the same eleven-function
 `convex/auth.ts`, a device list, and a side-by-side comparison against the
 bridge-mode [`examples/expo`](https://github.com/Fanzzzd/convex-logto/tree/main/examples/expo).
 

--- a/docs/content/docs/session-mode.mdx
+++ b/docs/content/docs/session-mode.mdx
@@ -95,12 +95,15 @@ export const {
   listSessions,
   renameSession,
   revokeSession,
+  exchangeToken,
+  fetchUserInfo,
   sessionValid,
 } = logtoSessionApi(components.logto);
 ```
 
-Re-export all nine with these exact names — the provider looks them up on the
-module you pass it.
+Re-export all eleven with these exact names — the provider looks them up on the
+module you pass it. A missing one disables that feature with a named error
+rather than failing the build, so a rolling upgrade is safe.
 
 ### 5. Mount the provider
 
@@ -187,7 +190,7 @@ configured Logto TTL.
 
 If an older `convex/auth.ts` has not re-exported `signOutEverywhere`, the
 provider rejects with an explicit upgrade message instead of exposing a
-cryptic missing-function response. Re-export the nine-function set shown above
+cryptic missing-function response. Re-export the eleven-function set shown above
 and deploy the Convex functions.
 
 ## Where am I signed in
@@ -661,9 +664,45 @@ rejects the response and leaves uncommitted remote credentials unreachable.
 | `onAuthError` | — | Sign-in initiation and callback failures, plus opted-in device-key storage failures. Initiation failures are reported before `signIn()` rejects, so `void signIn()` remains observable. |
 
 `logtoSessionApi(component, opts?)` accepts `scopes` (server-set — the browser
-can't request its own), `reuseWindowMs`, and env overrides. `resources` currently
-buys nothing in session mode: only the ID token reaches the browser, so the
-access token it requests is discarded.
+can't request its own), `reuseWindowMs`, env overrides, and two options that
+belong to the token exchange below: `resources` (API resource indicators, which
+Logto requires *before* sign-in) and `exposeAccessTokens`.
+
+## Organization and API-resource tokens
+
+Organization membership and roles need nothing here: Logto puts them in the ID
+token, so `user.organizations` and `user.organization_roles` are already in
+every authenticated request, and
+[`assertOrganizationRole`](/docs/api-reference#organization-authorization)
+reads them server-side for free.
+
+What does need a token is a fine-grained organization **permission**, or a
+non-Convex API you registered with Logto. The component mints those from the
+Session's Logto refresh token and returns **what they authorize**:
+
+```ts
+const { getOrganizationTokenClaims, fetchUserInfo } = useLogtoAuth();
+
+const { scopes } = await getOrganizationTokenClaims("org-id");
+```
+
+Set `exposeAccessTokens: true` on `logtoSessionApi()` if a caller genuinely
+needs the token *string* in the browser — `getOrganizationToken(id)` and
+`getAccessToken(resource)` then return it, and it becomes one more thing XSS can
+steal. The refresh token has no such option in either mode.
+
+Two constraints worth knowing before you design around it:
+
+- **A resource must be named before sign-in.** Logto answers `invalid_target` for
+  a resource the grant never mentioned, so `resources` is fixed at sign-in and
+  widening it means signing the user in again.
+- **The exchange shares the refresh claim**, because it spends the same Logto
+  refresh token — so it can answer the transient `refresh_in_flight` while a
+  refresh is in flight. Minted tokens are cached per session, audience and scope
+  set, so a permission check on render is not a grant per render.
+
+<Callout>Bridge mode already has all of this: `@logto/react`'s `useLogto()` is
+in your bundle, so call `getOrganizationToken` on it directly.</Callout>
 
 ## Choosing a mode
 

--- a/docs/content/docs/session-mode.mdx
+++ b/docs/content/docs/session-mode.mdx
@@ -333,7 +333,7 @@ closes the long-lived session-token exfiltration path rather than claiming to
 make arbitrary XSS harmless.
 
 The exported handler is a standard `(Request) => Promise<Response>` function
-with five routes under `/api/logto-session` by default:
+with six routes under `/api/logto-session` by default:
 
 | Route | Purpose |
 | --- | --- |
@@ -342,6 +342,7 @@ with five routes under `/api/logto-session` by default:
 | `token` | Rotate the cookie and return a fresh ID token. |
 | `sign-out` | Delete the component Session, expire the cookie, and optionally end SSO. |
 | `sessions` | List, rename, or revoke the caller's own sessions (`op` selects). Never expires the cookie — revoking another device must not sign this one out. |
+| `tokens` | Exchange an organization or resource token, or fetch the Logto profile (`op` selects). |
 
 Every application request has one fixed CSRF policy: `POST`, the
 `x-convex-logto-csrf: 1` custom header, and an exact match in `allowedOrigins`.

--- a/examples/expo-session/convex/auth.ts
+++ b/examples/expo-session/convex/auth.ts
@@ -1,4 +1,4 @@
-// The whole server side of session mode: nine public functions backed by the
+// The whole server side of session mode: eleven public functions backed by the
 // Logto session component. The native provider expects these exact names, and
 // they are the same functions the web session example re-exports — one server
 // surface for both platforms.
@@ -14,5 +14,7 @@ export const {
   listSessions,
   renameSession,
   revokeSession,
+  exchangeToken,
+  fetchUserInfo,
   sessionValid,
 } = logtoSessionApi(components.logto);

--- a/examples/vite-react-session/convex/auth.ts
+++ b/examples/vite-react-session/convex/auth.ts
@@ -1,4 +1,4 @@
-// The whole server side of session mode: nine public functions backed by the
+// The whole server side of session mode: eleven public functions backed by the
 // Logto session component. The frontend provider expects these exact names.
 import { logtoSessionApi } from "convex-logto";
 import { components } from "./_generated/api";
@@ -12,5 +12,7 @@ export const {
   listSessions,
   renameSession,
   revokeSession,
+  exchangeToken,
+  fetchUserInfo,
   sessionValid,
 } = logtoSessionApi(components.logto);

--- a/packages/convex-logto/README.md
+++ b/packages/convex-logto/README.md
@@ -214,6 +214,8 @@ export const {
   listSessions,
   renameSession,
   revokeSession,
+  exchangeToken,
+  fetchUserInfo,
   sessionValid,
 } = logtoSessionApi(components.logto);
 ```
@@ -350,7 +352,7 @@ Convex validates an OIDC **ID token**. Logto's access tokens are typed `at+jwt`,
 | `createLogtoBackchannelLogoutHandler(opts)` | `convex-logto` | Builds the back-channel Convex HTTP action for custom route composition. |
 | `verifyLogtoLogoutToken(token, opts?)` | `convex-logto` | Low-level RS256/PS256 Logout Token verification against Logto's JWKS. |
 | `verifyLogtoSignature(key, body, sig)` | `convex-logto` | Low-level signature check, for custom routing. |
-| `logtoSessionApi(component, opts?)` | `convex-logto` | [Session mode](#session-mode): builds the nine public auth functions backed by the session component. |
+| `logtoSessionApi(component, opts?)` | `convex-logto` | [Session mode](#session-mode): builds the eleven public auth functions backed by the session component. |
 | `assertSubjectHasActiveSession(ctx, component)` | `convex-logto` | Session mode: throw unless the authenticated subject has at least one active component Session; this does not bind the current bearer to one Session. A bounded scan can transiently throw `session_liveness_scan_incomplete` while bulk cleanup progresses. |
 | `assertUserHasActiveSession(ctx, component)` | `convex-logto` | Deprecated compatibility alias for `assertSubjectHasActiveSession`. |
 | `createLogtoSessionCookieHandler(opts)` | `convex-logto` | Five-route standard-fetch handler for the optional same-site HttpOnly cookie transport. |

--- a/packages/convex-logto/README.md
+++ b/packages/convex-logto/README.md
@@ -355,7 +355,7 @@ Convex validates an OIDC **ID token**. Logto's access tokens are typed `at+jwt`,
 | `logtoSessionApi(component, opts?)` | `convex-logto` | [Session mode](#session-mode): builds the eleven public auth functions backed by the session component. |
 | `assertSubjectHasActiveSession(ctx, component)` | `convex-logto` | Session mode: throw unless the authenticated subject has at least one active component Session; this does not bind the current bearer to one Session. A bounded scan can transiently throw `session_liveness_scan_incomplete` while bulk cleanup progresses. |
 | `assertUserHasActiveSession(ctx, component)` | `convex-logto` | Deprecated compatibility alias for `assertSubjectHasActiveSession`. |
-| `createLogtoSessionCookieHandler(opts)` | `convex-logto` | Five-route standard-fetch handler for the optional same-site HttpOnly cookie transport. |
+| `createLogtoSessionCookieHandler(opts)` | `convex-logto` | Six-route standard-fetch handler for the optional same-site HttpOnly cookie transport. |
 | `ConvexLogtoProvider` | `convex-logto/react` | Logto + Convex + auto sign-in callback in one provider. Static `config` or backend `configQuery`. |
 | `useLogtoAuth()` | `convex-logto/react` | `{ isAuthenticated, isLoading, user, signIn, signOut }`. |
 | default | `convex-logto/convex.config` | The session component, for `app.use(logto)`. |

--- a/packages/convex-logto/src/component/_generated/component.ts
+++ b/packages/convex-logto/src/component/_generated/component.ts
@@ -67,6 +67,48 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
         },
         Name
       >;
+      exchangeToken: FunctionReference<
+        "action",
+        "internal",
+        {
+          appId: string;
+          clientSecret: string;
+          deviceProof?: string;
+          endpoint: string;
+          includeToken?: boolean;
+          organizationId?: string;
+          resource?: string;
+          reuseWindowMs?: number;
+          scopes?: Array<string>;
+          sessionToken: string;
+        },
+        {
+          accessToken?: string;
+          claims: {
+            audience: string;
+            expiresAt: number;
+            organizationId?: string;
+            resource?: string;
+            scopes: Array<string>;
+          };
+          minted: boolean;
+        },
+        Name
+      >;
+      fetchUserInfo: FunctionReference<
+        "action",
+        "internal",
+        {
+          appId: string;
+          clientSecret: string;
+          deviceProof?: string;
+          endpoint: string;
+          reuseWindowMs?: number;
+          sessionToken: string;
+        },
+        any,
+        Name
+      >;
       forgetWebhookDelivery: FunctionReference<
         "mutation",
         "internal",

--- a/packages/convex-logto/src/component/core.ts
+++ b/packages/convex-logto/src/component/core.ts
@@ -547,6 +547,179 @@ export function decideRefresh(options: {
   return { outcome: "refresh-superseded" };
 }
 
+/**
+ * Decide whether a token exchange (Organization / Resource / userinfo) may run.
+ *
+ * Deliberately *not* {@link decideRefresh}. An exchange spends the same Logto
+ * refresh token — so it takes the same claim, and inherits `in-flight`,
+ * `claim-expired` and `reuse` unchanged — but it does not rotate the Session
+ * token, so there is no `cached`/`refresh-superseded` split and no candidate to
+ * adopt. A superseded generation still inside its Reuse window may exchange:
+ * nothing rotates, so nothing can be orphaned by it.
+ */
+export function decideExchange(options: {
+  presentedHash: string;
+  session: {
+    tokenHash: string;
+    prevTokenHash?: string;
+    rotatedAt?: number;
+    refreshingSince?: number;
+  };
+  now: number;
+  reuseWindowMs: number;
+  presentedTokenExpiresAt?: number;
+  claimTimeoutMs?: number;
+}):
+  | { outcome: "exchange" }
+  | { outcome: "in-flight" }
+  | { outcome: "claim-expired" }
+  | { outcome: "reuse" } {
+  const {
+    presentedHash,
+    session,
+    now,
+    reuseWindowMs,
+    presentedTokenExpiresAt,
+    claimTimeoutMs = 15 * 1000,
+  } = options;
+
+  const claimAge =
+    session.refreshingSince === undefined
+      ? undefined
+      : now - session.refreshingSince;
+  if (claimAge !== undefined && claimAge >= claimTimeoutMs) {
+    return { outcome: "claim-expired" };
+  }
+  const claimed = claimAge !== undefined;
+
+  if (presentedHash !== session.tokenHash) {
+    const inWindow =
+      presentedTokenExpiresAt === undefined
+        ? isPreviousTokenWithinReuseWindow({
+            rotatedAt: session.rotatedAt,
+            now,
+            reuseWindowMs,
+          })
+        : now < presentedTokenExpiresAt;
+    if (!inWindow) return { outcome: "reuse" };
+  }
+  if (claimed) return { outcome: "in-flight" };
+  return { outcome: "exchange" };
+}
+
+/**
+ * How many minted Resource/Organization tokens one Session caches.
+ *
+ * Bounded because a session's rows are deleted in the transaction that deletes
+ * the session — an unbounded cache would make that deletion unbounded too, and
+ * "a revoked session's rows are gone" is the invariant that stops a minted
+ * token from outliving the authority it was minted under. Eight covers a few
+ * organizations plus a couple of API resources; beyond that the
+ * least-recently-minted row is evicted.
+ */
+export const RESOURCE_TOKEN_CACHE_LIMIT = 8;
+
+/** Don't serve a cached access token with less than this much life left. */
+export const RESOURCE_TOKEN_SKEW_MS = 60 * 1000;
+
+/** Longest accepted organization id / resource indicator, in code points. */
+export const TOKEN_AUDIENCE_MAX_LENGTH = 256;
+
+/**
+ * The cache key's audience half.
+ *
+ * Prefixed rather than raw so an organization id can never collide with a
+ * resource indicator, and `default` — the opaque token `fetchUserInfo` needs —
+ * is a third namespace rather than the absence of one.
+ */
+export function tokenAudienceKey(target: {
+  organizationId?: string;
+  resource?: string;
+}): string {
+  if (target.organizationId !== undefined && target.resource !== undefined) {
+    throw terminal(
+      "ambiguous_token_target",
+      "Ask for an organization token or a resource token, not both.",
+    );
+  }
+  if (target.organizationId !== undefined) {
+    return `organization:${assertAudienceLength(target.organizationId, "organization id")}`;
+  }
+  if (target.resource !== undefined) {
+    return `resource:${assertAudienceLength(target.resource, "resource indicator")}`;
+  }
+  return "default";
+}
+
+function assertAudienceLength(value: string, what: string): string {
+  if (
+    value.length === 0 ||
+    Array.from(value).length > TOKEN_AUDIENCE_MAX_LENGTH
+  ) {
+    throw terminal(
+      "invalid_token_target",
+      `That ${what} is empty or longer than ${TOKEN_AUDIENCE_MAX_LENGTH} characters.`,
+    );
+  }
+  return value;
+}
+
+/**
+ * The cache key's scope half.
+ *
+ * Sorted and de-duplicated so the same ask in a different order is the same
+ * cache entry, and a *narrower* ask never gets served a token minted for a
+ * wider one — Logto issues exactly what was requested, so reusing across scope
+ * sets would silently hand back a token missing a scope the caller asked for.
+ */
+export function tokenScopeKey(scopes?: string[]): string {
+  if (!scopes || scopes.length === 0) return "";
+  const unique = [
+    ...new Set(scopes.map((scope) => scope.trim()).filter(Boolean)),
+  ];
+  // Sorted in place: the array was built on the line above and is owned by
+  // nobody else. `toSorted` would say it better but is ES2023, and the library
+  // targets ES2022.
+  unique.sort();
+  return unique.join(" ");
+}
+
+/**
+ * When a minted access token actually expires.
+ *
+ * The token's own `exp` wins where there is one: `expires_in` is relative to a
+ * clock we did not read it on, and an Organization token whose `exp` disagrees
+ * with `expires_in` is the one that would be cached past its life. An opaque
+ * token (the `default` audience) has no `exp`, so `expires_in` is all there is.
+ */
+export function accessTokenExpiresAt(options: {
+  accessToken: string;
+  expiresIn?: number;
+  now: number;
+}): number {
+  const claims = decodeJwtSegment(options.accessToken.split(".")[1] ?? "");
+  if (isRecord(claims) && typeof claims.exp === "number") {
+    return claims.exp * 1000;
+  }
+  const seconds =
+    typeof options.expiresIn === "number" && options.expiresIn > 0
+      ? options.expiresIn
+      : 60;
+  return options.now + seconds * 1000;
+}
+
+/**
+ * The claims an app can authorize on without the token string ever leaving the
+ * component — the default custody in `docs/adr/0002-token-custody.md`.
+ */
+export type ResourceTokenClaims = {
+  audience: string;
+  scopes: string[];
+  expiresAt: number;
+  organizationId?: string;
+  resource?: string;
+};
+
 /** Apply the exclusive grace window for a legacy previous-generation field. */
 export function isPreviousTokenWithinReuseWindow(options: {
   rotatedAt?: number;

--- a/packages/convex-logto/src/component/core.ts
+++ b/packages/convex-logto/src/component/core.ts
@@ -626,6 +626,31 @@ export const RESOURCE_TOKEN_SKEW_MS = 60 * 1000;
 export const TOKEN_AUDIENCE_MAX_LENGTH = 256;
 
 /**
+ * Bounds on the requested scope set.
+ *
+ * The scope key is caller-supplied and lands verbatim in a `resourceTokens`
+ * row, and session deletion collects those rows for eight sessions in one
+ * transaction. Every other caller-supplied string in this component is
+ * bounded; unbounded, eight rows of near-document-limit scope text is enough
+ * to put a subject's sessions permanently beyond a revocation batch's read
+ * budget — a session that can never be revoked.
+ */
+export const TOKEN_SCOPE_MAX_COUNT = 32;
+export const TOKEN_SCOPE_KEY_MAX_LENGTH = 512;
+
+/**
+ * Largest minted access token this will cache.
+ *
+ * The token comes from Logto rather than the caller, so this is not a defence
+ * against an attacker — it is what keeps the per-session row bound a *byte*
+ * bound and not just a row count, so the batched session deletion above stays
+ * inside its transaction budget no matter what a deployment's tokens look
+ * like. A token past this is still returned; it is simply not stored, so the
+ * next call mints again.
+ */
+export const MAX_CACHEABLE_ACCESS_TOKEN_LENGTH = 8 * 1024;
+
+/**
  * The cache key's audience half.
  *
  * Prefixed rather than raw so an organization id can never collide with a
@@ -674,6 +699,12 @@ function assertAudienceLength(value: string, what: string): string {
  */
 export function tokenScopeKey(scopes?: string[]): string {
   if (!scopes || scopes.length === 0) return "";
+  if (scopes.length > TOKEN_SCOPE_MAX_COUNT) {
+    throw terminal(
+      "invalid_token_scopes",
+      `Ask for at most ${TOKEN_SCOPE_MAX_COUNT} scopes at once.`,
+    );
+  }
   const unique = [
     ...new Set(scopes.map((scope) => scope.trim()).filter(Boolean)),
   ];
@@ -681,7 +712,14 @@ export function tokenScopeKey(scopes?: string[]): string {
   // nobody else. `toSorted` would say it better but is ES2023, and the library
   // targets ES2022.
   unique.sort();
-  return unique.join(" ");
+  const key = unique.join(" ");
+  if (Array.from(key).length > TOKEN_SCOPE_KEY_MAX_LENGTH) {
+    throw terminal(
+      "invalid_token_scopes",
+      `That scope set is longer than ${TOKEN_SCOPE_KEY_MAX_LENGTH} characters.`,
+    );
+  }
+  return key;
 }
 
 /**

--- a/packages/convex-logto/src/component/exchange.test.ts
+++ b/packages/convex-logto/src/component/exchange.test.ts
@@ -1,0 +1,677 @@
+import { ConvexError } from "convex/values";
+import { describe, expect, it } from "vitest";
+import {
+  beginTokenExchange,
+  cachedResourceToken,
+  completeTokenExchange,
+} from "./lib";
+import {
+  RESOURCE_TOKEN_CACHE_LIMIT,
+  RESOURCE_TOKEN_SKEW_MS,
+  TOKEN_AUDIENCE_MAX_LENGTH,
+  accessTokenExpiresAt,
+  decideExchange,
+  tokenAudienceKey,
+  tokenScopeKey,
+} from "./core";
+
+function handlerOf<Args, Result>(
+  value: unknown,
+  _types?: (args: Args) => Result,
+): (ctx: unknown, args: Args) => Promise<Result> {
+  return (
+    value as Record<string, (ctx: unknown, args: Args) => Promise<Result>>
+  )["_handler"]!;
+}
+
+// --- pure logic --------------------------------------------------------------
+
+describe("decideExchange", () => {
+  const session = {
+    tokenHash: "current",
+    rotatedAt: 1_000_000,
+  };
+
+  it("exchanges on the current token when nothing holds the claim", () => {
+    expect(
+      decideExchange({
+        presentedHash: "current",
+        session,
+        now: 1_000_100,
+        reuseWindowMs: 10_000,
+      }),
+    ).toEqual({ outcome: "exchange" });
+  });
+
+  it("queues behind an in-flight refresh rather than spending the token twice", () => {
+    expect(
+      decideExchange({
+        presentedHash: "current",
+        session: { ...session, refreshingSince: 1_000_000 },
+        now: 1_000_100,
+        reuseWindowMs: 10_000,
+      }),
+    ).toEqual({ outcome: "in-flight" });
+  });
+
+  it("reports claim-expired once the claim ages out, exactly like a refresh", () => {
+    expect(
+      decideExchange({
+        presentedHash: "current",
+        session: { ...session, refreshingSince: 1_000_000 },
+        now: 1_100_000,
+        reuseWindowMs: 10_000,
+      }),
+    ).toEqual({ outcome: "claim-expired" });
+  });
+
+  it("lets a superseded generation inside its reuse window exchange", () => {
+    // Nothing rotates, so nothing can be orphaned by it — the reason this is
+    // not `decideRefresh`, which would have to choose between cache and rotate.
+    expect(
+      decideExchange({
+        presentedHash: "previous",
+        session,
+        now: 1_005_000,
+        reuseWindowMs: 10_000,
+      }),
+    ).toEqual({ outcome: "exchange" });
+  });
+
+  it("treats a superseded generation past its window as reuse", () => {
+    expect(
+      decideExchange({
+        presentedHash: "previous",
+        session,
+        now: 1_020_000,
+        reuseWindowMs: 10_000,
+      }),
+    ).toEqual({ outcome: "reuse" });
+  });
+
+  it("prefers the generation row's own expiry over the rotation clock", () => {
+    expect(
+      decideExchange({
+        presentedHash: "previous",
+        session,
+        now: 1_020_000,
+        reuseWindowMs: 10_000,
+        presentedTokenExpiresAt: 1_030_000,
+      }),
+    ).toEqual({ outcome: "exchange" });
+  });
+});
+
+describe("tokenAudienceKey", () => {
+  it("namespaces organizations and resources so ids cannot collide", () => {
+    expect(tokenAudienceKey({ organizationId: "abc" })).toBe(
+      "organization:abc",
+    );
+    expect(tokenAudienceKey({ resource: "https://api.example.com" })).toBe(
+      "resource:https://api.example.com",
+    );
+    expect(tokenAudienceKey({})).toBe("default");
+  });
+
+  it("refuses an ambiguous target rather than silently preferring one", () => {
+    expect(() =>
+      tokenAudienceKey({ organizationId: "abc", resource: "https://x" }),
+    ).toThrow(ConvexError);
+  });
+
+  it("bounds the audience so a caller cannot park a large document", () => {
+    expect(() => tokenAudienceKey({ organizationId: "" })).toThrow(ConvexError);
+    expect(() =>
+      tokenAudienceKey({ resource: "x".repeat(TOKEN_AUDIENCE_MAX_LENGTH + 1) }),
+    ).toThrow(ConvexError);
+    expect(
+      tokenAudienceKey({ resource: "x".repeat(TOKEN_AUDIENCE_MAX_LENGTH) }),
+    ).toContain("resource:");
+  });
+});
+
+describe("tokenScopeKey", () => {
+  it("is order- and duplicate-insensitive, so the same ask is one cache entry", () => {
+    expect(tokenScopeKey(["b", "a", "b", " a "])).toBe("a b");
+    expect(tokenScopeKey(["a", "b"])).toBe(tokenScopeKey(["b", "a"]));
+  });
+
+  it("keeps a narrower ask distinct from a wider one", () => {
+    // Logto issues exactly what was asked for, so serving the narrow key from
+    // the wide token would hand back something missing a requested scope.
+    expect(tokenScopeKey(["read"])).not.toBe(tokenScopeKey(["read", "write"]));
+  });
+
+  it("collapses empty and whitespace-only asks to the same key", () => {
+    expect(tokenScopeKey()).toBe("");
+    expect(tokenScopeKey([])).toBe("");
+    expect(tokenScopeKey(["  "])).toBe("");
+  });
+});
+
+describe("accessTokenExpiresAt", () => {
+  function jwt(payload: Record<string, unknown>): string {
+    const encode = (value: unknown) =>
+      btoa(JSON.stringify(value))
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+    return `${encode({ alg: "RS256" })}.${encode(payload)}.signature`;
+  }
+
+  it("prefers the token's own exp over a relative expires_in", () => {
+    // `expires_in` is relative to a clock we did not read it on; `exp` is not.
+    expect(
+      accessTokenExpiresAt({
+        accessToken: jwt({ exp: 2_000 }),
+        expiresIn: 9_999,
+        now: 1_000_000,
+      }),
+    ).toBe(2_000_000);
+  });
+
+  it("falls back to expires_in for an opaque token", () => {
+    expect(
+      accessTokenExpiresAt({
+        accessToken: "opaque",
+        expiresIn: 60,
+        now: 1_000_000,
+      }),
+    ).toBe(1_060_000);
+  });
+
+  it("falls back to a short life when Logto reports neither", () => {
+    expect(
+      accessTokenExpiresAt({ accessToken: "opaque", now: 1_000_000 }),
+    ).toBe(1_060_000);
+  });
+});
+
+// --- mutations ---------------------------------------------------------------
+
+type ExchangeSession = {
+  _id: string;
+  subject: string;
+  sid?: string;
+  tokenHash: string;
+  prevTokenHash?: string;
+  rotatedAt?: number;
+  refreshingSince?: number;
+  refreshClaimId?: string;
+  logtoRefreshToken: string;
+  lastIdToken: string;
+  lastIdTokenExp: number;
+  createdAt: number;
+  lastRefreshedAt: number;
+};
+
+type ResourceTokenRow = {
+  _id: string;
+  sessionId: string;
+  audience: string;
+  scopeKey: string;
+  accessToken: string;
+  expiresAt: number;
+  grantedScope: string;
+  mintedAt: number;
+};
+
+function sessionFixture(
+  overrides: Partial<ExchangeSession> = {},
+): ExchangeSession {
+  return {
+    _id: "session-1",
+    subject: "user-1",
+    tokenHash: "current",
+    rotatedAt: 1_000_000,
+    logtoRefreshToken: "refresh-token",
+    lastIdToken: "id-token",
+    lastIdTokenExp: 3_000_000,
+    createdAt: 500_000,
+    lastRefreshedAt: 900_000,
+    ...overrides,
+  };
+}
+
+/**
+ * A database double that filters on *every* `eq` in the index chain, which the
+ * three-field `by_session_audience_scope` lookup needs.
+ */
+function exchangeHarness(
+  initialSession: ExchangeSession | null,
+  initialTokens: ResourceTokenRow[] = [],
+  revocations: {
+    subject?: { subject: string; revokedAt: number };
+    sids?: Array<{ sid: string; revokedAt: number }>;
+  } = {},
+) {
+  let session = initialSession === null ? null : { ...initialSession };
+  let tokens = initialTokens.map((row) => ({ ...row }));
+  const subjectRevocations =
+    revocations.subject === undefined
+      ? []
+      : [{ _id: "subject-marker", ...revocations.subject }];
+  const sidRevocations = (revocations.sids ?? []).map((row, index) => ({
+    _id: `sid-marker-${index}`,
+    ...row,
+  }));
+  const deleted: string[] = [];
+  const inserted: Array<{ table: string; doc: Record<string, unknown> }> = [];
+  let nextId = initialTokens.length + 1;
+
+  const rowsFor = (table: string): Array<Record<string, unknown>> => {
+    if (table === "sessions") return session === null ? [] : [session];
+    if (table === "resourceTokens") return tokens;
+    if (table === "subjectRevocations") return subjectRevocations;
+    if (table === "sidRevocations") return sidRevocations;
+    return [];
+  };
+
+  const db = {
+    query: (table: string) => ({
+      withIndex: (
+        _index: string,
+        configure?: (query: {
+          eq(field: string, value: unknown): unknown;
+          lt(field: string, value: number): unknown;
+        }) => unknown,
+      ) => {
+        const equals: Array<[string, unknown]> = [];
+        const lessThan: Array<[string, number]> = [];
+        configure?.({
+          eq(field, value) {
+            equals.push([field, value]);
+            return this;
+          },
+          lt(field, value) {
+            lessThan.push([field, value]);
+            return this;
+          },
+        });
+        let direction: "asc" | "desc" = "asc";
+        const matching = () => {
+          const filtered = rowsFor(table).filter(
+            (row) =>
+              equals.every(([field, value]) => row[field] === value) &&
+              lessThan.every(([field, value]) => {
+                const actual = row[field];
+                return typeof actual === "number" && actual < value;
+              }),
+          );
+          return filtered.toSorted((left, right) => {
+            const difference =
+              Number(left["mintedAt"] ?? 0) - Number(right["mintedAt"] ?? 0);
+            return direction === "desc" ? -difference : difference;
+          });
+        };
+        const result = {
+          unique: () => Promise.resolve(matching()[0] ?? null),
+          collect: () => Promise.resolve(matching()),
+          take: (count: number) => Promise.resolve(matching().slice(0, count)),
+          order: (next: "asc" | "desc") => {
+            direction = next;
+            return result;
+          },
+        };
+        return result;
+      },
+    }),
+    normalizeId: (_table: string, id: string) => id,
+    get: (id: string) =>
+      Promise.resolve(session !== null && session._id === id ? session : null),
+    patch: (id: string, fields: Record<string, unknown>) => {
+      if (session !== null && session._id === id) {
+        session = { ...session, ...fields } as ExchangeSession;
+      }
+      tokens = tokens.map((row) =>
+        row._id === id ? ({ ...row, ...fields } as ResourceTokenRow) : row,
+      );
+      return Promise.resolve();
+    },
+    insert: (table: string, doc: Record<string, unknown>) => {
+      inserted.push({ table, doc });
+      const id = `${table}-${nextId++}`;
+      if (table === "resourceTokens") {
+        tokens.push({ _id: id, ...doc } as unknown as ResourceTokenRow);
+      }
+      return Promise.resolve(id);
+    },
+    delete: (id: string) => {
+      deleted.push(id);
+      if (session !== null && session._id === id) session = null;
+      tokens = tokens.filter((row) => row._id !== id);
+      return Promise.resolve();
+    },
+  };
+
+  return {
+    db,
+    deleted,
+    inserted,
+    session: () => session,
+    tokens: () => tokens,
+  };
+}
+
+const beginHandler = handlerOf<
+  {
+    presentedHash: string;
+    claimId: string;
+    now: number;
+    reuseWindowMs: number;
+  },
+  { outcome: string; sessionId?: string; refreshToken?: string }
+>(beginTokenExchange);
+
+const completeHandler = handlerOf<
+  Record<string, unknown>,
+  { outcome: string; expiresAt?: number; grantedScope?: string }
+>(completeTokenExchange);
+
+const cachedHandler = handlerOf<
+  { presentedHash: string; audience: string; scopeKey: string; now: number },
+  { accessToken: string; expiresAt: number; grantedScope: string } | null
+>(cachedResourceToken);
+
+describe("beginTokenExchange", () => {
+  it("takes the same claim a refresh would, before Logto is touched", async () => {
+    const harness = exchangeHarness(sessionFixture());
+    await expect(
+      beginHandler(
+        { db: harness.db },
+        {
+          presentedHash: "current",
+          claimId: "claim-a",
+          now: 1_000_100,
+          reuseWindowMs: 10_000,
+        },
+      ),
+    ).resolves.toEqual({
+      outcome: "exchange",
+      sessionId: "session-1",
+      refreshToken: "refresh-token",
+    });
+    expect(harness.session()).toMatchObject({
+      refreshingSince: 1_000_100,
+      refreshClaimId: "claim-a",
+    });
+  });
+
+  it("does not rotate the session token", async () => {
+    // The distinguishing property against `beginRefresh`: an exchange has no
+    // candidate, so a caller mid-exchange keeps presenting the same token.
+    const harness = exchangeHarness(sessionFixture());
+    await beginHandler(
+      { db: harness.db },
+      {
+        presentedHash: "current",
+        claimId: "claim-a",
+        now: 1_000_100,
+        reuseWindowMs: 10_000,
+      },
+    );
+    expect(harness.session()?.tokenHash).toBe("current");
+    expect(harness.session()).not.toHaveProperty("prevTokenHash");
+  });
+
+  it("is transient while a refresh holds the claim", async () => {
+    const harness = exchangeHarness(
+      sessionFixture({ refreshingSince: 1_000_000, refreshClaimId: "other" }),
+    );
+    await expect(
+      beginHandler(
+        { db: harness.db },
+        {
+          presentedHash: "current",
+          claimId: "claim-a",
+          now: 1_000_100,
+          reuseWindowMs: 10_000,
+        },
+      ),
+    ).rejects.toMatchObject({
+      data: { kind: "transient", code: "refresh_in_flight" },
+    });
+    expect(harness.deleted).toEqual([]);
+  });
+
+  it("deletes the session when a previous claim's outcome is unknown", async () => {
+    const harness = exchangeHarness(
+      sessionFixture({
+        refreshingSince: 900_000,
+        refreshClaimId: "abandoned",
+      }),
+    );
+    await expect(
+      beginHandler(
+        { db: harness.db },
+        {
+          presentedHash: "current",
+          claimId: "claim-a",
+          now: 1_000_000,
+          reuseWindowMs: 10_000,
+        },
+      ),
+    ).resolves.toEqual({ outcome: "claim-expired" });
+    expect(harness.deleted).toEqual(["session-1"]);
+  });
+
+  it("refuses a logically revoked session even before its rows are gone", async () => {
+    const harness = exchangeHarness(sessionFixture(), [], {
+      subject: { subject: "user-1", revokedAt: 600_000 },
+    });
+    await expect(
+      beginHandler(
+        { db: harness.db },
+        {
+          presentedHash: "current",
+          claimId: "claim-a",
+          now: 1_000_100,
+          reuseWindowMs: 10_000,
+        },
+      ),
+    ).rejects.toMatchObject({
+      data: { kind: "terminal", code: "session_revoked" },
+    });
+  });
+});
+
+describe("completeTokenExchange", () => {
+  const baseArgs = {
+    sessionId: "session-1",
+    claimId: "claim-a",
+    audience: "organization:org-1",
+    scopeKey: "read",
+    accessToken: "minted-token",
+    expiresAt: 4_000_000,
+    grantedScope: "read",
+    now: 1_000_200,
+  };
+
+  function claimed(overrides: Partial<ExchangeSession> = {}) {
+    return sessionFixture({
+      refreshingSince: 1_000_100,
+      refreshClaimId: "claim-a",
+      ...overrides,
+    });
+  }
+
+  it("caches the token, persists rotation, and releases the claim together", async () => {
+    const harness = exchangeHarness(claimed());
+    await expect(
+      completeHandler(
+        { db: harness.db },
+        {
+          ...baseArgs,
+          newRefreshToken: "rotated",
+          refreshedIdToken: {
+            idToken: "fresh-id-token",
+            exp: 5_000_000,
+            sid: "sid-1",
+          },
+        },
+      ),
+    ).resolves.toEqual({
+      outcome: "committed",
+      expiresAt: 4_000_000,
+      grantedScope: "read",
+    });
+    expect(harness.tokens()).toHaveLength(1);
+    expect(harness.tokens()[0]).toMatchObject({
+      audience: "organization:org-1",
+      scopeKey: "read",
+      accessToken: "minted-token",
+    });
+    expect(harness.session()).toMatchObject({
+      logtoRefreshToken: "rotated",
+      lastIdToken: "fresh-id-token",
+      lastIdTokenExp: 5_000_000,
+      sid: "sid-1",
+      refreshingSince: undefined,
+      refreshClaimId: undefined,
+    });
+  });
+
+  it("keeps the stored refresh token when Logto rotated nothing", async () => {
+    const harness = exchangeHarness(claimed());
+    await completeHandler({ db: harness.db }, baseArgs);
+    expect(harness.session()).toMatchObject({
+      logtoRefreshToken: "refresh-token",
+      lastIdToken: "id-token",
+    });
+  });
+
+  it("replaces the row for a repeat of the same audience and scope", async () => {
+    const harness = exchangeHarness(claimed(), [
+      {
+        _id: "resourceTokens-0",
+        sessionId: "session-1",
+        audience: "organization:org-1",
+        scopeKey: "read",
+        accessToken: "older-token",
+        expiresAt: 2_000_000,
+        grantedScope: "read",
+        mintedAt: 900_000,
+      },
+    ]);
+    await completeHandler({ db: harness.db }, baseArgs);
+    expect(harness.tokens()).toHaveLength(1);
+    expect(harness.tokens()[0]).toMatchObject({
+      accessToken: "minted-token",
+      expiresAt: 4_000_000,
+    });
+  });
+
+  it("evicts the least recently minted rows to stay inside the cache bound", async () => {
+    // The bound is what keeps deleting a session a bounded amount of work.
+    const existing = Array.from(
+      { length: RESOURCE_TOKEN_CACHE_LIMIT },
+      (_, index) => ({
+        _id: `resourceTokens-${index}`,
+        sessionId: "session-1",
+        audience: `resource:api-${index}`,
+        scopeKey: "",
+        accessToken: `token-${index}`,
+        expiresAt: 4_000_000,
+        grantedScope: "",
+        mintedAt: 100_000 + index,
+      }),
+    );
+    const harness = exchangeHarness(claimed(), existing);
+    await completeHandler({ db: harness.db }, baseArgs);
+    expect(harness.tokens()).toHaveLength(RESOURCE_TOKEN_CACHE_LIMIT);
+    expect(harness.tokens().map((row) => row.audience)).toContain(
+      "organization:org-1",
+    );
+    expect(harness.tokens().map((row) => row.audience)).not.toContain(
+      "resource:api-0",
+    );
+  });
+
+  it("fences a completion whose claim was taken over", async () => {
+    const harness = exchangeHarness(
+      claimed({ refreshClaimId: "someone-else" }),
+    );
+    await expect(
+      completeHandler({ db: harness.db }, baseArgs),
+    ).resolves.toEqual({ outcome: "stale-owner" });
+    expect(harness.tokens()).toEqual([]);
+  });
+
+  it("deletes rather than caches a token minted under withdrawn authority", async () => {
+    const harness = exchangeHarness(claimed(), [], {
+      subject: { subject: "user-1", revokedAt: 600_000 },
+    });
+    await expect(
+      completeHandler({ db: harness.db }, baseArgs),
+    ).resolves.toEqual({ outcome: "revoked" });
+    expect(harness.deleted).toEqual(["session-1"]);
+    expect(harness.tokens()).toEqual([]);
+  });
+
+  it("reports a missing session rather than inventing one", async () => {
+    const harness = exchangeHarness(null);
+    await expect(
+      completeHandler({ db: harness.db }, baseArgs),
+    ).resolves.toEqual({ outcome: "missing" });
+  });
+});
+
+describe("cachedResourceToken", () => {
+  const row: ResourceTokenRow = {
+    _id: "resourceTokens-0",
+    sessionId: "session-1",
+    audience: "organization:org-1",
+    scopeKey: "read",
+    accessToken: "cached-token",
+    expiresAt: 2_000_000,
+    grantedScope: "read manage",
+    mintedAt: 1_000_000,
+  };
+  const args = {
+    presentedHash: "current",
+    audience: "organization:org-1",
+    scopeKey: "read",
+    now: 1_500_000,
+  };
+
+  it("serves a fresh row without touching Logto", async () => {
+    const harness = exchangeHarness(sessionFixture(), [row]);
+    await expect(cachedHandler({ db: harness.db }, args)).resolves.toEqual({
+      audience: "organization:org-1",
+      grantedScope: "read manage",
+      expiresAt: 2_000_000,
+      accessToken: "cached-token",
+    });
+  });
+
+  it("does not serve a row inside the expiry skew", async () => {
+    const harness = exchangeHarness(sessionFixture(), [row]);
+    await expect(
+      cachedHandler(
+        { db: harness.db },
+        { ...args, now: row.expiresAt - RESOURCE_TOKEN_SKEW_MS },
+      ),
+    ).resolves.toBeNull();
+  });
+
+  it("does not serve a different scope's token", async () => {
+    const harness = exchangeHarness(sessionFixture(), [row]);
+    await expect(
+      cachedHandler({ db: harness.db }, { ...args, scopeKey: "read write" }),
+    ).resolves.toBeNull();
+  });
+
+  it("is blind to a logically revoked session's cache", async () => {
+    // The row may still be waiting for a bounded cleanup batch. Until it is
+    // gone it must retain no authority — the same rule every other read follows.
+    const harness = exchangeHarness(sessionFixture(), [row], {
+      subject: { subject: "user-1", revokedAt: 600_000 },
+    });
+    await expect(cachedHandler({ db: harness.db }, args)).resolves.toBeNull();
+  });
+
+  it("answers null for a token that resolves to no session at all", async () => {
+    const harness = exchangeHarness(null, [row]);
+    await expect(cachedHandler({ db: harness.db }, args)).resolves.toBeNull();
+  });
+});

--- a/packages/convex-logto/src/component/exchange.test.ts
+++ b/packages/convex-logto/src/component/exchange.test.ts
@@ -4,8 +4,10 @@ import {
   beginTokenExchange,
   cachedResourceToken,
   completeTokenExchange,
+  exchangeToken,
 } from "./lib";
 import {
+  MAX_CACHEABLE_ACCESS_TOKEN_LENGTH,
   RESOURCE_TOKEN_CACHE_LIMIT,
   RESOURCE_TOKEN_SKEW_MS,
   TOKEN_AUDIENCE_MAX_LENGTH,
@@ -13,6 +15,7 @@ import {
   decideExchange,
   tokenAudienceKey,
   tokenScopeKey,
+  TOKEN_SCOPE_MAX_COUNT,
 } from "./core";
 
 function handlerOf<Args, Result>(
@@ -147,6 +150,18 @@ describe("tokenScopeKey", () => {
     expect(tokenScopeKey([])).toBe("");
     expect(tokenScopeKey(["  "])).toBe("");
   });
+
+  it("bounds the ask, because the key is stored in a row deletion has to read", () => {
+    // Unbounded, a signed-in caller can park near-document-limit rows on its
+    // own session until a revocation batch can no longer read them — a session
+    // that can never be revoked.
+    expect(() =>
+      tokenScopeKey(
+        Array.from({ length: TOKEN_SCOPE_MAX_COUNT + 1 }, (_, i) => `s${i}`),
+      ),
+    ).toThrow(ConvexError);
+    expect(() => tokenScopeKey(["x".repeat(1024)])).toThrow(ConvexError);
+  });
 });
 
 describe("accessTokenExpiresAt", () => {
@@ -237,6 +252,14 @@ function sessionFixture(
  * A database double that filters on *every* `eq` in the index chain, which the
  * three-field `by_session_audience_scope` lookup needs.
  */
+type TokenGenerationRow = {
+  _id: string;
+  sessionId: string;
+  tokenHash: string;
+  rotatedAt: number;
+  expiresAt: number;
+};
+
 function exchangeHarness(
   initialSession: ExchangeSession | null,
   initialTokens: ResourceTokenRow[] = [],
@@ -244,6 +267,7 @@ function exchangeHarness(
     subject?: { subject: string; revokedAt: number };
     sids?: Array<{ sid: string; revokedAt: number }>;
   } = {},
+  initialGenerations: TokenGenerationRow[] = [],
 ) {
   let session = initialSession === null ? null : { ...initialSession };
   let tokens = initialTokens.map((row) => ({ ...row }));
@@ -259,9 +283,11 @@ function exchangeHarness(
   const inserted: Array<{ table: string; doc: Record<string, unknown> }> = [];
   let nextId = initialTokens.length + 1;
 
+  let generations = initialGenerations.map((row) => ({ ...row }));
   const rowsFor = (table: string): Array<Record<string, unknown>> => {
     if (table === "sessions") return session === null ? [] : [session];
     if (table === "resourceTokens") return tokens;
+    if (table === "sessionTokenGenerations") return generations;
     if (table === "subjectRevocations") return subjectRevocations;
     if (table === "sidRevocations") return sidRevocations;
     return [];
@@ -340,6 +366,7 @@ function exchangeHarness(
       deleted.push(id);
       if (session !== null && session._id === id) session = null;
       tokens = tokens.filter((row) => row._id !== id);
+      generations = generations.filter((row) => row._id !== id);
       return Promise.resolve();
     },
   };
@@ -369,7 +396,13 @@ const completeHandler = handlerOf<
 >(completeTokenExchange);
 
 const cachedHandler = handlerOf<
-  { presentedHash: string; audience: string; scopeKey: string; now: number },
+  {
+    presentedHash: string;
+    audience: string;
+    scopeKey: string;
+    now: number;
+    reuseWindowMs: number;
+  },
   { accessToken: string; expiresAt: number; grantedScope: string } | null
 >(cachedResourceToken);
 
@@ -608,6 +641,60 @@ describe("completeTokenExchange", () => {
     expect(harness.tokens()).toEqual([]);
   });
 
+  it("deletes rather than commits when the incoming sid is already revoked", async () => {
+    // Logto may report an OP session this row has not adopted yet. Checking
+    // only the row's current sid would mint and cache one Organization token
+    // *after* the back-channel logout that withdrew its authority.
+    const harness = exchangeHarness(claimed({ sid: "sid-old" }), [], {
+      sids: [{ sid: "sid-new", revokedAt: 600_000 }],
+    });
+    await expect(
+      completeHandler(
+        { db: harness.db },
+        {
+          ...baseArgs,
+          refreshedIdToken: {
+            idToken: "fresh",
+            exp: 5_000_000,
+            sid: "sid-new",
+          },
+        },
+      ),
+    ).resolves.toEqual({ outcome: "revoked" });
+    expect(harness.deleted).toEqual(["session-1"]);
+    expect(harness.tokens()).toEqual([]);
+  });
+
+  it("returns an oversized token without caching it, and drops any stale row", async () => {
+    // The per-session row bound has to be a byte bound too: session deletion
+    // reads these rows for eight sessions in one transaction.
+    const harness = exchangeHarness(claimed(), [
+      {
+        _id: "resourceTokens-0",
+        sessionId: "session-1",
+        audience: "organization:org-1",
+        scopeKey: "read",
+        accessToken: "older-token",
+        expiresAt: 2_000_000,
+        grantedScope: "read",
+        mintedAt: 900_000,
+      },
+    ]);
+    await expect(
+      completeHandler(
+        { db: harness.db },
+        {
+          ...baseArgs,
+          accessToken: "x".repeat(MAX_CACHEABLE_ACCESS_TOKEN_LENGTH + 1),
+        },
+      ),
+    ).resolves.toMatchObject({ outcome: "committed" });
+    // Not kept, and the older one for the same key is gone rather than left to
+    // be served for a target whose current token could not be stored.
+    expect(harness.tokens()).toEqual([]);
+    expect(harness.session()).toMatchObject({ refreshClaimId: undefined });
+  });
+
   it("reports a missing session rather than inventing one", async () => {
     const harness = exchangeHarness(null);
     await expect(
@@ -632,6 +719,7 @@ describe("cachedResourceToken", () => {
     audience: "organization:org-1",
     scopeKey: "read",
     now: 1_500_000,
+    reuseWindowMs: 10_000,
   };
 
   it("serves a fresh row without touching Logto", async () => {
@@ -673,5 +761,90 @@ describe("cachedResourceToken", () => {
   it("answers null for a token that resolves to no session at all", async () => {
     const harness = exchangeHarness(null, [row]);
     await expect(cachedHandler({ db: harness.db }, args)).resolves.toBeNull();
+  });
+
+  it("serves a superseded generation that is still inside its reuse window", async () => {
+    const harness = exchangeHarness(
+      sessionFixture({ rotatedAt: 1_499_000 }),
+      [row],
+      {},
+      [
+        {
+          _id: "generation-0",
+          sessionId: "session-1",
+          tokenHash: "previous",
+          rotatedAt: 1_499_000,
+          expiresAt: 1_509_000,
+        },
+      ],
+    );
+    await expect(
+      cachedHandler({ db: harness.db }, { ...args, presentedHash: "previous" }),
+    ).resolves.toMatchObject({ accessToken: "cached-token" });
+  });
+
+  it("refuses a rotated-away token instead of handing it a live token", async () => {
+    // The whole point of the reuse window is that a generation past it is
+    // treated as theft. A cache read is a query and cannot kill the session, so
+    // it answers null and lets `beginTokenExchange` — a mutation — do that.
+    // Serving it here would be the one read in the component that keeps a
+    // stolen session usable without ever tripping reuse detection.
+    const harness = exchangeHarness(
+      sessionFixture({ rotatedAt: 1_400_000 }),
+      [row],
+      {},
+      [
+        {
+          _id: "generation-0",
+          sessionId: "session-1",
+          tokenHash: "previous",
+          rotatedAt: 1_400_000,
+          expiresAt: 1_410_000,
+        },
+      ],
+    );
+    await expect(
+      cachedHandler({ db: harness.db }, { ...args, presentedHash: "previous" }),
+    ).resolves.toBeNull();
+  });
+
+  it("refuses a stale legacy previous-generation token too", async () => {
+    const harness = exchangeHarness(
+      sessionFixture({ prevTokenHash: "previous", rotatedAt: 1_400_000 }),
+      [row],
+    );
+    await expect(
+      cachedHandler({ db: harness.db }, { ...args, presentedHash: "previous" }),
+    ).resolves.toBeNull();
+    await expect(
+      cachedHandler(
+        { db: harness.db },
+        { ...args, presentedHash: "previous", now: 1_400_500 },
+      ),
+    ).resolves.toMatchObject({ accessToken: "cached-token" });
+  });
+});
+
+describe("exchangeToken", () => {
+  it("refuses a call that names no target rather than falling through to `default`", async () => {
+    // `default` is the opaque token Logto's userinfo endpoint accepts — the one
+    // credential here carrying the user's whole profile scope. `fetchUserInfo`
+    // reaches it internally and never returns it; letting an argument-free call
+    // reach it would put a target on the public surface that no client method
+    // can name and `exposeAccessTokens` was never written about.
+    const handler = handlerOf<Record<string, unknown>, unknown>(exchangeToken);
+    await expect(
+      handler(
+        {},
+        {
+          endpoint: "https://auth.example.com",
+          appId: "a",
+          clientSecret: "s",
+          sessionToken: "t",
+        },
+      ),
+    ).rejects.toMatchObject({
+      data: { kind: "terminal", code: "missing_token_target" },
+    });
   });
 });

--- a/packages/convex-logto/src/component/lib.ts
+++ b/packages/convex-logto/src/component/lib.ts
@@ -13,6 +13,7 @@ import { internal } from "./_generated/api.js";
 import type { DataModel, Doc, Id } from "./_generated/dataModel.js";
 import {
   DEFAULT_REUSE_WINDOW_MS,
+  MAX_CACHEABLE_ACCESS_TOKEN_LENGTH,
   RESOURCE_TOKEN_CACHE_LIMIT,
   RESOURCE_TOKEN_SKEW_MS,
   REVOCATION_MARKER_GC_AFTER_MS,
@@ -1235,8 +1236,21 @@ export const exchangeToken = action({
     /** True when this call went to Logto rather than being served from cache. */
     minted: v.boolean(),
   }),
-  handler: async (ctx, args): Promise<ExchangeResult> =>
-    await runExchange(ctx, args),
+  handler: async (ctx, args): Promise<ExchangeResult> => {
+    // The `default` audience is the opaque token `/oidc/me` accepts — the one
+    // credential here that carries the user's whole profile scope. It is
+    // reachable from `fetchUserInfo`, which never returns it, and from nowhere
+    // else: `exposeAccessTokens` governs Organization and Resource tokens, and
+    // letting an argument-free call fall through to `default` would quietly put
+    // a target on the public surface that no typed client method can name.
+    if (args.organizationId === undefined && args.resource === undefined) {
+      throw terminal(
+        "missing_token_target",
+        "Ask for an organization token or a resource token.",
+      );
+    }
+    return await runExchange(ctx, args);
+  },
 });
 
 /**
@@ -1265,7 +1279,13 @@ async function runExchange(
 
   const cached: CachedResourceToken | null = await ctx.runQuery(
     internal.lib.cachedResourceToken,
-    { presentedHash, audience, scopeKey, now: Date.now() },
+    {
+      presentedHash,
+      audience,
+      scopeKey,
+      now: Date.now(),
+      reuseWindowMs: args.reuseWindowMs ?? DEFAULT_REUSE_WINDOW_MS,
+    },
   );
   if (cached) {
     return {
@@ -1426,6 +1446,7 @@ export const cachedResourceToken = internalQuery({
     audience: v.string(),
     scopeKey: v.string(),
     now: v.number(),
+    reuseWindowMs: v.number(),
   },
   returns: v.union(
     v.object({
@@ -1439,6 +1460,16 @@ export const cachedResourceToken = internalQuery({
   handler: async (ctx, args) => {
     const match = await resolveSessionToken(ctx.db, args.presentedHash);
     if (!match) return null;
+    // A superseded generation past its Reuse window resolves to a session but
+    // has no authority left. Answering `null` sends the caller to
+    // `beginTokenExchange`, which is a *mutation* and can do what a query
+    // cannot: treat the presentation as theft and kill the session. Serving the
+    // cache here would hand a live Organization token to a rotated-away token
+    // and leave reuse detection untriggered — the one read in this component
+    // that could be used to hold a stolen session open.
+    if (!tokenMatchIsWithinReuseWindow(match, args.now, args.reuseWindowMs)) {
+      return null;
+    }
     // A logically revoked session's cached tokens are invisible, exactly like
     // its other reads: the rows may still be waiting for a bounded cleanup
     // batch, and until then they must retain no authority.
@@ -1590,7 +1621,26 @@ export const completeTokenExchange = internalMutation({
       await deleteSessionWithGenerations(ctx.db, session._id);
       return { outcome: "revoked" as const };
     }
+    // The *incoming* sid too, exactly as `completeRefresh` does. Logto may
+    // report an OP session this row has not adopted yet, and a back-channel
+    // logout for that sid has already withdrawn the authority the token was
+    // minted under — patching it in first would issue one Organization token
+    // after the logout that was supposed to stop it.
+    const incomingSid = args.refreshedIdToken?.sid;
+    if (incomingSid !== undefined && incomingSid !== session.sid) {
+      const cutoff = await sidRevokedAt(ctx.db, incomingSid);
+      if (cutoff !== undefined && session.createdAt <= cutoff) {
+        await deleteSessionWithGenerations(ctx.db, session._id);
+        return { outcome: "revoked" as const };
+      }
+    }
 
+    // Cache only what keeps the per-session bound a *byte* bound. A token past
+    // this is still returned to the caller; it simply is not stored, so the
+    // batched session deletion cannot be pushed out of its read budget by a
+    // deployment whose tokens are unusually large.
+    const cacheable =
+      args.accessToken.length <= MAX_CACHEABLE_ACCESS_TOKEN_LENGTH;
     const existing = await ctx.db
       .query("resourceTokens")
       .withIndex("by_session_audience_scope", (q) =>
@@ -1600,7 +1650,12 @@ export const completeTokenExchange = internalMutation({
           .eq("scopeKey", args.scopeKey),
       )
       .unique();
-    if (existing) {
+    if (!cacheable) {
+      // Drop any older row for this key rather than leaving it: it would go on
+      // being served for a target whose current token this call could not
+      // store, which is a stale answer, not a conservative one.
+      if (existing) await ctx.db.delete(existing._id);
+    } else if (existing) {
       await ctx.db.patch(existing._id, {
         accessToken: args.accessToken,
         expiresAt: args.expiresAt,

--- a/packages/convex-logto/src/component/lib.ts
+++ b/packages/convex-logto/src/component/lib.ts
@@ -13,6 +13,8 @@ import { internal } from "./_generated/api.js";
 import type { DataModel, Doc, Id } from "./_generated/dataModel.js";
 import {
   DEFAULT_REUSE_WINDOW_MS,
+  RESOURCE_TOKEN_CACHE_LIMIT,
+  RESOURCE_TOKEN_SKEW_MS,
   REVOCATION_MARKER_GC_AFTER_MS,
   SESSION_GC_AFTER_MS,
   SESSION_TOKEN_GENERATION_LIMIT,
@@ -25,6 +27,8 @@ import {
   buildAuthorizeUrl,
   buildEndSessionUrl,
   classifyTokenEndpointFailure,
+  accessTokenExpiresAt,
+  decideExchange,
   decideRefresh,
   decodeIdToken,
   generatePkce,
@@ -43,8 +47,11 @@ import {
   sessionReadCost,
   sessionReuseDetectedError,
   terminal,
+  tokenAudienceKey,
+  tokenScopeKey,
   transient,
   type DevicePublicKey,
+  type ResourceTokenClaims,
 } from "./core.js";
 import { buildLogtoEndpointUrl } from "./endpoint.js";
 import { readBoundedBody } from "./http_body.js";
@@ -239,6 +246,14 @@ async function deleteSessionWithGenerations(
     .withIndex("by_sessionId_rotatedAt", (q) => q.eq("sessionId", sessionId))
     .collect();
   for (const generation of generations) await db.delete(generation._id);
+  // Minted Organization / Resource tokens die with the session that authorized
+  // them. Bounded by RESOURCE_TOKEN_CACHE_LIMIT, so this stays a small, fixed
+  // amount of work inside a transaction that is already deleting rows.
+  const minted = await db
+    .query("resourceTokens")
+    .withIndex("by_sessionId_mintedAt", (q) => q.eq("sessionId", sessionId))
+    .collect();
+  for (const token of minted) await db.delete(token._id);
   await db.delete(sessionId);
 }
 
@@ -418,6 +433,8 @@ async function tokenEndpoint(
   id_token?: string;
   refresh_token?: string;
   access_token?: string;
+  expires_in?: number;
+  scope?: string;
 }> {
   const controller = new AbortController();
   const timeout = setTimeout(() => {
@@ -476,13 +493,15 @@ async function tokenEndpoint(
       ...(typeof body.refresh_token === "string"
         ? { refresh_token: body.refresh_token }
         : {}),
-      // Read but never used: session mode exposes the ID token only, and the
-      // deprecated `resources` option is the one thing that would make this
-      // access token interesting. Kept so a future caller that needs it does
-      // not have to re-derive where it lives.
+      // The refresh path ignores these; the Organization / Resource token
+      // exchange is built on them.
       ...(typeof body.access_token === "string"
         ? { access_token: body.access_token }
         : {}),
+      ...(typeof body.expires_in === "number"
+        ? { expires_in: body.expires_in }
+        : {}),
+      ...(typeof body.scope === "string" ? { scope: body.scope } : {}),
     };
   } catch (error) {
     if (error instanceof ConvexError) throw error;
@@ -1136,6 +1155,563 @@ export const killSession = internalMutation({
     if (!session || session.refreshClaimId !== args.claimId) return false;
     await deleteSessionWithGenerations(ctx.db, session._id);
     return true;
+  },
+});
+
+// --- organization / resource tokens -----------------------------------------
+
+const resourceTokenClaimsValidator = v.object({
+  audience: v.string(),
+  scopes: v.array(v.string()),
+  expiresAt: v.number(),
+  organizationId: v.optional(v.string()),
+  resource: v.optional(v.string()),
+});
+
+function claimsFromRow(
+  row: { audience: string; grantedScope: string; expiresAt: number },
+  target: { organizationId?: string; resource?: string },
+): ResourceTokenClaims {
+  return {
+    audience: row.audience,
+    scopes: row.grantedScope === "" ? [] : row.grantedScope.split(" "),
+    expiresAt: row.expiresAt,
+    ...(target.organizationId === undefined
+      ? {}
+      : { organizationId: target.organizationId }),
+    ...(target.resource === undefined ? {} : { resource: target.resource }),
+  };
+}
+
+/**
+ * Mint (or serve from cache) an Organization token, a Resource token, or the
+ * opaque token `fetchUserInfo` needs.
+ *
+ * This spends the Session's Logto refresh token, so it runs inside the *same*
+ * claim as {@link refresh} and inherits its whole failure vocabulary. That is
+ * not defensive: Logto rotates on a rule blind to what the grant was for, and
+ * only past 70% of the refresh token's lifetime — so an exchange running
+ * outside the claim would look correct until real tokens aged, then start
+ * tripping reuse detection on a grant sibling sessions share. See
+ * `docs/adr/0003-organization-token-exchange.md`.
+ *
+ * Returns claims; the token string only when the caller asks and the deployment
+ * allowed it (`docs/adr/0002-token-custody.md`).
+ */
+type ExchangeArgs = {
+  endpoint: string;
+  appId: string;
+  clientSecret: string;
+  sessionToken: string;
+  deviceProof?: string;
+  organizationId?: string;
+  resource?: string;
+  scopes?: string[];
+  includeToken?: boolean;
+  reuseWindowMs?: number;
+};
+
+type ExchangeResult = {
+  claims: ResourceTokenClaims;
+  accessToken?: string;
+  minted: boolean;
+};
+
+export const exchangeToken = action({
+  args: {
+    ...oidcArgs,
+    sessionToken: v.string(),
+    deviceProof: v.optional(v.string()),
+    organizationId: v.optional(v.string()),
+    resource: v.optional(v.string()),
+    scopes: v.optional(v.array(v.string())),
+    /** Return the token string, not just its claims. Gated by the caller. */
+    includeToken: v.optional(v.boolean()),
+    reuseWindowMs: v.optional(v.number()),
+  },
+  returns: v.object({
+    claims: resourceTokenClaimsValidator,
+    accessToken: v.optional(v.string()),
+    /** True when this call went to Logto rather than being served from cache. */
+    minted: v.boolean(),
+  }),
+  handler: async (ctx, args): Promise<ExchangeResult> =>
+    await runExchange(ctx, args),
+});
+
+/**
+ * The exchange itself, as a plain function.
+ *
+ * `fetchUserInfo` needs the same work with a different audience, and an action
+ * calling an action would double the transaction boundaries around a claim that
+ * exists to keep exactly one caller inside it.
+ */
+async function runExchange(
+  ctx: GenericActionCtx<DataModel>,
+  args: ExchangeArgs,
+): Promise<ExchangeResult> {
+  const audience = tokenAudienceKey(args);
+  const scopeKey = tokenScopeKey(args.scopes);
+  const presentedHash = await hashToken(args.sessionToken);
+  const devicePublicKey: DevicePublicKey | null = await ctx.runQuery(
+    internal.lib.devicePublicKeyForToken,
+    { presentedHash },
+  );
+  await assertDeviceProof({
+    publicKey: devicePublicKey ?? undefined,
+    sessionToken: args.sessionToken,
+    proof: args.deviceProof,
+  });
+
+  const cached: CachedResourceToken | null = await ctx.runQuery(
+    internal.lib.cachedResourceToken,
+    { presentedHash, audience, scopeKey, now: Date.now() },
+  );
+  if (cached) {
+    return {
+      claims: claimsFromRow(cached, args),
+      ...(args.includeToken ? { accessToken: cached.accessToken } : {}),
+      minted: false,
+    };
+  }
+
+  const claimId = generateToken();
+  const begin: BeginExchangeResult = await ctx.runMutation(
+    internal.lib.beginTokenExchange,
+    {
+      presentedHash,
+      claimId,
+      now: Date.now(),
+      reuseWindowMs: args.reuseWindowMs ?? DEFAULT_REUSE_WINDOW_MS,
+    },
+  );
+  switch (begin.outcome) {
+    case "reuse":
+      throw sessionReuseDetectedError();
+    case "claim-expired":
+      throw terminal(
+        "refresh_claim_expired",
+        "A previous refresh did not finish safely. Sign in again.",
+      );
+    case "exchange":
+      break;
+  }
+
+  let tokens: Awaited<ReturnType<typeof tokenEndpoint>>;
+  try {
+    tokens = await tokenEndpoint(args, {
+      grant_type: "refresh_token",
+      refresh_token: begin.refreshToken,
+      ...(args.organizationId === undefined
+        ? {}
+        : { organization_id: args.organizationId }),
+      ...(args.resource === undefined ? {} : { resource: args.resource }),
+      ...(scopeKey === "" ? {} : { scope: scopeKey }),
+    });
+  } catch (error) {
+    // Identical reasoning to `refresh`: release only when the failure proves
+    // Logto never processed the grant. `killSession` is deliberately absent —
+    // a terminal token-endpoint failure here (a mistyped organization id
+    // reaching Logto as `invalid_grant`) must not delete a session the user
+    // is still signed in to.
+    if (!isOutcomeUnknownError(error)) {
+      await ctx.runMutation(internal.lib.releaseClaim, {
+        sessionId: begin.sessionId,
+        claimId,
+      });
+    }
+    throw error;
+  }
+  if (!tokens.tokenResponse) {
+    throw outcomeUnknown(
+      "Logto's token endpoint answered with something that is not a token response — " +
+        "the refresh outcome is unknown.",
+    );
+  }
+  if (tokens.access_token === undefined) {
+    // A well-formed token response with no access token: a deployment fault
+    // (an organization the user does not belong to, a resource that is not
+    // registered), not a dead session. Persist any rotation and keep the row.
+    await ctx.runMutation(internal.lib.abandonRefreshWithRotation, {
+      sessionId: begin.sessionId,
+      claimId,
+      ...(tokens.refresh_token === undefined
+        ? {}
+        : { refreshToken: tokens.refresh_token }),
+    });
+    throw asDeploymentFault(
+      terminal(
+        "no_access_token",
+        "Logto's token response carried no access_token for that target.",
+      ),
+    );
+  }
+  const accessToken = tokens.access_token;
+  const now = Date.now();
+  // Every `refresh_token` grant returns an id_token, including this one.
+  // Keeping it is not an optimisation: discarding it would leave the Session
+  // ageing on a Short bearer older than the one Logto just issued.
+  let refreshedIdToken:
+    | { idToken: string; exp: number; sid?: string }
+    | undefined;
+  if (tokens.id_token !== undefined) {
+    try {
+      const claims = decodeIdToken(tokens.id_token, args);
+      refreshedIdToken = {
+        idToken: tokens.id_token,
+        exp: claims.expiresAtMs,
+        ...(claims.sid === undefined ? {} : { sid: claims.sid }),
+      };
+    } catch {
+      // An ID token we cannot validate is dropped, not raised: the exchange
+      // asked for an access token and got one. `refresh` is where an
+      // unusable ID token is a reportable deployment fault.
+    }
+  }
+  const completed: CompleteExchangeResult = await ctx.runMutation(
+    internal.lib.completeTokenExchange,
+    {
+      sessionId: begin.sessionId,
+      claimId,
+      audience,
+      scopeKey,
+      accessToken,
+      expiresAt: accessTokenExpiresAt({
+        accessToken,
+        expiresIn: tokens.expires_in,
+        now,
+      }),
+      grantedScope: tokens.scope ?? scopeKey,
+      newRefreshToken: tokens.refresh_token,
+      refreshedIdToken,
+      now,
+    },
+  );
+  if (completed.outcome === "revoked") {
+    throw terminal(
+      "session_revoked",
+      "This session was revoked while the token exchange was in progress. Sign in again.",
+    );
+  }
+  if (completed.outcome !== "committed") {
+    throw terminal(
+      "refresh_claim_lost",
+      "This token exchange no longer owns the session. Sign in again.",
+    );
+  }
+  return {
+    claims: claimsFromRow(
+      {
+        audience,
+        grantedScope: completed.grantedScope,
+        expiresAt: completed.expiresAt,
+      },
+      args,
+    ),
+    ...(args.includeToken ? { accessToken } : {}),
+    minted: true,
+  };
+}
+
+type CachedResourceToken = {
+  audience: string;
+  grantedScope: string;
+  expiresAt: number;
+  accessToken: string;
+};
+
+export const cachedResourceToken = internalQuery({
+  args: {
+    presentedHash: v.string(),
+    audience: v.string(),
+    scopeKey: v.string(),
+    now: v.number(),
+  },
+  returns: v.union(
+    v.object({
+      audience: v.string(),
+      grantedScope: v.string(),
+      expiresAt: v.number(),
+      accessToken: v.string(),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const match = await resolveSessionToken(ctx.db, args.presentedHash);
+    if (!match) return null;
+    // A logically revoked session's cached tokens are invisible, exactly like
+    // its other reads: the rows may still be waiting for a bounded cleanup
+    // batch, and until then they must retain no authority.
+    if (await sessionIsLogicallyRevoked(ctx.db, match.session)) return null;
+    const row = await ctx.db
+      .query("resourceTokens")
+      .withIndex("by_session_audience_scope", (q) =>
+        q
+          .eq("sessionId", match.session._id)
+          .eq("audience", args.audience)
+          .eq("scopeKey", args.scopeKey),
+      )
+      .unique();
+    if (!row) return null;
+    if (row.expiresAt - RESOURCE_TOKEN_SKEW_MS <= args.now) return null;
+    return {
+      audience: row.audience,
+      grantedScope: row.grantedScope,
+      expiresAt: row.expiresAt,
+      accessToken: row.accessToken,
+    };
+  },
+});
+
+type BeginExchangeResult =
+  | { outcome: "exchange"; sessionId: string; refreshToken: string }
+  | { outcome: "reuse" }
+  | { outcome: "claim-expired" };
+
+export const beginTokenExchange = internalMutation({
+  args: {
+    presentedHash: v.string(),
+    claimId: v.string(),
+    now: v.number(),
+    reuseWindowMs: v.number(),
+  },
+  returns: v.union(
+    v.object({
+      outcome: v.literal("exchange"),
+      sessionId: v.string(),
+      refreshToken: v.string(),
+    }),
+    v.object({ outcome: v.literal("reuse") }),
+    v.object({ outcome: v.literal("claim-expired") }),
+  ),
+  handler: async (ctx, args) => {
+    const match = await resolveSessionToken(ctx.db, args.presentedHash);
+    if (!match) {
+      throw terminal(
+        "session_not_found",
+        "No session for this token — it was signed out or revoked. Sign in again.",
+      );
+    }
+    const { session } = match;
+    if (await sessionIsLogicallyRevoked(ctx.db, session)) {
+      throw terminal(
+        "session_revoked",
+        "This session has been revoked. Sign in again.",
+      );
+    }
+    const decision = decideExchange({
+      presentedHash: args.presentedHash,
+      session,
+      now: args.now,
+      reuseWindowMs: args.reuseWindowMs,
+      presentedTokenExpiresAt:
+        match.source === "generation" ? match.expiresAt : undefined,
+    });
+    switch (decision.outcome) {
+      case "in-flight":
+        // A refresh (or another exchange) holds the claim. Transient by
+        // design: an Organization token is not worth destroying a grant for,
+        // and the caller retries once the refresh lands.
+        throw transient(
+          "refresh_in_flight",
+          "A refresh for this session is mid-flight — retry shortly.",
+        );
+      case "reuse":
+        await deleteSessionWithGenerations(ctx.db, session._id);
+        return { outcome: "reuse" as const };
+      case "claim-expired":
+        await deleteSessionWithGenerations(ctx.db, session._id);
+        return { outcome: "claim-expired" as const };
+      case "exchange":
+        await ctx.db.patch(session._id, {
+          refreshingSince: args.now,
+          refreshClaimId: args.claimId,
+        });
+        return {
+          outcome: "exchange" as const,
+          sessionId: session._id,
+          refreshToken: session.logtoRefreshToken,
+        };
+    }
+    throw new Error("Unreachable exchange decision.");
+  },
+});
+
+type CompleteExchangeResult =
+  | { outcome: "committed"; expiresAt: number; grantedScope: string }
+  | { outcome: "missing" }
+  | { outcome: "stale-owner" }
+  | { outcome: "revoked" };
+
+/**
+ * Persist the minted token, any refresh-token rotation and any fresher ID
+ * token, and release the claim — in one transaction, for the same reason
+ * {@link abandonRefreshWithRotation} is one transaction.
+ */
+export const completeTokenExchange = internalMutation({
+  args: {
+    sessionId: v.string(),
+    claimId: v.string(),
+    audience: v.string(),
+    scopeKey: v.string(),
+    accessToken: v.string(),
+    expiresAt: v.number(),
+    grantedScope: v.string(),
+    newRefreshToken: v.optional(v.string()),
+    refreshedIdToken: v.optional(
+      v.object({
+        idToken: v.string(),
+        exp: v.number(),
+        sid: v.optional(v.string()),
+      }),
+    ),
+    now: v.number(),
+  },
+  returns: v.union(
+    v.object({
+      outcome: v.literal("committed"),
+      expiresAt: v.number(),
+      grantedScope: v.string(),
+    }),
+    v.object({ outcome: v.literal("missing") }),
+    v.object({ outcome: v.literal("stale-owner") }),
+    v.object({ outcome: v.literal("revoked") }),
+  ),
+  handler: async (ctx, args) => {
+    const id = ctx.db.normalizeId("sessions", args.sessionId);
+    const session = id && (await ctx.db.get(id));
+    if (!session) return { outcome: "missing" as const };
+    if (session.refreshClaimId !== args.claimId) {
+      return { outcome: "stale-owner" as const };
+    }
+    if (await sessionIsLogicallyRevoked(ctx.db, session)) {
+      // Revoked mid-flight. Delete rather than cache: a token minted under
+      // authority that has since been withdrawn must not survive in a row.
+      await deleteSessionWithGenerations(ctx.db, session._id);
+      return { outcome: "revoked" as const };
+    }
+
+    const existing = await ctx.db
+      .query("resourceTokens")
+      .withIndex("by_session_audience_scope", (q) =>
+        q
+          .eq("sessionId", session._id)
+          .eq("audience", args.audience)
+          .eq("scopeKey", args.scopeKey),
+      )
+      .unique();
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        accessToken: args.accessToken,
+        expiresAt: args.expiresAt,
+        grantedScope: args.grantedScope,
+        mintedAt: args.now,
+      });
+    } else {
+      // Evict before inserting, so the table can never exceed the documented
+      // per-session limit — the same ordering `rememberSupersededToken` uses,
+      // and what keeps session deletion a bounded amount of work.
+      const rows = await ctx.db
+        .query("resourceTokens")
+        .withIndex("by_sessionId_mintedAt", (q) =>
+          q.eq("sessionId", session._id),
+        )
+        .order("asc")
+        .collect();
+      for (const row of rows.slice(
+        0,
+        Math.max(0, rows.length - (RESOURCE_TOKEN_CACHE_LIMIT - 1)),
+      )) {
+        await ctx.db.delete(row._id);
+      }
+      await ctx.db.insert("resourceTokens", {
+        sessionId: session._id,
+        audience: args.audience,
+        scopeKey: args.scopeKey,
+        accessToken: args.accessToken,
+        expiresAt: args.expiresAt,
+        grantedScope: args.grantedScope,
+        mintedAt: args.now,
+      });
+    }
+
+    await ctx.db.patch(session._id, {
+      refreshingSince: undefined,
+      refreshClaimId: undefined,
+      lastRefreshedAt: args.now,
+      ...(args.newRefreshToken
+        ? { logtoRefreshToken: args.newRefreshToken }
+        : {}),
+      ...(args.refreshedIdToken
+        ? {
+            lastIdToken: args.refreshedIdToken.idToken,
+            lastIdTokenExp: args.refreshedIdToken.exp,
+            ...(args.refreshedIdToken.sid === undefined
+              ? {}
+              : { sid: args.refreshedIdToken.sid }),
+          }
+        : {}),
+    });
+    return {
+      outcome: "committed" as const,
+      expiresAt: args.expiresAt,
+      grantedScope: args.grantedScope,
+    };
+  },
+});
+
+/**
+ * Logto's `/oidc/me`, through the same exchange.
+ *
+ * The userinfo endpoint wants the *default* (opaque) access token, which is
+ * what the `default` audience caches — so a profile fetch costs a grant only
+ * when the cached token has aged out, not on every call.
+ */
+export const fetchUserInfo = action({
+  args: {
+    ...oidcArgs,
+    sessionToken: v.string(),
+    deviceProof: v.optional(v.string()),
+    reuseWindowMs: v.optional(v.number()),
+  },
+  returns: v.any(),
+  handler: async (ctx, args): Promise<unknown> => {
+    // The `default` audience: no organization, no resource — the opaque token
+    // Logto's userinfo endpoint accepts. `exposeAccessTokens` does not gate it,
+    // because it never leaves this function.
+    const exchanged = await runExchange(ctx, { ...args, includeToken: true });
+    if (exchanged.accessToken === undefined) {
+      throw transient(
+        "no_userinfo_token",
+        "Could not obtain an access token for Logto's userinfo endpoint.",
+      );
+    }
+    const controller = new AbortController();
+    const timeout = setTimeout(() => {
+      controller.abort();
+    }, TOKEN_ENDPOINT_TIMEOUT_MS);
+    try {
+      const res = await fetch(buildLogtoEndpointUrl(args.endpoint, "me"), {
+        headers: { Authorization: `Bearer ${exchanged.accessToken}` },
+        signal: controller.signal,
+      });
+      const body = await readBoundedBody(res, MAX_TOKEN_RESPONSE_BYTES);
+      if (!res.ok || !body.ok) {
+        throw transient(
+          "userinfo_failed",
+          `Logto's userinfo endpoint answered ${res.status}.`,
+        );
+      }
+      return JSON.parse(tokenResponseDecoder.decode(body.bytes)) as unknown;
+    } catch (error) {
+      if (error instanceof ConvexError) throw error;
+      throw transient(
+        "logto_unreachable",
+        "Could not reach Logto's userinfo endpoint.",
+      );
+    } finally {
+      clearTimeout(timeout);
+    }
   },
 });
 
@@ -1935,6 +2511,15 @@ export const gc = internalMutation({
     for (const generation of expiredGenerations) {
       await ctx.db.delete(generation._id);
     }
+    // Minted Organization / Resource tokens normally die with their session.
+    // This collects the ones whose session outlives them — an expired row keeps
+    // no authority (`cachedResourceToken` re-checks expiry) but it is dead
+    // weight inside the per-session cache bound until something removes it.
+    const expiredResourceTokens = await ctx.db
+      .query("resourceTokens")
+      .withIndex("by_expiresAt", (q) => q.lt("expiresAt", now))
+      .take(GC_SMALL_DOCUMENT_BATCH_SIZE);
+    for (const token of expiredResourceTokens) await ctx.db.delete(token._id);
     const staleDeliveries = await ctx.db
       .query("webhookDeliveries")
       .withIndex("by_seenAt", (q) =>
@@ -1948,6 +2533,7 @@ export const gc = internalMutation({
       expiredTransactions.length === GC_TRANSACTION_BATCH_SIZE ||
       deadSessions.length === REVOCATION_BATCH_SIZE ||
       expiredGenerations.length === GC_SMALL_DOCUMENT_BATCH_SIZE ||
+      expiredResourceTokens.length === GC_SMALL_DOCUMENT_BATCH_SIZE ||
       staleDeliveries.length === GC_SMALL_DOCUMENT_BATCH_SIZE
     ) {
       await ctx.scheduler.runAfter(0, internal.lib.gc, {});

--- a/packages/convex-logto/src/component/revocation.test.ts
+++ b/packages/convex-logto/src/component/revocation.test.ts
@@ -186,7 +186,10 @@ describe("bounded session revocation", () => {
                 },
               };
             }
-            if (table === "sessionTokenGenerations") {
+            if (
+              table === "sessionTokenGenerations" ||
+              table === "resourceTokens"
+            ) {
               return { collect: () => Promise.resolve([]) };
             }
             return {
@@ -243,8 +246,9 @@ describe("bounded session revocation", () => {
             };
           }
           if (
-            table === "sessionTokenGenerations" &&
-            index === "by_sessionId_rotatedAt"
+            (table === "sessionTokenGenerations" &&
+              index === "by_sessionId_rotatedAt") ||
+            (table === "resourceTokens" && index === "by_sessionId_mintedAt")
           ) {
             return { collect: () => Promise.resolve([]) };
           }

--- a/packages/convex-logto/src/component/schema.ts
+++ b/packages/convex-logto/src/component/schema.ts
@@ -124,6 +124,31 @@ export default defineSchema({
     .index("by_sid", ["sid"])
     .index("by_revokedAt", ["revokedAt"]),
 
+  // Organization / API-resource access tokens minted from a Session's Logto
+  // refresh token, cached so that an authorization check does not cost a grant
+  // per render. Server-held like the refresh token: the token string leaves the
+  // component only when the deployment set `exposeAccessTokens`.
+  //
+  // Rows are bounded per session (`RESOURCE_TOKEN_CACHE_LIMIT`) so the
+  // transaction that deletes a session can delete them with it. A minted token
+  // that outlived its session would keep authority the session no longer has.
+  resourceTokens: defineTable({
+    sessionId: v.id("sessions"),
+    /** `organization:<id>`, `resource:<indicator>`, or `default`. */
+    audience: v.string(),
+    /** Sorted, space-joined requested scopes — a narrower ask is a different key. */
+    scopeKey: v.string(),
+    accessToken: v.string(),
+    /** From the token's own `exp` where it has one, else `expires_in`. */
+    expiresAt: v.number(),
+    /** What Logto actually granted, which may be less than what was asked. */
+    grantedScope: v.string(),
+    mintedAt: v.number(),
+  })
+    .index("by_session_audience_scope", ["sessionId", "audience", "scopeKey"])
+    .index("by_sessionId_mintedAt", ["sessionId", "mintedAt"])
+    .index("by_expiresAt", ["expiresAt"]),
+
   // Bounded, indexed grace history for responses that arrive out of order.
   // `prevTokenHash` remains on sessions as a legacy adapter for rows created
   // before this table existed.

--- a/packages/convex-logto/src/index.ts
+++ b/packages/convex-logto/src/index.ts
@@ -38,6 +38,7 @@ export {
   assertSubjectHasActiveSession,
   assertUserHasActiveSession,
   logtoSessionApi,
+  type LogtoResourceTokenClaims,
   type LogtoSessionApi,
   type LogtoSessionApiOptions,
   type LogtoSessionClientDescriptor,

--- a/packages/convex-logto/src/native-session.tsx
+++ b/packages/convex-logto/src/native-session.tsx
@@ -30,6 +30,7 @@ import type { LogtoAuthEventHandler } from "./auth-events";
 import { SessionAuthEngine } from "./session-client";
 import { defaultSessionTransport } from "./session-transport";
 import type {
+  LogtoResourceTokenClaims,
   LogtoSessionApi,
   LogtoSessionClientDescriptor,
   LogtoSessionSummary,
@@ -330,6 +331,48 @@ export type LogtoSessionAuth = {
    * credentials — call `signOut` for that.
    */
   revokeSession: (targetSessionId: string) => Promise<void>;
+  /**
+   * The current ID token — the Short bearer Convex validates. `null` when
+   * signed out or when the stored one has aged out.
+   */
+  getIdToken: () => string | null;
+  /**
+   * What an Organization token authorizes, without the token itself.
+   *
+   * Membership and organization *roles* need none of this: Logto puts them in
+   * the ID token, so `user.organizations` and `user.organization_roles` are
+   * already here for free. This is for fine-grained organization
+   * **permissions**, which Logto issues nowhere but an Organization token.
+   */
+  getOrganizationTokenClaims: (
+    organizationId: string,
+    scopes?: string[],
+  ) => Promise<LogtoResourceTokenClaims>;
+  /**
+   * What a Resource token authorizes. The resource must be listed in
+   * `resources` on `logtoSessionApi()` — Logto will not issue a token for a
+   * resource the grant never named.
+   */
+  getAccessTokenClaims: (
+    resource: string,
+    scopes?: string[],
+  ) => Promise<LogtoResourceTokenClaims>;
+  /**
+   * The Organization token *string*, for a caller that must reach a non-Convex
+   * API from the browser. Rejects unless the deployment passed
+   * `exposeAccessTokens: true`.
+   */
+  getOrganizationToken: (
+    organizationId: string,
+    scopes?: string[],
+  ) => Promise<string>;
+  /** The Resource token *string*, under the same `exposeAccessTokens` gate. */
+  getAccessToken: (resource: string, scopes?: string[]) => Promise<string>;
+  /**
+   * Logto's live profile (`/oidc/me`), fetched by the component. A round trip,
+   * unlike `user`, which is the copy the last ID token froze.
+   */
+  fetchUserInfo: () => Promise<unknown>;
 };
 
 export function useLogtoAuth(): LogtoSessionAuth {
@@ -370,6 +413,28 @@ export function useLogtoAuth(): LogtoSessionAuth {
     (targetSessionId: string) => engine.revokeSession(targetSessionId),
     [engine],
   );
+  const getIdToken = useCallback(() => engine.getIdToken(), [engine]);
+  const getOrganizationTokenClaims = useCallback(
+    (organizationId: string, scopes?: string[]) =>
+      engine.getOrganizationTokenClaims(organizationId, scopes),
+    [engine],
+  );
+  const getAccessTokenClaims = useCallback(
+    (resource: string, scopes?: string[]) =>
+      engine.getAccessTokenClaims(resource, scopes),
+    [engine],
+  );
+  const getOrganizationToken = useCallback(
+    (organizationId: string, scopes?: string[]) =>
+      engine.getOrganizationToken(organizationId, scopes),
+    [engine],
+  );
+  const getAccessToken = useCallback(
+    (resource: string, scopes?: string[]) =>
+      engine.getAccessToken(resource, scopes),
+    [engine],
+  );
+  const fetchUserInfo = useCallback(() => engine.fetchUserInfo(), [engine]);
   return useMemo(
     () => ({
       isAuthenticated,
@@ -382,6 +447,12 @@ export function useLogtoAuth(): LogtoSessionAuth {
       listSessions,
       renameSession,
       revokeSession,
+      getIdToken,
+      getOrganizationTokenClaims,
+      getAccessTokenClaims,
+      getOrganizationToken,
+      getAccessToken,
+      fetchUserInfo,
     }),
     [
       isAuthenticated,
@@ -394,6 +465,12 @@ export function useLogtoAuth(): LogtoSessionAuth {
       listSessions,
       renameSession,
       revokeSession,
+      getIdToken,
+      getOrganizationTokenClaims,
+      getAccessTokenClaims,
+      getOrganizationToken,
+      getAccessToken,
+      fetchUserInfo,
     ],
   );
 }
@@ -405,6 +482,7 @@ export type {
   LogtoAuthPhase,
 } from "./auth-events";
 export type {
+  LogtoResourceTokenClaims,
   LogtoSessionApi,
   LogtoSessionClientDescriptor,
   LogtoSessionSummary,

--- a/packages/convex-logto/src/native-session.tsx
+++ b/packages/convex-logto/src/native-session.tsx
@@ -333,7 +333,9 @@ export type LogtoSessionAuth = {
   revokeSession: (targetSessionId: string) => Promise<void>;
   /**
    * The current ID token — the Short bearer Convex validates. `null` when
-   * signed out or when the stored one has aged out.
+   * signed out, when the stored one has aged out, or while the engine is still
+   * restoring — so read it under `isAuthenticated`, which is false until the
+   * restore finishes.
    */
   getIdToken: () => string | null;
   /**

--- a/packages/convex-logto/src/react-session.tsx
+++ b/packages/convex-logto/src/react-session.tsx
@@ -481,7 +481,9 @@ export type LogtoSessionAuth = {
   revokeSession: (targetSessionId: string) => Promise<void>;
   /**
    * The current ID token — the Short bearer Convex validates. `null` when
-   * signed out or when the stored one has aged out.
+   * signed out, when the stored one has aged out, or while the engine is still
+   * restoring — so read it under `isAuthenticated`, which is false until the
+   * restore finishes.
    */
   getIdToken: () => string | null;
   /**

--- a/packages/convex-logto/src/react-session.tsx
+++ b/packages/convex-logto/src/react-session.tsx
@@ -34,6 +34,7 @@ import {
   type LogtoSessionCookieTransportOptions,
 } from "./session-cookie";
 import type {
+  LogtoResourceTokenClaims,
   LogtoSessionApi,
   LogtoSessionClientDescriptor,
   LogtoSessionSummary,
@@ -478,6 +479,48 @@ export type LogtoSessionAuth = {
    * Logto SSO cookie can start a new sign-in.
    */
   revokeSession: (targetSessionId: string) => Promise<void>;
+  /**
+   * The current ID token — the Short bearer Convex validates. `null` when
+   * signed out or when the stored one has aged out.
+   */
+  getIdToken: () => string | null;
+  /**
+   * What an Organization token authorizes, without the token itself.
+   *
+   * Membership and organization *roles* need none of this: Logto puts them in
+   * the ID token, so `user.organizations` and `user.organization_roles` are
+   * already here for free. This is for fine-grained organization
+   * **permissions**, which Logto issues nowhere but an Organization token.
+   */
+  getOrganizationTokenClaims: (
+    organizationId: string,
+    scopes?: string[],
+  ) => Promise<LogtoResourceTokenClaims>;
+  /**
+   * What a Resource token authorizes. The resource must be listed in
+   * `resources` on `logtoSessionApi()` — Logto will not issue a token for a
+   * resource the grant never named.
+   */
+  getAccessTokenClaims: (
+    resource: string,
+    scopes?: string[],
+  ) => Promise<LogtoResourceTokenClaims>;
+  /**
+   * The Organization token *string*, for a caller that must reach a non-Convex
+   * API from the browser. Rejects unless the deployment passed
+   * `exposeAccessTokens: true`.
+   */
+  getOrganizationToken: (
+    organizationId: string,
+    scopes?: string[],
+  ) => Promise<string>;
+  /** The Resource token *string*, under the same `exposeAccessTokens` gate. */
+  getAccessToken: (resource: string, scopes?: string[]) => Promise<string>;
+  /**
+   * Logto's live profile (`/oidc/me`), fetched by the component. A round trip,
+   * unlike `user`, which is the copy the last ID token froze.
+   */
+  fetchUserInfo: () => Promise<unknown>;
 };
 
 /**
@@ -520,6 +563,28 @@ export function useLogtoAuth(): LogtoSessionAuth {
     (targetSessionId: string) => engine.revokeSession(targetSessionId),
     [engine],
   );
+  const getIdToken = useCallback(() => engine.getIdToken(), [engine]);
+  const getOrganizationTokenClaims = useCallback(
+    (organizationId: string, scopes?: string[]) =>
+      engine.getOrganizationTokenClaims(organizationId, scopes),
+    [engine],
+  );
+  const getAccessTokenClaims = useCallback(
+    (resource: string, scopes?: string[]) =>
+      engine.getAccessTokenClaims(resource, scopes),
+    [engine],
+  );
+  const getOrganizationToken = useCallback(
+    (organizationId: string, scopes?: string[]) =>
+      engine.getOrganizationToken(organizationId, scopes),
+    [engine],
+  );
+  const getAccessToken = useCallback(
+    (resource: string, scopes?: string[]) =>
+      engine.getAccessToken(resource, scopes),
+    [engine],
+  );
+  const fetchUserInfo = useCallback(() => engine.fetchUserInfo(), [engine]);
   return useMemo(
     () => ({
       isAuthenticated,
@@ -531,6 +596,12 @@ export function useLogtoAuth(): LogtoSessionAuth {
       listSessions,
       renameSession,
       revokeSession,
+      getIdToken,
+      getOrganizationTokenClaims,
+      getAccessTokenClaims,
+      getOrganizationToken,
+      getAccessToken,
+      fetchUserInfo,
     }),
     [
       isAuthenticated,
@@ -542,6 +613,12 @@ export function useLogtoAuth(): LogtoSessionAuth {
       listSessions,
       renameSession,
       revokeSession,
+      getIdToken,
+      getOrganizationTokenClaims,
+      getAccessTokenClaims,
+      getOrganizationToken,
+      getAccessToken,
+      fetchUserInfo,
     ],
   );
 }
@@ -553,6 +630,7 @@ export type {
   LogtoAuthPhase,
 } from "./auth-events";
 export type {
+  LogtoResourceTokenClaims,
   LogtoSessionApi,
   LogtoSessionClientDescriptor,
   LogtoSessionSummary,

--- a/packages/convex-logto/src/session-client.test.ts
+++ b/packages/convex-logto/src/session-client.test.ts
@@ -80,6 +80,8 @@ const api = {
   listSessions: { fn: "listSessions" },
   renameSession: { fn: "renameSession" },
   revokeSession: { fn: "revokeSession" },
+  exchangeToken: { fn: "exchangeToken" },
+  fetchUserInfo: { fn: "fetchUserInfo" },
   sessionValid: { fn: "sessionValid" },
 } as unknown as LogtoSessionApi;
 
@@ -92,6 +94,8 @@ type Handlers = {
   listSessions: ReturnType<typeof vi.fn>;
   renameSession: ReturnType<typeof vi.fn>;
   revokeSession: ReturnType<typeof vi.fn>;
+  exchangeToken: ReturnType<typeof vi.fn>;
+  fetchUserInfo: ReturnType<typeof vi.fn>;
 };
 
 function makeHarness(options?: {
@@ -123,6 +127,8 @@ function makeHarness(options?: {
     listSessions: vi.fn(),
     renameSession: vi.fn(),
     revokeSession: vi.fn(),
+    exchangeToken: vi.fn(),
+    fetchUserInfo: vi.fn(),
   };
   const transport = {
     action: (ref: unknown, args: unknown) =>
@@ -2407,5 +2413,163 @@ describe("auth phase events", () => {
     expect(phasesOf(events)).not.toContain("convex_authenticated");
     engine.reportConvexAuthenticated();
     expect(phasesOf(events).at(-1)).toBe("convex_authenticated");
+  });
+});
+
+describe("token exchange", () => {
+  const claims = {
+    audience: "organization:org-1",
+    scopes: ["manage"],
+    expiresAt: 5_000_000,
+    organizationId: "org-1",
+  };
+
+  it("authenticates the exchange with the current session token and proof", async () => {
+    const deviceBinding = {
+      sign: vi.fn().mockResolvedValue("device-proof"),
+    } as unknown as SessionDeviceBinding;
+    const harness = makeHarness({
+      storedSession: { token: "session-token", sessionId: "session-1" },
+      storedIdToken: freshToken(),
+      deviceBinding,
+    });
+    harness.engine.start();
+    await settled(harness.engine);
+    harness.handlers.exchangeToken.mockResolvedValue({
+      claims,
+      minted: true,
+    });
+
+    await expect(
+      harness.engine.getOrganizationTokenClaims("org-1", ["manage"]),
+    ).resolves.toEqual(claims);
+    expect(harness.handlers.exchangeToken).toHaveBeenCalledWith({
+      sessionToken: "session-token",
+      deviceProof: "device-proof",
+      organizationId: "org-1",
+      scopes: ["manage"],
+    });
+  });
+
+  it("asks for a resource by indicator, never as an organization", async () => {
+    const harness = makeHarness({
+      storedSession: { token: "session-token", sessionId: "session-1" },
+      storedIdToken: freshToken(),
+    });
+    harness.engine.start();
+    await settled(harness.engine);
+    harness.handlers.exchangeToken.mockResolvedValue({
+      claims: {
+        audience: "resource:https://api.example.com",
+        scopes: ["read"],
+        expiresAt: 5_000_000,
+      },
+      minted: true,
+    });
+
+    await harness.engine.getAccessTokenClaims("https://api.example.com");
+    expect(harness.handlers.exchangeToken).toHaveBeenCalledWith({
+      sessionToken: "session-token",
+      resource: "https://api.example.com",
+    });
+  });
+
+  it("asks for the token string only when a token-returning method was called", async () => {
+    const harness = makeHarness({
+      storedSession: { token: "session-token", sessionId: "session-1" },
+      storedIdToken: freshToken(),
+    });
+    harness.engine.start();
+    await settled(harness.engine);
+    harness.handlers.exchangeToken.mockResolvedValue({
+      claims,
+      accessToken: "org-token",
+      minted: true,
+    });
+
+    await expect(harness.engine.getOrganizationToken("org-1")).resolves.toBe(
+      "org-token",
+    );
+    expect(harness.handlers.exchangeToken).toHaveBeenCalledWith({
+      sessionToken: "session-token",
+      organizationId: "org-1",
+      includeToken: true,
+    });
+  });
+
+  it("errors rather than returning an empty credential when none came back", async () => {
+    const harness = makeHarness({
+      storedSession: { token: "session-token", sessionId: "session-1" },
+      storedIdToken: freshToken(),
+    });
+    harness.engine.start();
+    await settled(harness.engine);
+    harness.handlers.exchangeToken.mockResolvedValue({ claims, minted: true });
+
+    await expect(harness.engine.getAccessToken("https://api")).rejects.toThrow(
+      /exposeAccessTokens/,
+    );
+  });
+
+  it("names the missing export when the app module predates the action", async () => {
+    const harness = makeHarness({
+      storedSession: { token: "session-token", sessionId: "session-1" },
+      storedIdToken: freshToken(),
+      sessionApi: {
+        ...(api as unknown as Record<string, unknown>),
+        exchangeToken: undefined,
+        fetchUserInfo: undefined,
+      } as unknown as LogtoSessionApi,
+    });
+    harness.engine.start();
+    await settled(harness.engine);
+
+    await expect(
+      harness.engine.getOrganizationTokenClaims("org-1"),
+    ).rejects.toThrow(/exchangeToken/);
+    await expect(harness.engine.fetchUserInfo()).rejects.toThrow(
+      /fetchUserInfo/,
+    );
+  });
+
+  it("requires an active session before asking for anything", async () => {
+    const harness = makeHarness();
+    harness.engine.start();
+    await settled(harness.engine);
+    await expect(
+      harness.engine.getOrganizationTokenClaims("org-1"),
+    ).rejects.toThrow(/requires an active session/);
+    expect(harness.handlers.exchangeToken).not.toHaveBeenCalled();
+  });
+});
+
+describe("getIdToken", () => {
+  it("returns the stored Short bearer while it is still fresh", async () => {
+    const token = freshToken();
+    const harness = makeHarness({
+      storedSession: { token: "session-token", sessionId: "session-1" },
+      storedIdToken: token,
+    });
+    harness.engine.start();
+    await settled(harness.engine);
+    expect(harness.engine.getIdToken()).toBe(token);
+  });
+
+  it("withholds one that has aged into the skew rather than handing back a dud", async () => {
+    const harness = makeHarness({
+      storedSession: { token: "session-token", sessionId: "session-1" },
+      storedIdToken: staleToken(),
+    });
+    harness.handlers.refresh.mockRejectedValue(transientError());
+    harness.engine.start();
+    await settled(harness.engine);
+    expect(harness.engine.getIdToken()).toBeNull();
+  });
+
+  it("is null when signed out", async () => {
+    const harness = makeHarness();
+    harness.engine.start();
+    await settled(harness.engine);
+    expect(harness.engine.getIdToken()).toBeNull();
   });
 });

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -27,6 +27,7 @@ import {
   type SessionDeviceBinding,
 } from "./session-device";
 import type {
+  LogtoResourceTokenClaims,
   LogtoSessionApi,
   LogtoSessionClientDescriptor,
   LogtoSessionSummary,
@@ -1373,6 +1374,132 @@ export class SessionAuthEngine {
     await this.callSessionAction("revokeSession", () =>
       this.options.transport.action(action, { ...credential, targetSessionId }),
     );
+  }
+
+  /**
+   * The current ID token — the Short bearer Convex validates.
+   *
+   * Read from storage rather than the snapshot: the snapshot is what React
+   * rendered, and a rotation that landed since the last render is already in
+   * storage. Returns `null` when signed out, or when the stored token has aged
+   * out; call `refresh()`-driven flows (any Convex call) to mint a fresh one.
+   */
+  getIdToken(): string | null {
+    const cached = this.options.storage.readIdToken();
+    return cached !== null && this.isFresh(cached) ? cached : null;
+  }
+
+  /**
+   * What an Organization token authorizes, without the token itself.
+   *
+   * Membership and organization *roles* do not need this — Logto puts them in
+   * the ID token, so `user.organizations` and `user.organization_roles` are
+   * already there and cost nothing. Reach for this only for fine-grained
+   * organization **permissions**, which Logto issues nowhere else.
+   */
+  async getOrganizationTokenClaims(
+    organizationId: string,
+    scopes?: string[],
+  ): Promise<LogtoResourceTokenClaims> {
+    return (await this.exchange({ organizationId, scopes })).claims;
+  }
+
+  /**
+   * What a Resource token authorizes, without the token itself.
+   *
+   * The resource must be in `resources` on `logtoSessionApi()`: Logto will not
+   * issue a token for a resource the grant never named.
+   */
+  async getAccessTokenClaims(
+    resource: string,
+    scopes?: string[],
+  ): Promise<LogtoResourceTokenClaims> {
+    return (await this.exchange({ resource, scopes })).claims;
+  }
+
+  /**
+   * The Organization token *string*.
+   *
+   * Available only where the deployment passed `exposeAccessTokens: true`;
+   * otherwise this rejects with a terminal error naming the option, rather than
+   * returning claims and letting the missing credential surface as an
+   * authorization failure somewhere else. Prefer
+   * {@link getOrganizationTokenClaims} — a token in `window` is one more thing
+   * XSS can steal.
+   */
+  async getOrganizationToken(
+    organizationId: string,
+    scopes?: string[],
+  ): Promise<string> {
+    return this.requireToken(
+      await this.exchange({ organizationId, scopes, includeToken: true }),
+    );
+  }
+
+  /** The Resource token *string*, under the same `exposeAccessTokens` gate. */
+  async getAccessToken(resource: string, scopes?: string[]): Promise<string> {
+    return this.requireToken(
+      await this.exchange({ resource, scopes, includeToken: true }),
+    );
+  }
+
+  /**
+   * Logto's `/oidc/me`, fetched by the component.
+   *
+   * A round trip, unlike `user`: this is the live profile from Logto rather
+   * than the copy the last ID token froze. Use it after a profile edit.
+   */
+  async fetchUserInfo(): Promise<unknown> {
+    const action = this.options.api.fetchUserInfo;
+    if (action === undefined) throw sessionApiUpgradeError("fetchUserInfo");
+    const credential = await this.sessionCallCredential("fetchUserInfo");
+    return await this.callSessionAction("fetchUserInfo", () =>
+      this.options.transport.action(action, credential),
+    );
+  }
+
+  private async exchange(args: {
+    organizationId?: string;
+    resource?: string;
+    scopes?: string[];
+    includeToken?: boolean;
+  }): Promise<{
+    claims: LogtoResourceTokenClaims;
+    accessToken?: string;
+    minted: boolean;
+  }> {
+    const action = this.options.api.exchangeToken;
+    if (action === undefined) throw sessionApiUpgradeError("exchangeToken");
+    const credential = await this.sessionCallCredential("exchangeToken");
+    return await this.callSessionAction("exchangeToken", () =>
+      this.options.transport.action(action, {
+        ...credential,
+        ...(args.organizationId === undefined
+          ? {}
+          : { organizationId: args.organizationId }),
+        ...(args.resource === undefined ? {} : { resource: args.resource }),
+        ...(args.scopes === undefined ? {} : { scopes: args.scopes }),
+        ...(args.includeToken === undefined
+          ? {}
+          : { includeToken: args.includeToken }),
+      }),
+    );
+  }
+
+  /**
+   * The server refuses `includeToken` when the deployment did not opt in, so
+   * this only fires for a component that answered without one anyway. Still an
+   * error rather than an empty string: every caller here is about to put the
+   * value in an `Authorization` header.
+   */
+  private requireToken(result: { accessToken?: string }): string {
+    if (result.accessToken === undefined) {
+      throw new Error(
+        "convex-logto: the deployment did not return an access token. Pass " +
+          "`exposeAccessTokens: true` to logtoSessionApi() to allow it.",
+      );
+    }
+    return result.accessToken;
   }
 
   /**

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -1382,7 +1382,13 @@ export class SessionAuthEngine {
    * Read from storage rather than the snapshot: the snapshot is what React
    * rendered, and a rotation that landed since the last render is already in
    * storage. Returns `null` when signed out, or when the stored token has aged
-   * out; call `refresh()`-driven flows (any Convex call) to mint a fresh one.
+   * out; any Convex call mints a fresh one.
+   *
+   * Synchronous, which is what makes it usable in a render — and the reason it
+   * has one caveat. On React Native the SecureStore-backed adapter reads as
+   * empty until it has hydrated, so a call made while the engine is still
+   * `restoring` answers `null` even though a live token exists. Gate on
+   * `isAuthenticated` (false during restore) and that window is unreachable.
    */
   getIdToken(): string | null {
     const cached = this.options.storage.readIdToken();

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -1453,8 +1453,14 @@ export class SessionAuthEngine {
     const action = this.options.api.fetchUserInfo;
     if (action === undefined) throw sessionApiUpgradeError("fetchUserInfo");
     const credential = await this.sessionCallCredential("fetchUserInfo");
-    return await this.callSessionAction("fetchUserInfo", () =>
-      this.options.transport.action(action, credential),
+    // Also an exchange behind the scenes — it mints the opaque token Logto's
+    // userinfo endpoint wants — so it takes the same lock for the same reason.
+    return await this.withLock(() =>
+      this.retrying(() =>
+        this.callSessionAction("fetchUserInfo", () =>
+          this.options.transport.action(action, credential),
+        ),
+      ),
     );
   }
 
@@ -1471,6 +1477,34 @@ export class SessionAuthEngine {
     const action = this.options.api.exchangeToken;
     if (action === undefined) throw sessionApiUpgradeError("exchangeToken");
     const credential = await this.sessionCallCredential("exchangeToken");
+    // Under the same lock as `refreshIdToken`, and retried like it.
+    //
+    // The component runs this exchange inside the session's refresh claim, so
+    // it and a refresh cannot both be in flight — the loser gets a transient
+    // `refresh_in_flight`. Without the lock the loser is usually the *refresh*,
+    // and a refresh that exhausts its retries drops the whole app to
+    // unauthenticated until the recovery loop catches up. Serializing them in
+    // the browser removes the case that actually happens; `retrying` covers
+    // the rest (another tab, another device, a queued cron).
+    return await this.withLock(() =>
+      this.retrying(() => this.dispatchExchange(action, credential, args)),
+    );
+  }
+
+  private async dispatchExchange(
+    action: NonNullable<LogtoSessionApi["exchangeToken"]>,
+    credential: { sessionToken: string; deviceProof?: string },
+    args: {
+      organizationId?: string;
+      resource?: string;
+      scopes?: string[];
+      includeToken?: boolean;
+    },
+  ): Promise<{
+    claims: LogtoResourceTokenClaims;
+    accessToken?: string;
+    minted: boolean;
+  }> {
     return await this.callSessionAction("exchangeToken", () =>
       this.options.transport.action(action, {
         ...credential,

--- a/packages/convex-logto/src/session-cookie.test.ts
+++ b/packages/convex-logto/src/session-cookie.test.ts
@@ -29,7 +29,9 @@ type HandlerName =
   | "signOutEverywhere"
   | "listSessions"
   | "renameSession"
-  | "revokeSession";
+  | "revokeSession"
+  | "exchangeToken"
+  | "fetchUserInfo";
 type Handlers = Record<HandlerName, ReturnType<typeof vi.fn>>;
 
 function makeHarness(options?: {
@@ -75,6 +77,16 @@ function makeHarness(options?: {
     }),
     renameSession: vi.fn().mockResolvedValue(true),
     revokeSession: vi.fn().mockResolvedValue(true),
+    exchangeToken: vi.fn().mockResolvedValue({
+      claims: {
+        audience: "organization:org-1",
+        scopes: ["manage"],
+        expiresAt: 5_000_000,
+        organizationId: "org-1",
+      },
+      minted: true,
+    }),
+    fetchUserInfo: vi.fn().mockResolvedValue({ sub: "user-1", name: "Ada" }),
   };
   const action = vi.fn((reference: unknown, args: unknown) => {
     const name = getFunctionName(
@@ -107,7 +119,7 @@ function persistentCookie(value: string): string {
 }
 
 function request(
-  route: "sign-in" | "callback" | "token" | "sign-out" | "sessions",
+  route: "sign-in" | "callback" | "token" | "sign-out" | "sessions" | "tokens",
   options?: {
     method?: string;
     origin?: string | null;
@@ -1523,5 +1535,143 @@ describe("SSR ID token cookie", () => {
     ).toBeNull();
     expect(readLogtoIdTokenCookie({ get: () => undefined })).toBeNull();
     expect(readLogtoIdTokenCookie({ get: () => ({ value: "" }) })).toBeNull();
+  });
+});
+
+describe("tokens route", () => {
+  it("authenticates the exchange with the cookie and forwards the target", async () => {
+    const { handler, handlers } = makeHarness();
+    const response = await handler(
+      request("tokens", {
+        cookie: cookie("session-token-1"),
+        body: {
+          op: "exchange",
+          organizationId: "org-1",
+          scopes: ["manage"],
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      claims: { audience: "organization:org-1", scopes: ["manage"] },
+      minted: true,
+    });
+    expect(handlers.exchangeToken).toHaveBeenCalledWith({
+      sessionToken: "session-token-1",
+      organizationId: "org-1",
+      scopes: ["manage"],
+    });
+  });
+
+  it("proxies fetchUserInfo", async () => {
+    const { handler, handlers } = makeHarness();
+    const response = await handler(
+      request("tokens", {
+        cookie: cookie("session-token-1"),
+        body: { op: "userinfo" },
+      }),
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      sub: "user-1",
+      name: "Ada",
+    });
+    expect(handlers.fetchUserInfo).toHaveBeenCalledWith({
+      sessionToken: "session-token-1",
+    });
+  });
+
+  it("refuses without the session cookie", async () => {
+    const { handler, handlers } = makeHarness();
+    const response = await handler(
+      request("tokens", { body: { op: "exchange", organizationId: "org-1" } }),
+    );
+    expect(response.status).toBe(401);
+    expect(handlers.exchangeToken).not.toHaveBeenCalled();
+  });
+
+  it("bounds the scope array rather than proxying whatever was posted", async () => {
+    const { handler, handlers } = makeHarness();
+    const response = await handler(
+      request("tokens", {
+        cookie: cookie("session-token-1"),
+        body: {
+          op: "exchange",
+          organizationId: "org-1",
+          scopes: Array.from({ length: 64 }, (_, index) => `s${index}`),
+        },
+      }),
+    );
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "invalid_request" },
+    });
+    expect(handlers.exchangeToken).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown op", async () => {
+    const { handler } = makeHarness();
+    const response = await handler(
+      request("tokens", {
+        cookie: cookie("session-token-1"),
+        body: { op: "mint-me-something" },
+      }),
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it("names the missing re-export rather than answering a generic failure", async () => {
+    const withoutExchange = createLogtoSessionCookieHandler({
+      sessionApi: {
+        ...(api as unknown as Record<string, unknown>),
+        exchangeToken: undefined,
+      } as unknown as LogtoSessionApi,
+      action: (() => Promise.resolve(null)) as unknown as LogtoSessionAction,
+      allowedOrigins: [APP_ORIGIN],
+      basePath: BASE_PATH,
+    });
+    const response = await withoutExchange(
+      request("tokens", {
+        cookie: cookie("session-token-1"),
+        body: { op: "exchange", organizationId: "org-1" },
+      }),
+    );
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: "session_management_unavailable" },
+    });
+  });
+});
+
+describe("browser transport token exchange", () => {
+  it("routes exchangeToken and fetchUserInfo through the cookie handler", async () => {
+    const { handler } = makeHarness();
+    // Piped through the real handler rather than a canned Response, because
+    // the route is the thing under test. The two headers a browser adds for
+    // free — the origin and the cookie — are added here for the same reason.
+    const transport = createLogtoSessionCookieTransport(api, {
+      endpoint: `${APP_ORIGIN}${BASE_PATH}`,
+      fetch: (input, init) => {
+        const forwarded = new Request(input as string, init);
+        forwarded.headers.set("Origin", APP_ORIGIN);
+        forwarded.headers.set("Cookie", cookie("session-token-1"));
+        return handler(forwarded);
+      },
+    });
+
+    await expect(
+      transport.action(api.exchangeToken!, {
+        sessionToken: "ignored",
+        organizationId: "org-1",
+        scopes: ["manage"],
+      }),
+    ).resolves.toMatchObject({
+      claims: { organizationId: "org-1", scopes: ["manage"] },
+      minted: true,
+    });
+    await expect(
+      transport.action(api.fetchUserInfo!, { sessionToken: "ignored" }),
+    ).resolves.toEqual({ sub: "user-1", name: "Ada" });
   });
 });

--- a/packages/convex-logto/src/session-cookie.ts
+++ b/packages/convex-logto/src/session-cookie.ts
@@ -8,6 +8,7 @@ import type { SessionTransport, StoredSession } from "./session-client";
 import type {
   LogtoSessionApi,
   LogtoSessionClientDescriptor,
+  LogtoResourceTokenClaims,
   LogtoSessionSummary,
 } from "./session";
 
@@ -120,10 +121,18 @@ type SessionError = {
   message: string;
 };
 
-type CookieRoute = "sign-in" | "callback" | "token" | "sign-out" | "sessions";
+type CookieRoute =
+  | "sign-in"
+  | "callback"
+  | "token"
+  | "sign-out"
+  | "sessions"
+  | "tokens";
 
 const NO_STORE_HEADERS = { "Cache-Control": "no-store" } as const;
 const MAX_COOKIE_BODY_BYTES = 64 * 1024;
+/** Mirrors the component's `TOKEN_SCOPE_MAX_COUNT`. */
+const MAX_COOKIE_SCOPE_COUNT = 32;
 const MAX_COOKIE_RESPONSE_BYTES = 256 * 1024;
 const COOKIE_TRANSPORT_TIMEOUT_MS = 10 * 1000;
 
@@ -137,7 +146,8 @@ function isCookieRoute(value: string): value is CookieRoute {
     value === "callback" ||
     value === "token" ||
     value === "sign-out" ||
-    value === "sessions"
+    value === "sessions" ||
+    value === "tokens"
   );
 }
 
@@ -531,6 +541,30 @@ function optionalDisplayString(
   return trimmed === "" ? undefined : trimmed;
 }
 
+/**
+ * A list of short strings — OIDC scopes. Bounded here as well as in the
+ * component: this route is same-site and unauthenticated by anything but the
+ * cookie, so it should not be the one place a caller can post an unbounded
+ * array.
+ */
+function optionalStringArray(
+  body: Record<string, unknown>,
+  name: string,
+): string[] | undefined {
+  const value = body[name];
+  if (value === undefined) return undefined;
+  if (
+    !Array.isArray(value) ||
+    value.length > MAX_COOKIE_SCOPE_COUNT ||
+    value.some((entry) => typeof entry !== "string")
+  ) {
+    throw new RequestValidationError(
+      `${name} must be an array of at most ${MAX_COOKIE_SCOPE_COUNT} strings when provided`,
+    );
+  }
+  return value;
+}
+
 function optionalBoolean(
   body: Record<string, unknown>,
   name: string,
@@ -801,6 +835,61 @@ export function createLogtoSessionCookieHandler(
             }
             return actionErrorResponse(error, origin, headers);
           }
+        }
+        case "tokens": {
+          // The exchange authenticates with the same cookie every other route
+          // uses; the session token never leaves the server here either.
+          const sessionToken = readCookie(request);
+          if (sessionToken === null) {
+            throw new ConvexError({
+              kind: "terminal" as const,
+              code: "session_cookie_missing",
+              message: "No session cookie is present. Sign in again.",
+            });
+          }
+          const op = requiredString(body, "op");
+          if (op === "exchange") {
+            const exchangeToken = options.sessionApi.exchangeToken;
+            if (exchangeToken === undefined) {
+              return sessionManagementUnavailable("exchangeToken", origin);
+            }
+            const organizationId = optionalDisplayString(
+              body,
+              "organizationId",
+            );
+            const resource = optionalDisplayString(body, "resource");
+            const scopes = optionalStringArray(body, "scopes");
+            const includeToken = optionalBoolean(body, "includeToken");
+            return jsonResponse(
+              await options.action(exchangeToken, {
+                sessionToken,
+                ...(organizationId === undefined ? {} : { organizationId }),
+                ...(resource === undefined ? {} : { resource }),
+                ...(scopes === undefined ? {} : { scopes }),
+                // Forwarded as asked. Whether it is *allowed* is the app
+                // action's decision (`exposeAccessTokens` on
+                // `logtoSessionApi`), and duplicating that gate here would
+                // give the same policy two places to disagree.
+                ...(includeToken === undefined ? {} : { includeToken }),
+              }),
+              {},
+              origin,
+            );
+          }
+          if (op === "userinfo") {
+            const fetchUserInfo = options.sessionApi.fetchUserInfo;
+            if (fetchUserInfo === undefined) {
+              return sessionManagementUnavailable("fetchUserInfo", origin);
+            }
+            return jsonResponse(
+              await options.action(fetchUserInfo, { sessionToken }),
+              {},
+              origin,
+            );
+          }
+          throw new RequestValidationError(
+            "op must be one of exchange, userinfo",
+          );
         }
         case "sessions": {
           const sessionToken = readCookie(request);
@@ -1170,6 +1259,68 @@ function readOptionalLabel(args: unknown): string | undefined {
   return value.trim() === "" ? undefined : value;
 }
 
+function readExchangeArgs(args: Record<string, unknown>): {
+  organizationId?: string;
+  resource?: string;
+  scopes?: string[];
+  includeToken?: boolean;
+} {
+  const organizationId = args["organizationId"];
+  const resource = args["resource"];
+  const scopes = args["scopes"];
+  const includeToken = args["includeToken"];
+  return {
+    ...(typeof organizationId === "string" ? { organizationId } : {}),
+    ...(typeof resource === "string" ? { resource } : {}),
+    ...(Array.isArray(scopes) &&
+    scopes.every((entry) => typeof entry === "string")
+      ? { scopes }
+      : {}),
+    ...(typeof includeToken === "boolean" ? { includeToken } : {}),
+  };
+}
+
+function parseExchangeTokenResponse(value: unknown): {
+  claims: LogtoResourceTokenClaims;
+  accessToken?: string;
+  minted: boolean;
+} {
+  if (!isRecord(value) || typeof value.minted !== "boolean") {
+    throw invalidCookieResponse();
+  }
+  const claims: unknown = value.claims;
+  if (
+    !isRecord(claims) ||
+    typeof claims.audience !== "string" ||
+    typeof claims.expiresAt !== "number" ||
+    !Array.isArray(claims.scopes)
+  ) {
+    throw invalidCookieResponse();
+  }
+  const scopes: string[] = [];
+  for (const entry of claims.scopes) {
+    if (typeof entry !== "string") throw invalidCookieResponse();
+    scopes.push(entry);
+  }
+  return {
+    claims: {
+      audience: claims.audience,
+      expiresAt: claims.expiresAt,
+      scopes,
+      ...(typeof claims.organizationId === "string"
+        ? { organizationId: claims.organizationId }
+        : {}),
+      ...(typeof claims.resource === "string"
+        ? { resource: claims.resource }
+        : {}),
+    },
+    ...(typeof value.accessToken === "string"
+      ? { accessToken: value.accessToken }
+      : {}),
+    minted: value.minted,
+  };
+}
+
 function parseSessionListResponse(value: unknown): {
   sessions: LogtoSessionSummary[];
   truncated: boolean;
@@ -1277,6 +1428,14 @@ export function createLogtoSessionCookieTransport(
       sessionApi.revokeSession === undefined
         ? undefined
         : getFunctionName(sessionApi.revokeSession),
+    exchangeToken:
+      sessionApi.exchangeToken === undefined
+        ? undefined
+        : getFunctionName(sessionApi.exchangeToken),
+    fetchUserInfo:
+      sessionApi.fetchUserInfo === undefined
+        ? undefined
+        : getFunctionName(sessionApi.fetchUserInfo),
   };
 
   const post = async (route: CookieRoute, body: unknown): Promise<unknown> => {
@@ -1386,6 +1545,20 @@ export function createLogtoSessionCookieTransport(
           }),
           "revoked",
         );
+      }
+      if (
+        actionNames.exchangeToken !== undefined &&
+        actionName === actionNames.exchangeToken
+      ) {
+        return parseExchangeTokenResponse(
+          await post("tokens", { op: "exchange", ...readExchangeArgs(args) }),
+        );
+      }
+      if (
+        actionNames.fetchUserInfo !== undefined &&
+        actionName === actionNames.fetchUserInfo
+      ) {
+        return await post("tokens", { op: "userinfo" });
       }
       throw new Error(
         "convex-logto: the cookie transport received an unknown session action.",

--- a/packages/convex-logto/src/session.test.ts
+++ b/packages/convex-logto/src/session.test.ts
@@ -179,3 +179,140 @@ describe("logtoSessionApi signOut", () => {
     });
   });
 });
+
+describe("logtoSessionApi exchangeToken", () => {
+  const action = { fn: "exchangeToken" };
+  const component = {
+    lib: { exchangeToken: action },
+  } as unknown as LogtoSessionComponent;
+
+  type Handler = (
+    ctx: { runAction: ReturnType<typeof vi.fn> },
+    args: {
+      sessionToken: string;
+      deviceProof?: string;
+      organizationId?: string;
+      resource?: string;
+      scopes?: string[];
+      includeToken?: boolean;
+    },
+  ) => Promise<{
+    claims: { audience: string; scopes: string[]; expiresAt: number };
+    accessToken?: string;
+    minted: boolean;
+  }>;
+
+  function handlerFor(options: Record<string, unknown> = {}) {
+    const api = logtoSessionApi(component, {
+      endpoint: "https://auth.example.com",
+      appId: "app-1",
+      clientSecret: "secret",
+      ...options,
+    });
+    return (api.exchangeToken as unknown as Record<string, Handler>)[
+      "_handler"
+    ]!;
+  }
+
+  it("forwards the target and the deployment's reuse policy", async () => {
+    const runAction = vi.fn().mockResolvedValue({
+      claims: {
+        audience: "organization:org-1",
+        scopes: ["manage"],
+        expiresAt: 5_000_000,
+      },
+      minted: true,
+    });
+
+    await handlerFor({ reuseWindowMs: 321 })(
+      { runAction },
+      {
+        sessionToken: "session-token",
+        deviceProof: "proof",
+        organizationId: "org-1",
+        scopes: ["manage"],
+      },
+    );
+
+    expect(runAction).toHaveBeenCalledWith(action, {
+      endpoint: "https://auth.example.com",
+      appId: "app-1",
+      clientSecret: "secret",
+      sessionToken: "session-token",
+      deviceProof: "proof",
+      organizationId: "org-1",
+      resource: undefined,
+      scopes: ["manage"],
+      includeToken: undefined,
+      reuseWindowMs: 321,
+    });
+  });
+
+  it("refuses to hand back a token string unless the deployment opted in", async () => {
+    // Refusing beats silently returning claims: the caller is about to put the
+    // value in an Authorization header, and `undefined` would surface as an
+    // authorization failure somewhere else entirely.
+    const runAction = vi.fn();
+    await expect(
+      handlerFor()(
+        { runAction },
+        { sessionToken: "session-token", includeToken: true },
+      ),
+    ).rejects.toMatchObject({
+      data: { kind: "terminal", code: "access_tokens_not_exposed" },
+    });
+    expect(runAction).not.toHaveBeenCalled();
+  });
+
+  it("allows the token string once exposeAccessTokens is set", async () => {
+    const runAction = vi.fn().mockResolvedValue({
+      claims: {
+        audience: "resource:https://api.example.com",
+        scopes: ["read"],
+        expiresAt: 5_000_000,
+      },
+      accessToken: "minted",
+      minted: true,
+    });
+
+    const result = await handlerFor({ exposeAccessTokens: true })(
+      { runAction },
+      {
+        sessionToken: "session-token",
+        resource: "https://api.example.com",
+        includeToken: true,
+      },
+    );
+
+    expect(result.accessToken).toBe("minted");
+    expect(runAction).toHaveBeenCalledWith(
+      action,
+      expect.objectContaining({ includeToken: true }),
+    );
+  });
+
+  it("serves claims without the opt-in, which is the default custody", async () => {
+    const runAction = vi.fn().mockResolvedValue({
+      claims: {
+        audience: "organization:org-1",
+        scopes: ["manage"],
+        expiresAt: 5_000_000,
+      },
+      minted: false,
+    });
+
+    const result = await handlerFor()(
+      { runAction },
+      { sessionToken: "session-token", organizationId: "org-1" },
+    );
+
+    expect(result).toEqual({
+      claims: {
+        audience: "organization:org-1",
+        scopes: ["manage"],
+        expiresAt: 5_000_000,
+      },
+      minted: false,
+    });
+  });
+});

--- a/packages/convex-logto/src/session.test.ts
+++ b/packages/convex-logto/src/session.test.ts
@@ -256,7 +256,11 @@ describe("logtoSessionApi exchangeToken", () => {
     await expect(
       handlerFor()(
         { runAction },
-        { sessionToken: "session-token", includeToken: true },
+        {
+          sessionToken: "session-token",
+          organizationId: "org-1",
+          includeToken: true,
+        },
       ),
     ).rejects.toMatchObject({
       data: { kind: "terminal", code: "access_tokens_not_exposed" },
@@ -314,5 +318,34 @@ describe("logtoSessionApi exchangeToken", () => {
       },
       minted: false,
     });
+  });
+});
+
+describe("logtoSessionApi exchangeToken targets", () => {
+  it("refuses a target-free call before it becomes a component round trip", async () => {
+    const action = { fn: "exchangeToken" };
+    const component = {
+      lib: { exchangeToken: action },
+    } as unknown as LogtoSessionComponent;
+    const api = logtoSessionApi(component, {
+      endpoint: "https://auth.example.com",
+      appId: "app-1",
+      clientSecret: "secret",
+    });
+    const runAction = vi.fn();
+    type Handler = (
+      ctx: { runAction: typeof runAction },
+      args: { sessionToken: string },
+    ) => Promise<unknown>;
+    const handler = (api.exchangeToken as unknown as Record<string, Handler>)[
+      "_handler"
+    ]!;
+
+    await expect(
+      handler({ runAction }, { sessionToken: "session-token" }),
+    ).rejects.toMatchObject({
+      data: { kind: "terminal", code: "missing_token_target" },
+    });
+    expect(runAction).not.toHaveBeenCalled();
   });
 });

--- a/packages/convex-logto/src/session.ts
+++ b/packages/convex-logto/src/session.ts
@@ -783,6 +783,17 @@ export function logtoSessionApi(
         minted: v.boolean(),
       }),
       handler: async (ctx, args) => {
+        if (args.organizationId === undefined && args.resource === undefined) {
+          // The component refuses this too. Refusing here as well keeps the
+          // deployment-facing error close to the call and stops a target-free
+          // request ever becoming a component round trip.
+          throw new ConvexError({
+            kind: "terminal" as const,
+            code: "missing_token_target",
+            message:
+              "convex-logto: pass an organizationId or a resource to exchangeToken.",
+          });
+        }
         if (args.includeToken && !options.exposeAccessTokens) {
           // Refuse rather than silently downgrade to claims. A caller that
           // asked for the token string is about to call an API with it, and

--- a/packages/convex-logto/src/session.ts
+++ b/packages/convex-logto/src/session.ts
@@ -113,6 +113,40 @@ export type LogtoSessionComponent = {
       },
       { idToken: string; sessionToken: string; sessionId: string }
     >;
+    exchangeToken: FunctionReference<
+      "action",
+      "internal",
+      {
+        endpoint: string;
+        appId: string;
+        clientSecret: string;
+        sessionToken: string;
+        deviceProof?: string;
+        organizationId?: string;
+        resource?: string;
+        scopes?: string[];
+        includeToken?: boolean;
+        reuseWindowMs?: number;
+      },
+      {
+        claims: LogtoResourceTokenClaims;
+        accessToken?: string;
+        minted: boolean;
+      }
+    >;
+    fetchUserInfo: FunctionReference<
+      "action",
+      "internal",
+      {
+        endpoint: string;
+        appId: string;
+        clientSecret: string;
+        sessionToken: string;
+        deviceProof?: string;
+        reuseWindowMs?: number;
+      },
+      unknown
+    >;
     signOut: FunctionReference<
       "action",
       "internal",
@@ -230,6 +264,23 @@ export type LogtoSessionClientDescriptor = {
   browser?: string;
 };
 
+/**
+ * What an Organization or Resource token authorizes, without the token itself.
+ *
+ * The default custody in session mode: an app checks `scopes` server-side and
+ * the credential never enters `window`. `docs/adr/0002-token-custody.md`.
+ */
+export type LogtoResourceTokenClaims = {
+  /** `organization:<id>`, `resource:<indicator>`, or `default`. */
+  audience: string;
+  /** What Logto granted — which may be narrower than what was asked for. */
+  scopes: string[];
+  /** Absolute expiry in ms. */
+  expiresAt: number;
+  organizationId?: string;
+  resource?: string;
+};
+
 /** One of the caller's sessions, as returned by `listSessions`. */
 export type LogtoSessionSummary = {
   sessionId: string;
@@ -330,6 +381,34 @@ export type LogtoSessionApi = {
     { sessionToken: string; deviceProof?: string; targetSessionId: string },
     boolean
   >;
+  /**
+   * Optional for the same rolling-upgrade reason as `listSessions`. Absent
+   * means the app has not re-exported it; the client surfaces that as a clear
+   * error rather than a mystery.
+   */
+  exchangeToken?: FunctionReference<
+    "action",
+    "public",
+    {
+      sessionToken: string;
+      deviceProof?: string;
+      organizationId?: string;
+      resource?: string;
+      scopes?: string[];
+      includeToken?: boolean;
+    },
+    {
+      claims: LogtoResourceTokenClaims;
+      accessToken?: string;
+      minted: boolean;
+    }
+  >;
+  fetchUserInfo?: FunctionReference<
+    "action",
+    "public",
+    { sessionToken: string; deviceProof?: string },
+    unknown
+  >;
   sessionValid: FunctionReference<
     "query",
     "public",
@@ -347,14 +426,26 @@ export type LogtoSessionApiOptions = LogtoEndpointPolicy & {
   /**
    * API resource indicators appended to the authorize request.
    *
-   * Currently a no-op you can still be punished for. The component holds the
-   * refresh token and exposes only the ID token, so the resource-scoped access
-   * token this buys is discarded and the refresh grant never asks for another —
-   * while a resource indicator Logto does not have registered breaks sign-in
-   * outright. Leave it unset until session mode can hand the token (or its
-   * claims) back; see `docs/adr/0002-token-custody.md`.
+   * Required for `getAccessTokenClaims`: Logto will not issue a Resource token
+   * from a grant that never named the resource — it answers `invalid_target` —
+   * so the set has to be fixed before the user signs in and cannot be widened
+   * in place. Every indicator must be registered in Logto; one that is not
+   * breaks sign-in outright.
+   *
+   * Organization tokens need nothing here.
    */
   resources?: string[];
+  /**
+   * Let `getOrganizationToken` / `getAccessToken` return the token *string*,
+   * not just its claims.
+   *
+   * Off by default, which is the whole point of session mode: the component
+   * mints the token and hands back what it authorizes, so nothing long-lived
+   * enters `window`. Turn this on only for a caller that must reach a
+   * non-Convex API from the browser, accepting that the token becomes one more
+   * thing XSS can steal. `docs/adr/0002-token-custody.md`.
+   */
+  exposeAccessTokens?: boolean;
   /**
    * How long (ms) recently superseded Session-token generations stay accepted,
    * absorbing multi-tab races and network retries. Default 10s.
@@ -391,7 +482,7 @@ function readSessionConfig(options: LogtoSessionApiOptions): {
  * Build the public auth functions for session mode, backed by the Logto session
  * component. Reads `LOGTO_ENDPOINT`, `LOGTO_APP_ID` and `LOGTO_CLIENT_SECRET`
  * from the deployment's env (the secret never leaves the server). Re-export all
- * nine — the frontend provider looks them up by these exact names, and a
+ * eleven — the frontend provider looks them up by these exact names, and a
  * missing one disables that feature rather than failing the build:
  *
  * @example
@@ -408,6 +499,8 @@ function readSessionConfig(options: LogtoSessionApiOptions): {
  *   listSessions,
  *   renameSession,
  *   revokeSession,
+ *   exchangeToken,
+ *   fetchUserInfo,
  *   sessionValid,
  * } = logtoSessionApi(components.logto);
  */
@@ -478,6 +571,27 @@ export function logtoSessionApi(
     "public",
     { sessionToken: string; deviceProof?: string; targetSessionId: string },
     Promise<boolean>
+  >;
+  exchangeToken: RegisteredAction<
+    "public",
+    {
+      sessionToken: string;
+      deviceProof?: string;
+      organizationId?: string;
+      resource?: string;
+      scopes?: string[];
+      includeToken?: boolean;
+    },
+    Promise<{
+      claims: LogtoResourceTokenClaims;
+      accessToken?: string;
+      minted: boolean;
+    }>
+  >;
+  fetchUserInfo: RegisteredAction<
+    "public",
+    { sessionToken: string; deviceProof?: string },
+    Promise<unknown>
   >;
   sessionValid: RegisteredQuery<
     "public",
@@ -645,6 +759,68 @@ export function logtoSessionApi(
           targetSessionId: args.targetSessionId,
           now: Date.now(),
           reuseWindowMs: options.reuseWindowMs ?? DEFAULT_REUSE_WINDOW_MS,
+        });
+      },
+    }),
+    exchangeToken: actionGeneric({
+      args: {
+        sessionToken: v.string(),
+        deviceProof: v.optional(v.string()),
+        organizationId: v.optional(v.string()),
+        resource: v.optional(v.string()),
+        scopes: v.optional(v.array(v.string())),
+        includeToken: v.optional(v.boolean()),
+      },
+      returns: v.object({
+        claims: v.object({
+          audience: v.string(),
+          scopes: v.array(v.string()),
+          expiresAt: v.number(),
+          organizationId: v.optional(v.string()),
+          resource: v.optional(v.string()),
+        }),
+        accessToken: v.optional(v.string()),
+        minted: v.boolean(),
+      }),
+      handler: async (ctx, args) => {
+        if (args.includeToken && !options.exposeAccessTokens) {
+          // Refuse rather than silently downgrade to claims. A caller that
+          // asked for the token string is about to call an API with it, and
+          // `undefined` would surface as an authorization failure somewhere
+          // else entirely.
+          throw new ConvexError({
+            kind: "terminal" as const,
+            code: "access_tokens_not_exposed",
+            message:
+              "convex-logto: this deployment does not expose access tokens. " +
+              "Pass `exposeAccessTokens: true` to logtoSessionApi() to allow " +
+              "the token string to reach the browser, or use the claims instead.",
+          });
+        }
+        return await ctx.runAction(component.lib.exchangeToken, {
+          ...readSessionConfig(options),
+          sessionToken: args.sessionToken,
+          deviceProof: args.deviceProof,
+          organizationId: args.organizationId,
+          resource: args.resource,
+          scopes: args.scopes,
+          includeToken: args.includeToken,
+          reuseWindowMs: options.reuseWindowMs,
+        });
+      },
+    }),
+    fetchUserInfo: actionGeneric({
+      args: {
+        sessionToken: v.string(),
+        deviceProof: v.optional(v.string()),
+      },
+      returns: v.any(),
+      handler: async (ctx, args) => {
+        return await ctx.runAction(component.lib.fetchUserInfo, {
+          ...readSessionConfig(options),
+          sessionToken: args.sessionToken,
+          deviceProof: args.deviceProof,
+          reuseWindowMs: options.reuseWindowMs,
         });
       },
     }),


### PR DESCRIPTION
Closes #206. The last gap against `@logto/react`'s `useLogto()`.

```ts
const { getOrganizationTokenClaims, getAccessTokenClaims, fetchUserInfo, getIdToken } =
  useLogtoAuth();

const { scopes } = await getOrganizationTokenClaims("org-id");
```

The component mints the token from the session's Logto refresh token and returns **what it authorizes** — nothing long-lived enters `window`. `exposeAccessTokens: true` on `logtoSessionApi()` opts into the token string, for a caller that must reach a non-Convex API from the browser; without it the token-returning methods reject **by name** rather than quietly returning nothing, because the caller is about to put the value in an `Authorization` header.

Membership and organization *roles* still need none of this — Logto puts them in the ID token, so `assertOrganizationRole` costs no round trip. This is for fine-grained organization permissions and registered API resources.

## The load-bearing decision

The exchange runs inside the **same claim as `refresh`**, because it spends the same refresh token.

That is not caution. Logto rotates on a rule blind to what the grant was for, in the one shared `refresh_token` handler `organization_id` and `resource` also go through — but only once the token is past 70% of its lifetime. So an exchange running outside the claim passes every test, every staging soak and most of production, and starts destroying grants only when real refresh tokens age into their last 30% — taking sibling sessions of the same Logto SSO session with them.

Established against a live Logto and against `rotateRefreshToken` in the running image, not from the observed behaviour alone. [ADR 0003](docs/adr/0003-organization-token-exchange.md) (in #208) records it, along with the two surface facts from the same run: every refresh grant returns an `id_token` (so the exchange keeps it rather than letting the session age), and a resource must be named at authorization time.

## Consequences worth reading

- `resources` on `logtoSessionApi()` stops being a no-op. It is the exchange's input — and it is fixed before sign-in, because Logto answers `invalid_target` for a resource the grant never named.
- Minted tokens are cached per `(session, audience, requested scope set)`, so a permission check on render is not a grant per render. Bounded per session, so deleting a session stays bounded; invisible the moment the session is logically revoked, and deleted with it.
- The exchange can answer the transient `refresh_in_flight`. Retry it — an organization token is not worth destroying a grant for.
- Two new actions to re-export (`exchangeToken`, `fetchUserInfo`). A module that has not been updated keeps working: the methods report the missing export.

## Verification

Whole-workspace `verify` sequence locally: audit, lint, format, both typecheck projects, 652 tests (39 new), build, `lint:package`. The component's `_generated/` was regenerated, so the public type boundary is checked against the examples' `tsc -p convex`.

> Stacked conceptually on #208, which carries ADR 0003 and the probe that produced these answers. Merge that first so the ADR link resolves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added organization and API-resource token exchange support.
  * Added access to token claims, ID tokens, optional access tokens, and live user information.
  * Added token and user-info operations to session APIs and browser cookie transport.
  * Added configurable resources and access-token exposure settings.
* **Improvements**
  * Added token caching, expiration handling, refresh coordination, retries, and revocation cleanup.
  * Added safeguards for oversized tokens and excessive scopes.
* **Documentation**
  * Updated session, React, native, cookie, and API reference documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->