### PR TITLE
fix(examples): stop paying a Logto round trip on every page load

### DIFF
--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -505,6 +505,20 @@ signOutEverywhere, listSessions, renameSession, revokeSession }`.
   from its session token, records logical revocation before bounded row cleanup,
   and always completes federated sign-out for this device. Older app modules that
   have not re-exported the action fail with an explicit deployment fix.
+
+<Callout type="warn">
+A federated sign-out resolves once the browser has been **told** to leave for
+Logto, not once it has arrived. The local credentials are already gone at that
+point, so the UI reads "signed out" while the request that ends the *Logto*
+session is still in flight. Issuing a **hard** navigation of your own after
+`await signOut()` — `window.location.assign(...)`, `location.href = ...`, a full
+page load — supersedes it, and the SSO session survives a sign-out that looked
+like it worked. The next visitor to that browser is signed straight back in.
+
+A router `push`/`replace` is a soft, same-document navigation and is safe. If
+you need a hard one, pass the destination as `postLogoutRedirectUri` and let the
+sign-out land there itself.
+</Callout>
 - `listSessions()` — a snapshot (not a subscription: the credential it
   authenticates with rotates) of the caller's own sessions, `{ sessions,
   truncated }`, newest first. Call it again after a rename or revoke.

--- a/docs/content/docs/how-it-works.mdx
+++ b/docs/content/docs/how-it-works.mdx
@@ -28,6 +28,35 @@ existing sessions stay signed in. After rotating, the discovery document adverti
 Sessions refresh via Logto's refresh token, which is why `ConvexLogtoProvider`
 requests the `offline_access` scope by default.
 
+## One token round trip per page load, unless you opt out
+
+Convex's client fetches an auth token twice on every page load. It sends the one
+your app already has, waits for the server to confirm it, and then — by default
+— throws it away and asks for a fresh one. The second fetch is `forceRefreshToken`,
+which this library is obliged to honour: it means "the token you last gave me
+will not do."
+
+That costs a **Logto token-endpoint round trip on every page load**, in both
+modes. In bridge mode the Logto SDK spends a refresh grant; in session mode your
+deployment does, and rotates the session token with it. None of it is needed
+when the token in hand is fresh and the server just said so.
+
+Convex has an option for exactly this. Turn it on where you construct the
+client:
+
+```ts
+const convex = new ConvexReactClient(CONVEX_URL, {
+  initialAuthTokenReuse: true,
+});
+```
+
+Now the confirmed token is kept and a refresh is scheduled before it expires,
+which is what makes a warm page load reach an authenticated render without
+touching the network at all. Every example in this repository sets it.
+
+It is marked experimental in `convex@1.44` and may change; that is the only
+reason it is not the default here.
+
 ## Server-side rendering
 
 `ConvexLogtoProvider` is safe to render on the server. Until the backend config

--- a/docs/content/docs/how-it-works.mdx
+++ b/docs/content/docs/how-it-works.mdx
@@ -57,6 +57,27 @@ touching the network at all. Every example in this repository sets it.
 It is marked experimental in `convex@1.44` and may change; that is the only
 reason it is not the default here.
 
+### What you give up
+
+That per-page-load round trip was doing one useful thing by accident: it asked
+Logto whether the grant was still alive. Reusing the cached token skips the
+question, so a session revoked *at Logto* — an admin ending it, a password
+change, another device signing out everywhere — goes unnoticed until the token
+expires. With Logto's default one-hour ID token, that is a window of up to an
+hour of page loads.
+
+In **session mode** that window is closed by something better: the provider
+subscribes to `sessionValid`, so a revocation lands on the open tab live,
+without a reload and without asking Logto. Turn the option on.
+
+In **bridge mode** there is no such subscription, and the window is real. It is
+the same window an already-open tab has always had — the token is cached for its
+lifetime either way, and closing the browser was never what made a revocation
+take effect — but it now covers page loads too. If your threat model needs
+revocation to bite faster than the ID token's lifetime, either leave the option
+off and pay the round trip knowingly, or shorten the ID token's TTL in Logto,
+or use [session mode](/docs/session-mode).
+
 ## Server-side rendering
 
 `ConvexLogtoProvider` is safe to render on the server. Until the backend config

--- a/docs/content/docs/quick-start.mdx
+++ b/docs/content/docs/quick-start.mdx
@@ -151,7 +151,10 @@ provider logs the failure and delivers it to `onAuthError`, even though
 `signOut()` ends the Logto session and returns the user to your app's origin (the
 **Post sign-out redirect URI** from step 1). Pass
 `signOut({ postLogoutRedirectUri: "https://app.com/bye" })` to land somewhere
-else — just register that URI too.
+else — just register that URI too. Don't follow it with a **hard** navigation of
+your own (`location.href = ...`): it resolves once the browser has been told to
+leave for Logto, not once it has arrived, and a second full-page navigation
+supersedes the request that ends the Logto session.
 
 In any Convex function, the Logto identity is already there:
 

--- a/docs/content/docs/quick-start.mdx
+++ b/docs/content/docs/quick-start.mdx
@@ -97,6 +97,10 @@ root.render(
 );
 ```
 
+Add `{ initialAuthTokenReuse: true }` to the client when you are ready to stop
+paying a Logto round trip on every page load — see
+[one token round trip per page load](/docs/how-it-works#one-token-round-trip-per-page-load-unless-you-opt-out).
+
 <Callout>
 Prefer resolving the config at runtime from the Convex deployment instead (e.g.
 multi-tenant, one frontend artifact for many environments)? Export

--- a/docs/content/docs/session-mode.mdx
+++ b/docs/content/docs/session-mode.mdx
@@ -119,6 +119,11 @@ const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL);
 </ConvexLogtoSessionProvider>;
 ```
 
+Pass `{ initialAuthTokenReuse: true }` to the client too. Without it Convex
+refetches a token the moment it confirms the cached one, which in session mode
+means a Logto refresh grant *and* a session-token rotation on every page load —
+see [one token round trip per page load](/docs/how-it-works#one-token-round-trip-per-page-load-unless-you-opt-out).
+
 That's the whole frontend. No `@logto/react`, no callback component — the
 provider finishes the exchange on `/callback` and replace-navigates back into
 the app by itself. `useLogtoAuth()` from `convex-logto/react-session` extends

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -57,12 +57,24 @@ have to be printed to be useful.
 
 ## 2. Point an example at it
 
-Set the printed `LOGTO_*` values on the example's Convex deployment
-(`npx convex env set ...`), start the backend and the app, and note the URL.
-
 Session mode wants `examples/vite-react-session` on `:5174`; bridge mode wants
 `examples/tanstack-router-spa` on `:5173`. Those ports are what `provision.mjs`
 registers as redirect URIs — Logto rejects any other origin with a bare 400.
+
+Set the values on that example's Convex deployment. The names differ on purpose:
+the file names the *app* whose secret it is, the deployment names the *client*
+the library authenticates as, and session mode's `LOGTO_APP_ID` is the
+Traditional Web app, not the SPA one.
+
+```bash
+set -a; . e2e/.env.e2e; set +a          # from the repo root, for this block only
+cd examples/vite-react-session
+npx convex env set LOGTO_ENDPOINT "$LOGTO_ENDPOINT"
+npx convex env set LOGTO_APP_ID "$LOGTO_SESSION_APP_ID"
+npx convex env set LOGTO_CLIENT_SECRET "$LOGTO_APP_SECRET"
+npx convex dev &                        # note the http://127.0.0.1:PORT it prints
+npx vite                                # :5174, per vite.config.ts
+```
 
 > Port conflicts to expect on a dev machine: `:5173` is a common Vite default and
 > `:3212` is used by another local Convex backend. If you move a port, re-run
@@ -71,30 +83,57 @@ registers as redirect URIs — Logto rejects any other origin with a bare 400.
 
 ## 3. Run the flow
 
-All commands in this file run **from `e2e/`**.
+Back in **`e2e/`**, where every other command in this file runs.
 
 ```bash
 npm install                       # playwright-core only; no browser download
 set -a; . ./.env.e2e; set +a
 export E2E_APP_URL=http://localhost:5174
-export E2E_CONVEX_URL=http://127.0.0.1:3214     # the deployment the app talks to
+export E2E_CONVEX_URL=http://127.0.0.1:3216     # the port `convex dev` printed
 node session-flow.mjs
 ```
 
 Drives the real browser through cold sign-in → zero-RTT restore → two rounds of
-rotation → sign-out → re-sign-in. `E2E_HEADED=1` to watch it. A failure writes
-`failure.png` next to the script and exits non-zero.
+rotation → sign-out → re-sign-in → revoking a second device → sign-out
+everywhere. `E2E_HEADED=1` to watch it. A failure writes `failure.png` next to
+the script and exits non-zero.
+
+The last two steps open **separate browser contexts**, which is what makes them
+worth running: a second context is a second cookie jar and a second storage
+origin, so it is a second *device* to both Logto and the component — and
+"another device lost its session, live, without asking" is not a claim one
+browser can check.
 
 Every step is a required assertion, and each one asserts the thing rather than a
 proxy for it:
 
-- **zero-RTT** watches for a POST at the deployment and fails if one happens —
-  elapsed time proves nothing, because a fast round trip looks identical;
+- **zero-RTT** fails if the restore *mints a token*, named by function rather
+  than counted by URL — elapsed time proves nothing (a fast round trip looks
+  identical), and a POST count would also catch the calls the example's own UI
+  makes, so the library's test would break whenever the example changed;
 - **rotation runs twice**, because a rotated token that was never persisted
   passes the first refresh and fails the second;
 - **sign-out is re-checked after a reload**, because cleared UI with live
   credentials still in storage is exactly the bug;
-- **re-sign-in** must mint a *different* session token, not resurrect the old one.
+- **re-sign-in must be prompted.** Sign-out is federated by default, so Logto
+  has to ask for credentials again — that prompt is the only evidence the
+  RP-initiated logout actually reached Logto, since clearing local storage looks
+  identical from the app either way;
+- **revocation reaches the other device without a reload**, because a revocation
+  that only lands on the next page load is a cache expiry, not a revocation —
+  and the device that *did* the revoking has to stay signed in;
+- **sign-out everywhere** is checked on the device that never saw the click.
+
+Each run names the session it is about to revoke (`e2e-target-<runid>`). The
+test account accumulates sessions — every run leaves some behind — so "the other
+device" is not something the list can be asked for, and aiming a revoke at it
+would eventually aim at whatever an earlier run abandoned.
+
+> The zero-RTT step needs `initialAuthTokenReuse: true` on the app's
+> `ConvexReactClient`, which every example here sets. Without it Convex confirms
+> the cached token and immediately refetches, spending a Logto refresh grant on
+> every page load — see
+> [how it works](../docs/content/docs/how-it-works.mdx).
 
 It reads the library's own storage keys, so it tests the library rather than the
 example's UI.

--- a/e2e/session-flow.mjs
+++ b/e2e/session-flow.mjs
@@ -24,6 +24,9 @@ const email = need("E2E_USER_EMAIL");
 const password = need("E2E_USER_PASSWORD");
 const headless = process.env.E2E_HEADED !== "1";
 const screenshotPath = fileURLToPath(new URL("./failure.png", import.meta.url));
+// Labels outlive a run: a revoke aimed at "the other device" would eventually
+// aim at a session some earlier run abandoned. Every run names its own.
+const runId = Date.now().toString(36);
 
 function trimSlash(value) {
   return value.replace(/\/+$/, "");
@@ -100,6 +103,59 @@ function readStoredSessionToken(page) {
   });
 }
 
+/**
+ * Sign in from a browser context that has never seen Logto. Its cookie jar is
+ * empty, so the credential prompt is guaranteed — this is a second device, not
+ * a second tab.
+ */
+async function signInOnFreshDevice(target) {
+  await target.goto(appUrl, { waitUntil: "domcontentloaded" });
+  await target.getByRole("button", { name: /sign in/i }).click();
+  await signInAtLogto(target);
+  await waitForSignedIn(target);
+}
+
+/** Rename this device's own session through the app's list UI. */
+async function renameCurrentDevice(target, label) {
+  const own = target.getByRole("listitem").filter({ hasText: "this device" });
+  await own.first().waitFor({ timeout: 30_000 });
+  await own.first().getByRole("button", { name: /^rename$/i }).click();
+  await own.first().getByRole("textbox").fill(label);
+  await own.first().getByRole("button", { name: /^save$/i }).click();
+  await target
+    .getByRole("listitem")
+    .filter({ hasText: label })
+    .first()
+    .waitFor({ timeout: 30_000 });
+}
+
+/**
+ * Which outcome a sign-in click produced: Logto's credential prompt, or an app
+ * that is already signed in. Racing the two is the point — "silent" and
+ * "prompted" are both plausible outcomes of the same click, and waiting for
+ * only the one we expect turns a wrong answer into an opaque timeout.
+ */
+async function signInOutcome(page) {
+  return await Promise.race([
+    page
+      .waitForSelector("input[name=identifier]", { timeout: 45_000 })
+      .then(
+        () => "prompted",
+        () => "neither",
+      ),
+    page
+      .waitForFunction(
+        () => /sign out/i.test(document.body.innerText),
+        undefined,
+        { timeout: 45_000 },
+      )
+      .then(
+        () => "silent",
+        () => "neither",
+      ),
+  ]);
+}
+
 /** Drop the cached ID token so the next restore must go to the deployment. */
 function clearCachedIdToken(page) {
   return page.evaluate(() => {
@@ -112,16 +168,49 @@ function clearCachedIdToken(page) {
 }
 
 const browser = await chromium.launch({ headless, channel: "chrome" });
-const context = await browser.newContext();
-const page = await context.newPage();
 
-/** Every POST at the deployment — the session actions all go through one. */
-const deploymentPosts = [];
+/**
+ * A browser context is a separate cookie jar and a separate storage origin, so
+ * a second one is a second *device* as far as Logto and the component are
+ * concerned — which is the only way to test revoking one from the other.
+ */
+async function newDevice() {
+  const context = await browser.newContext();
+  return { context, page: await context.newPage() };
+}
+
+const { page } = await newDevice();
+
+/**
+ * Every action the page runs at the deployment, by function name.
+ *
+ * The name, not the URL: session mode's whole surface is one HTTP endpoint, so
+ * a URL count cannot tell the library's own token round-trip apart from a call
+ * the *app* made — and the app in front of this one lists its devices on
+ * render. Asserting on the count would make the library's test fail whenever
+ * the example's UI changed, which is the definition of testing a proxy.
+ */
+const deploymentCalls = [];
 page.on("request", (request) => {
-  if (request.method() === "POST" && request.url().startsWith(convexUrl)) {
-    deploymentPosts.push(request.url());
+  if (request.method() !== "POST" || !request.url().startsWith(convexUrl)) {
+    return;
   }
+  let path = "(unparseable)";
+  try {
+    path = JSON.parse(request.postData() ?? "{}").path ?? "(no path)";
+  } catch {
+    // Keep the placeholder: an action call whose body we cannot read is still
+    // evidence, and it must not be silently dropped from the record.
+  }
+  deploymentCalls.push(path);
 });
+
+/** The calls that mint a token — the ones a warm restore must not need. */
+function tokenCalls() {
+  return deploymentCalls.filter((path) =>
+    /:(refresh|callback)$/.test(path),
+  );
+}
 
 try {
   console.error(`session-flow against ${appUrl} (deployment ${convexUrl})\n`);
@@ -142,15 +231,20 @@ try {
   // 2. Zero-RTT restore. Timing proves nothing — a fast round trip looks
   //    identical — so assert the absence of the round trip itself. The library
   //    should serve the cached ID token without asking the deployment for one.
-  deploymentPosts.length = 0;
+  //
+  //    This needs `initialAuthTokenReuse: true` on the ConvexReactClient. Without
+  //    it Convex confirms the cached token and then immediately refetches, which
+  //    spends a Logto refresh grant on every page load; the app under test sets
+  //    it, so a failure here is a real regression and not a missing flag.
+  deploymentCalls.length = 0;
   await page.reload({ waitUntil: "domcontentloaded" });
   await waitForSignedIn(page);
   assert(
-    deploymentPosts.length === 0,
-    `restore should not reach the deployment, but posted ${deploymentPosts.length}×: ` +
-      deploymentPosts.slice(0, 3).join(", "),
+    tokenCalls().length === 0,
+    "restore should not mint a token, but called " +
+      `${tokenCalls().join(", ")} (all calls: ${deploymentCalls.join(", ") || "none"})`,
   );
-  step("zero-RTT restore", "no deployment request before authenticated render");
+  step("zero-RTT restore", "no token minted before authenticated render");
 
   // 3. Rotation, twice. Once proves a refresh worked; the failure worth catching
   //    is a rotated token that was never persisted, and that only surfaces on the
@@ -173,7 +267,10 @@ try {
 
   // 4. Sign-out has to survive a reload. A cleared UI with live credentials
   //    still in storage would pass a text-only check and is exactly the bug.
-  await page.getByRole("button", { name: /^sign out/i }).click();
+  // Not `/^sign out/`: the app also offers "Sign out everywhere", and matching
+  // both makes Playwright refuse rather than pick — which is the right call, and
+  // the reason this names the one it means.
+  await page.getByRole("button", { name: /^sign out(?! everywhere)/i }).click();
   await waitForSignedOut(page);
   await page.reload({ waitUntil: "domcontentloaded" });
   await waitForSignedOut(page);
@@ -184,10 +281,22 @@ try {
   );
   step("sign-out", "credentials gone, and still gone after a reload");
 
-  // 5. Sign in again over Logto's surviving SSO cookie. This is how a user
-  //    retries anything that looks like a sign-out, and it must work without a
-  //    fresh credential prompt.
+  // 5. Sign in again. Sign-out is federated by default — it ends Logto's SSO
+  //    session as well as the local one — so this must *not* be silent. The
+  //    credential prompt is the only evidence that the RP-initiated logout
+  //    actually reached Logto: clearing local storage looks identical from the
+  //    app either way, and a surviving OP session would sign the next visitor
+  //    straight back in.
   await page.getByRole("button", { name: /sign in/i }).click();
+  const outcome = await signInOutcome(page);
+  assert(
+    outcome === "prompted",
+    outcome === "silent"
+      ? "sign-out did not end Logto's session: the next sign-in completed " +
+          "silently over a surviving SSO cookie"
+      : "the sign-in click reached neither Logto's prompt nor a signed-in app",
+  );
+  await signInAtLogto(page);
   await waitForSignedIn(page);
   const resigned = await readStoredSessionToken(page);
   assert(resigned !== null, "re-sign-in produced no session token");
@@ -195,7 +304,73 @@ try {
     resigned !== previous,
     "re-sign-in reused the previous session token instead of minting one",
   );
-  step("re-sign-in", "silent through the surviving SSO session");
+  step("re-sign-in", "prompted — the federated sign-out reached Logto");
+
+  // 6. Revoking another device has to reach it without a reload, and must not
+  //    touch this one. This is the reactive `sessionValid` subscription plus
+  //    the revocation watermark, and it is the part of the component with the
+  //    most moving pieces: a marker commits before the rows are drained, and a
+  //    row that is logically revoked has to stop being an authority — and stop
+  //    being *visible* — before it is physically gone.
+  const second = await newDevice();
+  try {
+    await signInOnFreshDevice(second.page);
+    // Name it, and revoke it *by that name*. The test account accumulates
+    // sessions — every earlier run left some behind — so "the other one" is not
+    // a thing the list can be asked for. Naming the target also means the
+    // revoke below is aimed at a session this run created, never at a stranger.
+    const label = `e2e-target-${runId}`;
+    await renameCurrentDevice(second.page, label);
+
+    // This device's list was rendered before the other one existed.
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await waitForSignedIn(page);
+    const target = page.getByRole("listitem").filter({ hasText: label });
+    await target.first().waitFor({ timeout: 30_000 });
+    assert(
+      (await target.count()) === 1,
+      `expected exactly one session named ${label}, saw ${await target.count()}`,
+    );
+    assert(
+      !(await target.first().innerText()).includes("this device"),
+      `${label} is this device — the rename landed on the wrong session`,
+    );
+    await target.first().getByRole("button", { name: /^revoke$/i }).click();
+
+    // No reload on the revoked device: a revocation that only lands on the next
+    // page load is not a revocation, it is a cache expiry.
+    await waitForSignedOut(second.page);
+    assert(
+      (await readStoredSessionToken(second.page)) === null,
+      "the revoked device kept its session token",
+    );
+    // And the device that did the revoking is still signed in — revoking
+    // another session must not sign me out of this one.
+    await waitForSignedIn(page);
+    step("revocation", "reached the other device live, and left this one alone");
+  } finally {
+    await second.context.close();
+  }
+
+  // 7. Sign out everywhere. The one guarantee that cannot be checked from a
+  //    single browser: a *different* device, which never sees the click, has to
+  //    lose its session too — live, and without asking for it.
+  const third = await newDevice();
+  try {
+    await signInOnFreshDevice(third.page);
+    await page
+      .getByRole("button", { name: /^sign out everywhere$/i })
+      .click();
+    await waitForSignedOut(page);
+    await waitForSignedOut(third.page);
+    assert(
+      (await readStoredSessionToken(third.page)) === null,
+      "a device kept its session token through sign-out-everywhere",
+    );
+    step("sign out everywhere", "the other device lost its session too");
+  } finally {
+    await third.context.close();
+  }
 
   console.error(`\n${passed} steps passed.`);
 } catch (error) {

--- a/e2e/session-flow.mjs
+++ b/e2e/session-flow.mjs
@@ -19,6 +19,10 @@ import { fileURLToPath } from "node:url";
 import { chromium } from "playwright-core";
 
 const appUrl = trimSlash(need("E2E_APP_URL"));
+// Compared as an origin, never as a prefix: `https://app.example` is a prefix of
+// `https://app.example.invalid`, and a check that accepts the second is the same
+// mistake the library refuses to make in its own redirect validation.
+const appOrigin = new URL(appUrl).origin;
 const convexUrl = trimSlash(need("E2E_CONVEX_URL"));
 const email = need("E2E_USER_EMAIL");
 const password = need("E2E_USER_PASSWORD");
@@ -98,7 +102,7 @@ async function waitForSignedOut(page) {
  * storage assertion waits for this first.
  */
 async function waitForAppOrigin(target) {
-  await target.waitForURL((url) => url.href.startsWith(appUrl), {
+  await target.waitForURL((url) => url.origin === appOrigin, {
     timeout: 45_000,
   });
   await target.waitForLoadState("domcontentloaded");
@@ -280,8 +284,8 @@ try {
   await signInAtLogto(page);
   await waitForSignedIn(page);
   assert(
-    page.url().startsWith(appUrl),
-    `expected to land back on ${appUrl}, got ${page.url()}`,
+    new URL(page.url()).origin === appOrigin,
+    `expected to land back on ${appOrigin}, got ${page.url()}`,
   );
   const firstToken = await readStoredSessionToken(page);
   assert(firstToken !== null, "no session token was persisted after sign-in");

--- a/e2e/session-flow.mjs
+++ b/e2e/session-flow.mjs
@@ -26,7 +26,7 @@ const headless = process.env.E2E_HEADED !== "1";
 const screenshotPath = fileURLToPath(new URL("./failure.png", import.meta.url));
 // Labels outlive a run: a revoke aimed at "the other device" would eventually
 // aim at a session some earlier run abandoned. Every run names its own.
-const runId = Date.now().toString(36);
+const runId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 
 function trimSlash(value) {
   return value.replace(/\/+$/, "");
@@ -86,6 +86,65 @@ async function waitForSignedOut(page) {
     undefined,
     { timeout: 30_000 },
   );
+}
+
+/**
+ * Wait until the browser is back on the app's own origin.
+ *
+ * `localStorage` is per origin, and a federated sign-out leaves the page on
+ * Logto's while it ends the OP session. Reading storage there answers a
+ * question about *Logto's* storage — and answers "no session token" no matter
+ * what the app kept, which is a passing assertion that checked nothing. Every
+ * storage assertion waits for this first.
+ */
+async function waitForAppOrigin(target) {
+  await target.waitForURL((url) => url.href.startsWith(appUrl), {
+    timeout: 45_000,
+  });
+  await target.waitForLoadState("domcontentloaded");
+}
+
+/**
+ * Sign out, and wait for the logout to actually reach Logto and come back.
+ *
+ * The app clears its own credentials *before* the network call, and the browser
+ * is still on the app's origin while it does — so "signed out, and on the app"
+ * is already true a millisecond after the click, before the end-session
+ * redirect has even started. Anything that navigates into that window cancels
+ * the request to Logto, and the OP session survives a sign-out that every
+ * local assertion says succeeded. Waiting for the end-session request itself is
+ * the only thing that closes it.
+ */
+async function signOutAndWaitForLogto(target, buttonName) {
+  const reachedLogto = target.waitForRequest(
+    (request) => request.url().includes("/oidc/session/end"),
+    { timeout: 45_000 },
+  );
+  await target.getByRole("button", { name: buttonName }).click();
+  await reachedLogto;
+  await waitForAppOrigin(target);
+  await waitForSignedOut(target);
+}
+
+/**
+ * Load the app again, tolerating a redirect still in flight.
+ *
+ * A federated sign-out is a chain — app → Logto's end-session → back — and the
+ * last hop can still be committing when the signed-out UI is already on screen.
+ * A navigation issued into that window aborts. Retrying is not papering over a
+ * product bug: the chain really is asynchronous, and the assertion that follows
+ * is about storage, not about how many redirects it took to get here.
+ */
+async function reopenApp(target) {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      await target.goto(appUrl, { waitUntil: "domcontentloaded" });
+      return;
+    } catch (error) {
+      if (attempt >= 3) throw error;
+      await target.waitForTimeout(500);
+    }
+  }
 }
 
 /** The rotating session token the library persisted, read from its own key. */
@@ -270,9 +329,8 @@ try {
   // Not `/^sign out/`: the app also offers "Sign out everywhere", and matching
   // both makes Playwright refuse rather than pick — which is the right call, and
   // the reason this names the one it means.
-  await page.getByRole("button", { name: /^sign out(?! everywhere)/i }).click();
-  await waitForSignedOut(page);
-  await page.reload({ waitUntil: "domcontentloaded" });
+  await signOutAndWaitForLogto(page, /^sign out(?! everywhere)/i);
+  await reopenApp(page);
   await waitForSignedOut(page);
   const afterSignOut = await readStoredSessionToken(page);
   assert(
@@ -358,11 +416,20 @@ try {
   const third = await newDevice();
   try {
     await signInOnFreshDevice(third.page);
-    await page
-      .getByRole("button", { name: /^sign out everywhere$/i })
-      .click();
+    await signOutAndWaitForLogto(page, /^sign out everywhere$/i);
+    // Same settling as step 4, for the same reason: the sign-out chain's last
+    // hop can still be committing, and a storage read into that window is
+    // evaluated in a document that is being replaced.
+    await reopenApp(page);
     await waitForSignedOut(page);
     await waitForSignedOut(third.page);
+    // Both devices, not just the far one: sign-out-everywhere is a different
+    // code path from sign-out, and "cleared UI, live credentials in storage" is
+    // as much a bug on the device that clicked as on the one that did not.
+    assert(
+      (await readStoredSessionToken(page)) === null,
+      "the device that signed out everywhere kept its own session token",
+    );
     assert(
       (await readStoredSessionToken(third.page)) === null,
       "a device kept its session token through sign-out-everywhere",

--- a/examples/expo-session/App.tsx
+++ b/examples/expo-session/App.tsx
@@ -32,6 +32,10 @@ import { api } from "./convex/_generated/api";
 // short-lived ID token and a rotating session token, both in SecureStore.
 const convex = new ConvexReactClient(process.env.EXPO_PUBLIC_CONVEX_URL!, {
   unsavedChangesWarning: false,
+  // Convex otherwise refetches a fresh token the instant it confirms the cached
+  // one, which costs a Logto refresh grant on every page load — and in session
+  // mode a session-token rotation with it. Experimental in convex@1.44.
+  initialAuthTokenReuse: true,
 });
 
 function Spinner({ label }: { label: string }) {

--- a/examples/expo/App.tsx
+++ b/examples/expo/App.tsx
@@ -23,6 +23,10 @@ import { api } from "./convex/_generated/api";
 // from the Convex deployment, so it's set in exactly one place per environment.
 const convex = new ConvexReactClient(process.env.EXPO_PUBLIC_CONVEX_URL!, {
   unsavedChangesWarning: false,
+  // Convex otherwise refetches a fresh token the instant it confirms the cached
+  // one, which costs a Logto refresh grant on every page load — and in session
+  // mode a session-token rotation with it. Experimental in convex@1.44.
+  initialAuthTokenReuse: true,
 });
 
 function Spinner({ label }: { label: string }) {

--- a/examples/nextjs-session/app/providers.tsx
+++ b/examples/nextjs-session/app/providers.tsx
@@ -8,7 +8,12 @@ import { ConvexLogtoSessionProvider } from "convex-logto/react-session";
 import { useRouter } from "next/navigation";
 import { api } from "@/convex/_generated/api";
 
-const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!, {
+  // Convex otherwise refetches a fresh token the instant it confirms the cached
+  // one, which costs a Logto refresh grant on every page load — and in session
+  // mode a session-token rotation with it. Experimental in convex@1.44.
+  initialAuthTokenReuse: true,
+});
 
 /**
  * No `initialToken` here, deliberately.

--- a/examples/nextjs/app/providers.tsx
+++ b/examples/nextjs/app/providers.tsx
@@ -8,7 +8,12 @@ import { useRouter } from "next/navigation";
 import { api } from "../convex/_generated/api";
 
 // Created once on the client — never recreated across renders.
-const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!, {
+  // Convex otherwise refetches a fresh token the instant it confirms the cached
+  // one, which costs a Logto refresh grant on every page load — and in session
+  // mode a session-token rotation with it. Experimental in convex@1.44.
+  initialAuthTokenReuse: true,
+});
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const router = useRouter();

--- a/examples/tanstack-router-spa/src/main.tsx
+++ b/examples/tanstack-router-spa/src/main.tsx
@@ -5,7 +5,12 @@ import { ConvexLogtoProvider, useLogtoAuth } from "convex-logto/react";
 import { RouterProvider } from "@tanstack/react-router";
 import { router } from "./router";
 
-const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL as string);
+const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL as string, {
+  // Convex otherwise refetches a fresh token the instant it confirms the cached
+  // one, which costs a Logto refresh grant on every page load — and in session
+  // mode a session-token rotation with it. Experimental in convex@1.44.
+  initialAuthTokenReuse: true,
+});
 
 // Inside <ConvexLogtoProvider> so useLogtoAuth() has its context.
 function RouterWithAuth() {

--- a/examples/tanstack-start/src/router.tsx
+++ b/examples/tanstack-start/src/router.tsx
@@ -31,7 +31,13 @@ export function getRouter() {
     console.error("missing VITE_CONVEX_URL envar");
   }
 
-  const convexQueryClient = new ConvexQueryClient(CONVEX_URL);
+  const convexQueryClient = new ConvexQueryClient(CONVEX_URL, {
+    // Convex otherwise refetches a fresh token the instant it confirms the
+    // cached one, which costs a Logto refresh grant on every page load — and in
+    // session mode a session-token rotation with it. Experimental in
+    // convex@1.44.
+    initialAuthTokenReuse: true,
+  });
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {

--- a/examples/vite-react-session/src/main.tsx
+++ b/examples/vite-react-session/src/main.tsx
@@ -5,7 +5,12 @@ import { ConvexLogtoSessionProvider } from "convex-logto/react-session";
 import { api } from "../convex/_generated/api";
 import { App } from "./App";
 
-const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL as string);
+const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL as string, {
+  // Convex otherwise refetches a fresh token the instant it confirms the cached
+  // one, which costs a Logto refresh grant on every page load — and in session
+  // mode a session-token rotation with it. Experimental in convex@1.44.
+  initialAuthTokenReuse: true,
+});
 
 // Session mode: no Logto SDK, no Logto config in the bundle. The provider
 // talks to your Convex functions (api.auth = logtoSessionApi re-exports);

--- a/examples/vite-react/src/main.tsx
+++ b/examples/vite-react/src/main.tsx
@@ -4,7 +4,12 @@ import { ConvexReactClient } from "convex/react";
 import { ConvexLogtoProvider } from "convex-logto/react";
 import { App } from "./App";
 
-const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL as string);
+const convex = new ConvexReactClient(import.meta.env.VITE_CONVEX_URL as string, {
+  // Convex otherwise refetches a fresh token the instant it confirms the cached
+  // one, which costs a Logto refresh grant on every page load — and in session
+  // mode a session-token rotation with it. Experimental in convex@1.44.
+  initialAuthTokenReuse: true,
+});
 
 // Static public config (endpoint + app id are not secrets): no config
 // round-trip before sign-in is interactive. Runtime-resolved config is still


### PR DESCRIPTION
## What the live harness found

Convex's client fetches an auth token **twice** on every page load. It sends the one the page already has, waits for the server to confirm it, and then — by default — discards it and calls `fetchAccessToken({ forceRefreshToken: true })`. That flag means *"the token you last gave me will not do"*, so both modes obey it:

- **bridge mode** clears the access token and goes back to Logto's token endpoint;
- **session mode** calls `refresh`, which presents the Logto refresh token *and* rotates the session token.

Traced in a real browser against a real Logto: on reload, with a cached ID token holding **3599 of its 3600 seconds**, the page posted `auth:refresh` at +599ms. The zero-RTT restore the library implements was real, and then immediately thrown away.

Convex has [`initialAuthTokenReuse`](https://github.com/get-convex/convex-js) for exactly this — it keeps the confirmed token and schedules a refresh before it expires. With it on, the same trace shows **no `auth:refresh` at all**.

Every example sets it now. `docs/how-it-works` explains it, and quick-start and session-mode point there from the line that constructs the client. It is marked experimental in `convex@1.44`, which is the only reason it is not simply required.

## Live harness, same pass

`e2e/session-flow.mjs` had never run green end to end. Four fixes and two new steps:

- **zero-RTT** counted *every* POST at the deployment, so the example's own device list failed it. It now names the call it forbids — a token mint — which is both the thing it means and the thing that survives a UI change.
- **step 5** asserted that re-signing-in after a sign-out would be silent *"over Logto's surviving SSO cookie"*. Sign-out is federated by default and ends that session on purpose, so the step asserted the opposite of documented behaviour. Inverted: the credential prompt is now **required**, because it is the only evidence the RP-initiated logout actually reached Logto — clearing local storage looks identical from the app either way.
- `/^sign out/` matched "Sign out everywhere" too, and Playwright refused to guess. Named.
- **new: revocation** — a second browser context is a second cookie jar and storage origin, so a real second device. Revoking it from the first has to land **live, without a reload**, and leave the revoking device signed in.
- **new: sign-out everywhere** — checked on the device that never saw the click.

Each run names its target `e2e-target-<runid>`: the test account accumulates sessions, so "the other device" would eventually mean whatever an earlier run abandoned.

## Verification

- All seven live steps pass against a real Logto and a local Convex backend, run twice with identical results.
- `pnpm lint`, `format:check`, `check-types`, `test`, `build` green over the whole workspace.
- No published-package source changed, so no changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for reusing the initial authentication token to reduce page-load refreshes and round trips.
  * Documented token refresh behavior, revocation tradeoffs, configuration, session-mode usage, and safe sign-out navigation.
  * Expanded end-to-end setup and verification instructions.

* **Examples**
  * Updated authentication examples to enable initial token reuse during client initialization.

* **Tests**
  * Expanded session-flow coverage for multi-device revocation, sign-out-everywhere, federated logout, and zero-round-trip restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->