### PR TITLE
fix(session): a 403 from Logto deleted sessions, and organization token scopes are always empty

### DIFF
--- a/.changeset/token-force-refresh.md
+++ b/.changeset/token-force-refresh.md
@@ -22,3 +22,14 @@ minted is a deployment fault, and it does not spend a second grant on one.
 Also: a userinfo response that is not JSON no longer reports as
 `logto_unreachable`, which sent readers looking at the network for a deployment
 answering wrongly.
+
+Also, and separately: a `403` from Logto's token endpoint was read as "the
+refresh outcome is unknown", which keeps the refresh claim — so the session
+answered `refresh_in_flight` to everything and was **deleted** when the claim
+aged out. Logto answers exactly that for an Organization token asked for on a
+grant without `urn:logto:scope:organizations`, so one missing scope in a
+deployment's config signed every user out. A 403 with a machine-readable body
+is a decision like a 400 or a 401, and `insufficient_scope` is a configuration
+fault: transient, sessions kept, message naming the scope. `logtoSessionApi`
+now refuses an organization exchange it can see cannot work, before it spends a
+claim.

--- a/.changeset/token-force-refresh.md
+++ b/.changeset/token-force-refresh.md
@@ -1,0 +1,24 @@
+---
+"convex-logto": minor
+---
+
+Add `forceRefresh` to every token-exchange method, and make `fetchUserInfo`
+recover from a rejected cached token on its own.
+
+The component caches a minted Organization or Resource token until it expires,
+so a token the *resource server* has stopped accepting — a revoked grant, a
+clock that drifted past the skew allowance, an organization whose roles changed
+— kept being served for the rest of its lifetime, and the caller had no way to
+say "not that one". `getOrganizationTokenClaims`, `getAccessTokenClaims`,
+`getOrganizationToken`, `getAccessToken` and `fetchUserInfo` now take a final
+`{ forceRefresh: true }` that skips the cache and replaces what was there. It
+costs a Logto grant, so it belongs on the failure path.
+
+`fetchUserInfo` is the one caller inside the library that consumes a minted
+token, so it does that itself: when Logto answers `401`/`403` for a token that
+came from the cache it mints once and retries. A rejection of a token it just
+minted is a deployment fault, and it does not spend a second grant on one.
+
+Also: a userinfo response that is not JSON no longer reports as
+`logto_unreachable`, which sent readers looking at the network for a deployment
+answering wrongly.

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ e2e/failure.png
 e2e/.env.e2e
 e2e/package-lock.json
 e2e/.probe-*.json
+e2e/.probe-*.log

--- a/docs/adr/0003-organization-token-exchange.md
+++ b/docs/adr/0003-organization-token-exchange.md
@@ -22,7 +22,15 @@ That measurement had to be arranged, and arranging it is the point. A confidenti
 Three more answers from the same run shape the surface rather than the concurrency:
 
 - **Every `refresh_token` grant returns an `id_token`**, including the Organization and Resource variants — so an exchange also mints a fresh Short bearer, and discarding it would throw away a free refresh and leave the Session ageing faster than it needs to. The exchange persists it like any other refresh outcome.
-- **Membership and organization roles need no exchange at all.** The ID token carried `organizations: ["<id>"]` and `organization_roles: ["<id>:<role>"]`, confirming what [ADR 0002](./0002-token-custody.md) assumes. Only fine-grained organization *permissions* require a token.
+- **Membership and organization roles need no exchange at all.** The ID token carried `organizations: ["<id>"]` and `organization_roles: ["<id>:<role>"]`, confirming what [ADR 0002](./0002-token-custody.md) assumes.
+- **And organization *permissions* cannot be reached through this exchange at all.** A later measurement (2026-08-21, through the component this time rather than raw OIDC) found the minted Organization token's own `scope` claim empty, for a user holding a role that grants `e2e:manage`. Logto issues `availableScopes ∩ requestedScopes` — the user's organization permissions intersected with the request's scope set, which defaults to the *grant's* scopes:
+
+  ```js
+  const scope = params.scope ? requestParamScopes : refreshToken.scopes;
+  const issuedScopes = availableScopes.filter((name) => scope.has(name)).join(" ");
+  ```
+
+  Organization permissions are not OIDC scopes: they are absent from `scopes_supported`, so oidc-provider drops them from the authorize request and they can never be in `refreshToken.scopes`. The intersection is therefore always empty, and naming one on the token request is refused by the subset check above it (`invalid_scope`, "refresh token missing requested scope"). Authorization on organization permissions has to come from `organization_roles`, which is free and in the ID token; the Organization token remains the right thing to *send* to a service that validates the `urn:logto:organization:<id>` audience itself. A Resource token is different, and does carry the scopes its grant named.
 - **A rejected grant is not a spend.** Presenting a refresh token for an unregistered resource answers `invalid_target` and leaves the token usable — checked by replaying it immediately afterwards. This is what makes releasing the claim on a terminal token-endpoint failure safe rather than a guess.
 
 A resource, finally, must be named by the **`resource` parameter at authorization time**. Requesting the resource's *scope* instead does not work — that combination was rejected `invalid_target`, and the `resource` parameter alone succeeded — so `resources` is a sign-in-time input, and `scopes` is a separate one: a grant that named the resource but not its scopes yields a token with no scopes at all.
@@ -32,5 +40,5 @@ A resource, finally, must be named by the **`resource` parameter at authorizatio
 - The exchange is not a fast path. It queues behind an in-flight refresh on the same Session, and inherits the claim's whole failure vocabulary — including "outcome unknown, keep the claim and let it age into `claim-expired`".
 - `resources` must be declared before sign-in, and the scopes wanted from those resources belong in `scopes`. An app that discovers it needs a new API resource has to sign the user in again; there is no way to widen a grant in place.
 - A Session's stored ID token can be replaced by an Organization token exchange. Anything reasoning about *why* the Short bearer changed must not assume a plain refresh caused it.
-- Organization membership and role checks stay synchronous and free (`logtoOrganizations`, `assertOrganizationRole`). Only permission checks pay for a round trip, and the difference is worth documenting because it is invisible from the call site.
+- Organization membership and role checks stay synchronous and free (`logtoOrganizations`, `assertOrganizationRole`) — and they are the *only* organization authorization this library can offer, because an Organization token's scopes are always empty. `getOrganizationTokenClaims(...).scopes` must never be used as a permission check; the docs say so in a warning callout.
 - The rotation toggle is a deployment's to set, and turning it *off* does not make the exchange safe to run outside the claim: it makes the bug invisible instead of absent.

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -318,9 +318,10 @@ which Convex rejects as a request credential. Session mode can mint one for you
 <Callout type="info">Session mode only. In bridge mode the Logto SDK is already
 in the bundle: use `useLogto().getOrganizationToken(...)` directly.</Callout>
 
-Reach for this **only** for fine-grained organization permissions, or for a
-non-Convex API you registered with Logto. Membership and organization roles are
-already in the ID token (above) and cost nothing.
+Reach for this for a non-Convex API you registered with Logto, or to hand an
+organization-audienced token to something that checks permissions itself.
+Membership and organization roles are already in the ID token (above) and cost
+nothing.
 
 ```ts
 const {
@@ -330,11 +331,29 @@ const {
   getIdToken,
 } = useLogtoAuth();
 
-const { scopes } = await getOrganizationTokenClaims("org-id");
+// A Resource token's scopes are the ones this grant was signed for.
+const { scopes } = await getAccessTokenClaims("https://api.example.com");
 if (scopes.includes("invoice:delete")) {
   /* ... */
 }
 ```
+
+<Callout type="warn">
+**An organization token's `scopes` is empty.** Measured against a real Logto,
+three ways: Logto issues `availableScopes ∩ requestedScopes`, where
+`availableScopes` is the user's organization permissions and `requestedScopes`
+defaults to the grant's own scopes. Organization permissions are not OIDC scopes
+— they are absent from `scopes_supported`, so the authorize request drops them
+and they can never be in a grant. The intersection is therefore always empty,
+and asking for one explicitly is refused (`invalid_scope`, "a refresh grant can
+only request scopes it already holds").
+
+So do not authorize on `getOrganizationTokenClaims(...).scopes` — it would deny
+everyone. Use `organization_roles` from the ID token, which is free and
+authoritative: `assertOrganizationRole(ctx, orgId, ["admin"])` above. The
+organization token is still the right thing to *send* to a service that
+validates the `urn:logto:organization:<id>` audience itself.
+</Callout>
 
 The component mints the token from the Session's Logto refresh token and hands
 back **what it authorizes**, not the token itself — nothing long-lived enters

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -360,11 +360,31 @@ export const { /* ... */ exchangeToken, fetchUserInfo } = logtoSessionApi(
 - **Minted tokens are cached** per session, audience and requested scope set, so
   a permission check on render does not cost a grant. A revoked session's cache
   is invisible immediately and deleted with it.
+- **When the API you called rejects the token, ask for a new one.** Every method
+  takes a final `{ forceRefresh: true }`, which skips the cache and replaces
+  what was there. Without it a token the resource server has stopped accepting
+  would go on being served for the rest of its lifetime, with no way to say
+  "not that one". It costs a grant, so it belongs on the failure path:
+
+  ```ts
+  let token = await getAccessToken("https://api.example.com");
+  let res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  if (res.status === 401) {
+    token = await getAccessToken("https://api.example.com", undefined, {
+      forceRefresh: true,
+    });
+    res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+  }
+  ```
 - **The exchange queues behind a refresh.** It spends the same Logto refresh
   token, so it takes the same claim and can answer the transient
   `refresh_in_flight` — retry it.
 - `fetchUserInfo()` is Logto's live `/oidc/me`, unlike `user`, which is the copy
   the last ID token froze. `getIdToken()` returns that Short bearer itself.
+  `fetchUserInfo` does the retry above for you — it is the one caller inside the
+  library that consumes a minted token, so when Logto answers `401`/`403` for a
+  *cached* one it mints once and tries again. A rejection of a token it just
+  minted is a deployment fault, and it does not spend a second grant on that.
 
 See [ADR 0002](https://github.com/Fanzzzd/convex-logto/blob/main/docs/adr/0002-token-custody.md)
 for the custody decision and

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -173,7 +173,8 @@ organization the test user belongs to:
 
 ```bash
 export E2E_ORG_ID=...          # from `GET /api/organizations`
-node probe-exchange.mjs
+node probe-exchange.mjs                       # findings on stderr, like the rest
+node probe-exchange.mjs 2> .probe-exchange.log # …redirect to keep them
 ```
 
 It found two defects the first time it ran: Logto answers `403` for an

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -167,6 +167,24 @@ decoded claims are credentials and go to `.probe-org-tokens.json` (mode `0600`,
 gitignored), rewritten after every finding so a late failure does not discard
 evidence that cost real authorization grants.
 
+`probe-exchange.mjs` asks the same kind of question one layer up — through the
+*component*, not raw OIDC. It needs an app already running (see step 2) and an
+organization the test user belongs to:
+
+```bash
+export E2E_ORG_ID=...          # from `GET /api/organizations`
+node probe-exchange.mjs
+```
+
+It found two defects the first time it ran: Logto answers `403` for an
+organization token asked for on a grant without
+`urn:logto:scope:organizations`, and the component read that as *"the refresh
+outcome is unknown"* — keeping the claim, so every later refresh answered
+`refresh_in_flight` and the session was deleted when the claim aged out. One
+missing scope in a deployment's config signed every user out. It also showed
+that an Organization token's `scopes` is always empty, which the docs had been
+telling readers to authorize on.
+
 > **Design the experiment so the answer is visible.** Rotation is invisible on
 > any *confidential* client's fresh refresh token — Logto only rotates one past
 > 70% of its lifetime — so asking that client answers "no rotation" no matter

--- a/e2e/probe-exchange.mjs
+++ b/e2e/probe-exchange.mjs
@@ -1,0 +1,121 @@
+// What does the token exchange actually do, end to end through the component?
+//
+// A probe, not a regression: it asks the deployment questions whose answers are
+// not known yet and prints findings. It found two of them the first time it ran.
+//
+//   set -a; . ./.env.e2e; set +a
+//   export E2E_APP_URL=http://localhost:5174 E2E_CONVEX_URL=http://127.0.0.1:3216
+//   export E2E_ORG_ID=<an organization the test user belongs to>
+//   node probe-exchange.mjs 2>&1
+//
+// The app must export `exchangeToken` and `fetchUserInfo` from
+// `logtoSessionApi(...)`, and — for the organization half — request
+// `ORGANIZATIONS_SCOPE`. Running it *without* that scope is itself informative:
+// it is the configuration that used to leave the session unusable.
+//
+// Nothing here asks for a token string (`includeToken` is never set), so no
+// credential is printed. The ID token's claim *names* are, because which claims
+// a scope produces is the question.
+import { chromium } from "playwright-core";
+
+const appUrl = need("E2E_APP_URL").replace(/\/+$/, "");
+const convexUrl = need("E2E_CONVEX_URL").replace(/\/+$/, "");
+const organizationId = need("E2E_ORG_ID");
+const email = need("E2E_USER_EMAIL");
+const password = need("E2E_USER_PASSWORD");
+
+function need(name) {
+  const value = process.env[name];
+  if (!value) {
+    console.error(
+      `probe-exchange: ${name} is required. See the header of this file.`,
+    );
+    process.exit(1);
+  }
+  return value;
+}
+
+const browser = await chromium.launch({ headless: true, channel: "chrome" });
+const page = await (await browser.newContext()).newPage();
+try {
+  await page.goto(appUrl, { waitUntil: "domcontentloaded" });
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await page.waitForSelector("input[name=identifier]", { timeout: 30_000 });
+  await page.fill("input[name=identifier]", email);
+  await page.keyboard.press("Enter");
+  await page.waitForSelector("input[type=password]", { timeout: 30_000 });
+  await page.fill("input[type=password]", password);
+  await page.keyboard.press("Enter");
+  await page.waitForFunction(
+    () =>
+      Object.keys(localStorage).some((key) =>
+        key.startsWith("convex-logto:"),
+      ) && /sign out/i.test(document.body.innerText),
+    undefined,
+    { timeout: 45_000 },
+  );
+
+  // Which claims the configured scopes actually produced. Membership and roles
+  // arriving here is the whole reason an organization *token* is rarely needed.
+  const idToken = await page.evaluate(() => {
+    const key = Object.keys(sessionStorage).find((candidate) =>
+      candidate.endsWith(":idToken"),
+    );
+    if (key === undefined) return null;
+    const stored = JSON.parse(sessionStorage.getItem(key) ?? "null");
+    const raw = typeof stored === "string" ? stored : stored?.token;
+    if (typeof raw !== "string") return null;
+    const claims = JSON.parse(
+      atob((raw.split(".")[1] ?? "").replace(/-/g, "+").replace(/_/g, "/")),
+    );
+    return {
+      organizations: claims.organizations ?? null,
+      organization_roles: claims.organization_roles ?? null,
+      claimNames: Object.keys(claims).sort(),
+    };
+  });
+  console.error("ID token claims:", JSON.stringify(idToken, null, 2));
+
+  const sessionToken = await page.evaluate(() => {
+    const key = Object.keys(localStorage).find((candidate) =>
+      candidate.endsWith(":session"),
+    );
+    return JSON.parse(localStorage.getItem(key ?? "") ?? "null")?.token ?? null;
+  });
+
+  // Run through the page so the request carries the app's own origin.
+  async function callAction(path, args) {
+    return await page.evaluate(
+      async ([url, name, payload]) => {
+        const response = await fetch(`${url}/api/action`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ path: name, args: payload, format: "json" }),
+        });
+        return await response.text();
+      },
+      [convexUrl, path, args],
+    );
+  }
+
+  for (const [label, path, args] of [
+    [
+      "organization token",
+      "auth:exchangeToken",
+      { sessionToken, organizationId },
+    ],
+    [
+      // Expected to fail: organization permissions are not OIDC scopes, so a
+      // refresh grant can never hold one to narrow by. See ADR 0003.
+      "organization token, narrowed by a permission",
+      "auth:exchangeToken",
+      { sessionToken, organizationId, scopes: ["e2e:manage"] },
+    ],
+    ["userinfo", "auth:fetchUserInfo", { sessionToken }],
+  ]) {
+    console.error(`\n=== ${label}`);
+    console.error((await callAction(path, args)).slice(0, 900));
+  }
+} finally {
+  await browser.close();
+}

--- a/examples/vite-react-session/convex/auth.ts
+++ b/examples/vite-react-session/convex/auth.ts
@@ -1,6 +1,10 @@
 // The whole server side of session mode: eleven public functions backed by the
 // Logto session component. The frontend provider expects these exact names.
-import { logtoSessionApi } from "convex-logto";
+import {
+  ORGANIZATIONS_SCOPE,
+  ORGANIZATION_ROLES_SCOPE,
+  logtoSessionApi,
+} from "convex-logto";
 import { components } from "./_generated/api";
 
 export const {
@@ -15,4 +19,12 @@ export const {
   exchangeToken,
   fetchUserInfo,
   sessionValid,
-} = logtoSessionApi(components.logto);
+} = logtoSessionApi(components.logto, {
+  // Scopes are server-configured: the browser cannot ask for its own, and they
+  // are fixed at authorization time — a grant cannot be widened in place, so
+  // adding one here means signing in again. These two put `organizations` and
+  // `organization_roles` in the ID token, which is where membership and role
+  // checks read them from for free. The organization *token* exchange also
+  // requires the first one; without it Logto answers `403 insufficient_scope`.
+  scopes: [ORGANIZATIONS_SCOPE, ORGANIZATION_ROLES_SCOPE],
+});

--- a/packages/convex-logto/src/component/_generated/component.ts
+++ b/packages/convex-logto/src/component/_generated/component.ts
@@ -75,6 +75,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           clientSecret: string;
           deviceProof?: string;
           endpoint: string;
+          forceRefresh?: boolean;
           includeToken?: boolean;
           organizationId?: string;
           resource?: string;
@@ -103,6 +104,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           clientSecret: string;
           deviceProof?: string;
           endpoint: string;
+          forceRefresh?: boolean;
           reuseWindowMs?: number;
           sessionToken: string;
         },

--- a/packages/convex-logto/src/component/core.test.ts
+++ b/packages/convex-logto/src/component/core.test.ts
@@ -551,6 +551,9 @@ it.each([
   [400, "unsupported_grant_type", "transient"],
   [401, "invalid_client", "transient"],
   [401, "unauthorized_client", "transient"],
+  // 403 is not in RFC 6749 §5.2, but Logto answers it — and it is a decision,
+  // not an unknown outcome. The dedicated test below is the one that proves it.
+  [403, "invalid_grant", "terminal"],
   [429, undefined, "transient"],
   [500, undefined, "transient"],
   [502, undefined, "transient"],
@@ -561,7 +564,7 @@ it.each([
   ).toBe(kind);
 });
 
-it.each([400, 401])(
+it.each([400, 401, 403])(
   "classifyTokenEndpointFailure(%i) without an error code keeps the session",
   (status) => {
     // Deleting every session of a deployment is irreversible; an answer we
@@ -571,6 +574,39 @@ it.each([400, 401])(
     );
   },
 );
+
+it("does not read a 403 as an unknown outcome, which would delete the session", () => {
+  // The whole chain this prevents, measured live before it was fixed: an
+  // Organization token requested without `urn:logto:scope:organizations`
+  // answers `403 insufficient_scope`; read as "outcome unknown" the component
+  // keeps the refresh claim, every later refresh answers `refresh_in_flight`,
+  // and when the claim ages out the session is *deleted*. One missing scope in
+  // a deployment's config, every user signed out.
+  const error = classifyTokenEndpointFailure(403, {
+    error: "insufficient_scope",
+    scope: "urn:logto:scope:organizations",
+  });
+  expect(error.data.kind).toBe("transient");
+  expect(error.data.code).toBe("insufficient_scope");
+  expect(error.data.code).not.toBe("logto_outcome_unknown");
+  // And it names the scope Logto asked for, because "insufficient_scope"
+  // alone does not tell a reader which option to add.
+  expect(error.data.message).toContain("urn:logto:scope:organizations");
+  expect(error.data.message).toContain("scopes");
+});
+
+it("does not blame the client credentials for a scope Logto refused", () => {
+  // `invalid_scope` shares the configuration-fault branch with
+  // `invalid_client`, whose message names LOGTO_APP_ID / LOGTO_CLIENT_SECRET /
+  // LOGTO_ENDPOINT. For a scope that is the wrong three things to check.
+  const error = classifyTokenEndpointFailure(400, {
+    error: "invalid_scope",
+    scope: "e2e:manage",
+  });
+  expect(error.data.kind).toBe("transient");
+  expect(error.data.message).toContain("e2e:manage");
+  expect(error.data.message).not.toContain("LOGTO_CLIENT_SECRET");
+});
 
 it("classifyTokenEndpointFailure surfaces Logto's error code", () => {
   expect(

--- a/packages/convex-logto/src/component/core.ts
+++ b/packages/convex-logto/src/component/core.ts
@@ -966,6 +966,13 @@ const CONFIGURATION_FAULT_ERRORS = new Set([
   "unauthorized_client",
   "unsupported_grant_type",
   "invalid_scope",
+  // Measured, not assumed: asking Logto for an Organization token on a grant
+  // that never requested `urn:logto:scope:organizations` answers
+  // `403 insufficient_scope`. Scopes are fixed at authorization time, so this
+  // is a deployment that has not put them in `logtoSessionApi({ scopes })` —
+  // and it is answered identically for every session, which is exactly why it
+  // must never be terminal.
+  "insufficient_scope",
 ]);
 
 /**
@@ -992,14 +999,45 @@ export function isOutcomeUnknownError(error: unknown): boolean {
 
 export function classifyTokenEndpointFailure(
   status: number,
-  body: { error?: string },
+  body: { error?: string; scope?: string },
 ): ConvexError<SessionErrorData> {
-  if (status === 400 || status === 401) {
+  // 403 belongs here with 400 and 401. RFC 6749 §5.2 does not use it, but Logto
+  // does — an Organization token asked for on a grant without
+  // `urn:logto:scope:organizations` comes back `403 insufficient_scope`, with a
+  // machine-readable body. Reading that as "outcome unknown" was a real bug:
+  // the claim was kept, every later refresh answered `refresh_in_flight`, and
+  // when the claim aged out the session was *deleted* — one missing scope in a
+  // deployment's config signing every user out.
+  if (status === 400 || status === 401 || status === 403) {
     // Logto answered with a decision, so it did not rotate anything.
     if (
       body.error !== undefined &&
       CONFIGURATION_FAULT_ERRORS.has(body.error)
     ) {
+      if (body.error === "insufficient_scope") {
+        return transient(
+          body.error,
+          `Logto refused this grant: it never requested ${body.scope ?? "the scope this call needs"}. ` +
+            "Scopes are fixed at authorization time — add it to " +
+            "`logtoSessionApi({ scopes })` and sign in again. Sessions are kept.",
+        );
+      }
+      if (body.error === "invalid_scope") {
+        // Not a credentials problem, so the generic message below would send
+        // the reader to the wrong three environment variables. Logto names the
+        // offending scope, and the rule is a subset rule: a refresh grant may
+        // only ask for scopes it already holds. Organization *permissions*
+        // never do — they are not OIDC scopes at all (they are absent from
+        // `scopes_supported`), so asking for one here can only fail.
+        return transient(
+          body.error,
+          `Logto rejected the scopes this call asked for${body.scope === undefined ? "" : ` (${body.scope})`}: ` +
+            "a refresh grant can only request scopes it already holds. Add " +
+            "them to `logtoSessionApi({ scopes })` and sign in again — and note " +
+            "that organization permissions are not OIDC scopes, so they cannot " +
+            "be asked for this way. Sessions are kept.",
+        );
+      }
       return transient(
         body.error,
         `Logto rejected this deployment's own request (${body.error}) — check ` +

--- a/packages/convex-logto/src/component/exchange.test.ts
+++ b/packages/convex-logto/src/component/exchange.test.ts
@@ -1,10 +1,12 @@
+import { getFunctionName, type FunctionReference } from "convex/server";
 import { ConvexError } from "convex/values";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   beginTokenExchange,
   cachedResourceToken,
   completeTokenExchange,
   exchangeToken,
+  fetchUserInfo,
 } from "./lib";
 import {
   MAX_CACHEABLE_ACCESS_TOKEN_LENGTH,
@@ -846,5 +848,203 @@ describe("exchangeToken", () => {
     ).rejects.toMatchObject({
       data: { kind: "terminal", code: "missing_token_target" },
     });
+  });
+});
+
+// --- forceRefresh and the userinfo self-heal --------------------------------
+
+/**
+ * A minimal action ctx plus a `fetch` that answers by URL. Enough to drive the
+ * exchange end to end without a deployment: the mutations are the only state,
+ * and what this asserts is which calls were made, not what they stored.
+ */
+function actionHarness(options: {
+  cached?: { accessToken: string } | null;
+  userInfoStatuses?: number[];
+}) {
+  const cached = options.cached ?? null;
+  const userInfoStatuses = [...(options.userInfoStatuses ?? [])];
+  const runQuery = vi.fn((reference: unknown) => {
+    const name = getFunctionName(
+      reference as FunctionReference<"query", "internal">,
+    );
+    if (name === "lib:devicePublicKeyForToken") return Promise.resolve(null);
+    if (name === "lib:cachedResourceToken") {
+      return Promise.resolve(
+        cached === null
+          ? null
+          : {
+              audience: "default",
+              grantedScope: "",
+              expiresAt: Date.now() + 3_600_000,
+              accessToken: cached.accessToken,
+            },
+      );
+    }
+    throw new Error(`unexpected query ${name}`);
+  });
+  const runMutation = vi.fn((reference: unknown) => {
+    const name = getFunctionName(
+      reference as FunctionReference<"mutation", "internal">,
+    );
+    if (name === "lib:beginTokenExchange") {
+      return Promise.resolve({
+        outcome: "exchange" as const,
+        sessionId: "session-1",
+        refreshToken: "refresh-1",
+      });
+    }
+    if (name === "lib:completeTokenExchange") {
+      return Promise.resolve({
+        outcome: "committed" as const,
+        expiresAt: Date.now() + 3_600_000,
+        grantedScope: "",
+      });
+    }
+    throw new Error(`unexpected mutation ${name}`);
+  });
+  const tokenRequests: string[] = [];
+  const userInfoRequests: string[] = [];
+  const fetchMock = vi.fn((input: unknown, init?: { body?: unknown }) => {
+    const url = String(input);
+    if (url.endsWith("/oidc/token")) {
+      tokenRequests.push(String(init?.body ?? ""));
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            access_token: `minted-${tokenRequests.length}`,
+            expires_in: 3600,
+            scope: "",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      );
+    }
+    if (url.endsWith("/oidc/me")) {
+      userInfoRequests.push(url);
+      const status = userInfoStatuses.shift() ?? 200;
+      return Promise.resolve(
+        new Response(JSON.stringify({ sub: "user-1" }), { status }),
+      );
+    }
+    throw new Error(`unexpected fetch ${url}`);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return {
+    ctx: { runQuery, runMutation },
+    runQuery,
+    runMutation,
+    tokenRequests,
+    userInfoRequests,
+    args: {
+      endpoint: "https://auth.example.com",
+      appId: "app",
+      clientSecret: "secret",
+      sessionToken: "session-token",
+    },
+  };
+}
+
+describe("forceRefresh", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("serves the cached token when it is not asked to mint", async () => {
+    const harness = actionHarness({ cached: { accessToken: "cached-1" } });
+    const handler = handlerOf<Record<string, unknown>, { minted: boolean }>(
+      exchangeToken,
+    );
+    const result = await handler(harness.ctx, {
+      ...harness.args,
+      organizationId: "org-1",
+    });
+    expect(result.minted).toBe(false);
+    expect(harness.tokenRequests).toHaveLength(0);
+  });
+
+  it("skips the cache and mints when asked, so a rejected token can be replaced", async () => {
+    // The whole point: the component caches a minted token until it expires,
+    // so without this a token the resource server has stopped accepting keeps
+    // being served and the caller has no way to say "not that one".
+    const harness = actionHarness({ cached: { accessToken: "cached-1" } });
+    const handler = handlerOf<Record<string, unknown>, { minted: boolean }>(
+      exchangeToken,
+    );
+    const result = await handler(harness.ctx, {
+      ...harness.args,
+      organizationId: "org-1",
+      forceRefresh: true,
+    });
+    expect(result.minted).toBe(true);
+    expect(harness.tokenRequests).toHaveLength(1);
+    expect(
+      harness.runQuery.mock.calls.map((call) =>
+        getFunctionName(call[0] as FunctionReference<"query", "internal">),
+      ),
+    ).not.toContain("lib:cachedResourceToken");
+  });
+
+  it("still proves the device before minting, so a forced call is not a way past it", async () => {
+    const harness = actionHarness({ cached: null });
+    const handler = handlerOf<Record<string, unknown>, unknown>(exchangeToken);
+    await handler(harness.ctx, {
+      ...harness.args,
+      organizationId: "org-1",
+      forceRefresh: true,
+    });
+    expect(
+      harness.runQuery.mock.calls.map((call) =>
+        getFunctionName(call[0] as FunctionReference<"query", "internal">),
+      ),
+    ).toContain("lib:devicePublicKeyForToken");
+  });
+});
+
+describe("fetchUserInfo", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("mints once and retries when Logto rejects a token that came from the cache", async () => {
+    const harness = actionHarness({
+      cached: { accessToken: "cached-1" },
+      userInfoStatuses: [401, 200],
+    });
+    const handler = handlerOf<Record<string, unknown>, unknown>(fetchUserInfo);
+    await expect(handler(harness.ctx, harness.args)).resolves.toEqual({
+      sub: "user-1",
+    });
+    expect(harness.userInfoRequests).toHaveLength(2);
+    // Exactly one extra grant: the retry, and nothing more.
+    expect(harness.tokenRequests).toHaveLength(1);
+  });
+
+  it("does not retry a rejection of a token it just minted", async () => {
+    // A freshly minted token Logto refuses is a deployment fault — a wrong
+    // client, a disabled user. Minting again would spend grants on it forever.
+    const harness = actionHarness({
+      cached: null,
+      userInfoStatuses: [401, 200],
+    });
+    const handler = handlerOf<Record<string, unknown>, unknown>(fetchUserInfo);
+    await expect(handler(harness.ctx, harness.args)).rejects.toMatchObject({
+      data: { kind: "transient", code: "userinfo_failed" },
+    });
+    expect(harness.userInfoRequests).toHaveLength(1);
+    expect(harness.tokenRequests).toHaveLength(1);
+  });
+
+  it("does not spend a second grant on a 5xx, which says nothing about the token", async () => {
+    const harness = actionHarness({
+      cached: { accessToken: "cached-1" },
+      userInfoStatuses: [503, 200],
+    });
+    const handler = handlerOf<Record<string, unknown>, unknown>(fetchUserInfo);
+    await expect(handler(harness.ctx, harness.args)).rejects.toMatchObject({
+      data: { kind: "transient", code: "userinfo_failed" },
+    });
+    expect(harness.userInfoRequests).toHaveLength(1);
+    expect(harness.tokenRequests).toHaveLength(0);
   });
 });

--- a/packages/convex-logto/src/component/lib.ts
+++ b/packages/convex-logto/src/component/lib.ts
@@ -1209,6 +1209,8 @@ type ExchangeArgs = {
   resource?: string;
   scopes?: string[];
   includeToken?: boolean;
+  /** Skip the cache and mint a new token, replacing whatever was cached. */
+  forceRefresh?: boolean;
   reuseWindowMs?: number;
 };
 
@@ -1228,6 +1230,18 @@ export const exchangeToken = action({
     scopes: v.optional(v.array(v.string())),
     /** Return the token string, not just its claims. Gated by the caller. */
     includeToken: v.optional(v.boolean()),
+    /**
+     * Mint a new token even if a live one is cached.
+     *
+     * The cache is keyed by target and scope set and holds a token until it
+     * expires, so a token the *resource server* has stopped accepting — a
+     * revoked grant, a clock that drifted past the skew allowance, an
+     * organization whose roles changed — would otherwise keep being served for
+     * up to its whole lifetime with no way for the caller to say "not that
+     * one". This is that way. It costs a grant, so it belongs on the failure
+     * path, not on every call.
+     */
+    forceRefresh: v.optional(v.boolean()),
     reuseWindowMs: v.optional(v.number()),
   },
   returns: v.object({
@@ -1277,16 +1291,17 @@ async function runExchange(
     proof: args.deviceProof,
   });
 
-  const cached: CachedResourceToken | null = await ctx.runQuery(
-    internal.lib.cachedResourceToken,
-    {
-      presentedHash,
-      audience,
-      scopeKey,
-      now: Date.now(),
-      reuseWindowMs: args.reuseWindowMs ?? DEFAULT_REUSE_WINDOW_MS,
-    },
-  );
+  // The device proof is checked above, before this branch: a forced mint must
+  // not be a way to skip it, and neither must a cache hit.
+  const cached: CachedResourceToken | null = args.forceRefresh
+    ? null
+    : await ctx.runQuery(internal.lib.cachedResourceToken, {
+        presentedHash,
+        audience,
+        scopeKey,
+        now: Date.now(),
+        reuseWindowMs: args.reuseWindowMs ?? DEFAULT_REUSE_WINDOW_MS,
+      });
   if (cached) {
     return {
       claims: claimsFromRow(cached, args),
@@ -1727,6 +1742,7 @@ export const fetchUserInfo = action({
     ...oidcArgs,
     sessionToken: v.string(),
     deviceProof: v.optional(v.string()),
+    forceRefresh: v.optional(v.boolean()),
     reuseWindowMs: v.optional(v.number()),
   },
   returns: v.any(),
@@ -1734,41 +1750,93 @@ export const fetchUserInfo = action({
     // The `default` audience: no organization, no resource — the opaque token
     // Logto's userinfo endpoint accepts. `exposeAccessTokens` does not gate it,
     // because it never leaves this function.
-    const exchanged = await runExchange(ctx, { ...args, includeToken: true });
-    if (exchanged.accessToken === undefined) {
+    const first = await callUserInfo(ctx, args);
+    if (first.ok) return first.profile;
+    // Logto refused the token itself. If it came from the cache, this is the
+    // one caller in the library that *knows* a cached token has stopped
+    // working — and the only one that can act on it. Mint once and retry:
+    // without this, a token Logto has stopped honouring keeps being served for
+    // the rest of its lifetime and every profile fetch fails until it expires.
+    // Bounded to a single extra grant, and only when the first token was
+    // cached: a freshly minted token Logto rejects is a deployment fault, and
+    // minting again would spend grants on it forever.
+    if (!first.tokenRejected || first.minted) {
       throw transient(
-        "no_userinfo_token",
-        "Could not obtain an access token for Logto's userinfo endpoint.",
+        "userinfo_failed",
+        `Logto's userinfo endpoint answered ${first.status}.`,
       );
     }
-    const controller = new AbortController();
-    const timeout = setTimeout(() => {
-      controller.abort();
-    }, TOKEN_ENDPOINT_TIMEOUT_MS);
-    try {
-      const res = await fetch(buildLogtoEndpointUrl(args.endpoint, "me"), {
-        headers: { Authorization: `Bearer ${exchanged.accessToken}` },
-        signal: controller.signal,
-      });
-      const body = await readBoundedBody(res, MAX_TOKEN_RESPONSE_BYTES);
-      if (!res.ok || !body.ok) {
-        throw transient(
-          "userinfo_failed",
-          `Logto's userinfo endpoint answered ${res.status}.`,
-        );
-      }
-      return JSON.parse(tokenResponseDecoder.decode(body.bytes)) as unknown;
-    } catch (error) {
-      if (error instanceof ConvexError) throw error;
-      throw transient(
-        "logto_unreachable",
-        "Could not reach Logto's userinfo endpoint.",
-      );
-    } finally {
-      clearTimeout(timeout);
-    }
+    const second = await callUserInfo(ctx, { ...args, forceRefresh: true });
+    if (second.ok) return second.profile;
+    throw transient(
+      "userinfo_failed",
+      `Logto's userinfo endpoint answered ${second.status}, ` +
+        "including for a freshly minted token.",
+    );
   },
 });
+
+type UserInfoAttempt =
+  | { ok: true; profile: unknown }
+  | { ok: false; status: number; tokenRejected: boolean; minted: boolean };
+
+/** One exchange plus one `/oidc/me` call. */
+async function callUserInfo(
+  ctx: GenericActionCtx<DataModel>,
+  args: ExchangeArgs,
+): Promise<UserInfoAttempt> {
+  const exchanged = await runExchange(ctx, { ...args, includeToken: true });
+  if (exchanged.accessToken === undefined) {
+    throw transient(
+      "no_userinfo_token",
+      "Could not obtain an access token for Logto's userinfo endpoint.",
+    );
+  }
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort();
+  }, TOKEN_ENDPOINT_TIMEOUT_MS);
+  let payload: string;
+  try {
+    const res = await fetch(buildLogtoEndpointUrl(args.endpoint, "me"), {
+      headers: { Authorization: `Bearer ${exchanged.accessToken}` },
+      signal: controller.signal,
+    });
+    const body = await readBoundedBody(res, MAX_TOKEN_RESPONSE_BYTES);
+    if (!res.ok || !body.ok) {
+      return {
+        ok: false,
+        status: res.status,
+        // 401 is "this credential is not acceptable" and 403 is "it is, but it
+        // does not authorize this" — Logto answers the second for a token
+        // whose scopes no longer cover the profile. Both are answers about the
+        // token, and both are worth one fresh mint. A 5xx is not.
+        tokenRejected: res.status === 401 || res.status === 403,
+        minted: exchanged.minted,
+      };
+    }
+    payload = tokenResponseDecoder.decode(body.bytes);
+  } catch (error) {
+    if (error instanceof ConvexError) throw error;
+    throw transient(
+      "logto_unreachable",
+      "Could not reach Logto's userinfo endpoint.",
+    );
+  } finally {
+    clearTimeout(timeout);
+  }
+  // Parsed outside the network `try`: a body that is not JSON is a deployment
+  // answering wrongly, not an unreachable one, and folding it into
+  // "could not reach Logto" sends the reader looking at the network.
+  try {
+    return { ok: true, profile: JSON.parse(payload) as unknown };
+  } catch {
+    throw transient(
+      "userinfo_malformed",
+      "Logto's userinfo endpoint answered with something that is not JSON.",
+    );
+  }
+}
 
 // --- sign-out ---------------------------------------------------------------
 

--- a/packages/convex-logto/src/component/lib.ts
+++ b/packages/convex-logto/src/component/lib.ts
@@ -486,7 +486,17 @@ async function tokenEndpoint(
     }
     const error =
       isRecord(body) && typeof body.error === "string" ? body.error : undefined;
-    if (!res.ok) throw classifyTokenEndpointFailure(res.status, { error });
+    // Logto names the missing scope in a `scope` field beside the error. It is
+    // the difference between "insufficient_scope" and a message that says which
+    // option to add, so it is worth carrying the extra field.
+    const scope =
+      isRecord(body) && typeof body.scope === "string" ? body.scope : undefined;
+    if (!res.ok) {
+      throw classifyTokenEndpointFailure(res.status, {
+        ...(error === undefined ? {} : { error }),
+        ...(scope === undefined ? {} : { scope }),
+      });
+    }
     if (!parsed || !isRecord(body)) return { tokenResponse: false };
     return {
       tokenResponse: true,

--- a/packages/convex-logto/src/native-session.tsx
+++ b/packages/convex-logto/src/native-session.tsx
@@ -27,7 +27,10 @@ import {
 } from "./native-session-client";
 import type { LogtoUserClaims } from "./claims";
 import type { LogtoAuthEventHandler } from "./auth-events";
-import { SessionAuthEngine } from "./session-client";
+import {
+  SessionAuthEngine,
+  type LogtoTokenExchangeOptions,
+} from "./session-client";
 import { defaultSessionTransport } from "./session-transport";
 import type {
   LogtoResourceTokenClaims,
@@ -349,6 +352,7 @@ export type LogtoSessionAuth = {
   getOrganizationTokenClaims: (
     organizationId: string,
     scopes?: string[],
+    options?: LogtoTokenExchangeOptions,
   ) => Promise<LogtoResourceTokenClaims>;
   /**
    * What a Resource token authorizes. The resource must be listed in
@@ -358,6 +362,7 @@ export type LogtoSessionAuth = {
   getAccessTokenClaims: (
     resource: string,
     scopes?: string[],
+    options?: LogtoTokenExchangeOptions,
   ) => Promise<LogtoResourceTokenClaims>;
   /**
    * The Organization token *string*, for a caller that must reach a non-Convex
@@ -367,14 +372,19 @@ export type LogtoSessionAuth = {
   getOrganizationToken: (
     organizationId: string,
     scopes?: string[],
+    options?: LogtoTokenExchangeOptions,
   ) => Promise<string>;
   /** The Resource token *string*, under the same `exposeAccessTokens` gate. */
-  getAccessToken: (resource: string, scopes?: string[]) => Promise<string>;
+  getAccessToken: (
+    resource: string,
+    scopes?: string[],
+    options?: LogtoTokenExchangeOptions,
+  ) => Promise<string>;
   /**
    * Logto's live profile (`/oidc/me`), fetched by the component. A round trip,
    * unlike `user`, which is the copy the last ID token froze.
    */
-  fetchUserInfo: () => Promise<unknown>;
+  fetchUserInfo: (options?: LogtoTokenExchangeOptions) => Promise<unknown>;
 };
 
 export function useLogtoAuth(): LogtoSessionAuth {
@@ -417,26 +427,41 @@ export function useLogtoAuth(): LogtoSessionAuth {
   );
   const getIdToken = useCallback(() => engine.getIdToken(), [engine]);
   const getOrganizationTokenClaims = useCallback(
-    (organizationId: string, scopes?: string[]) =>
-      engine.getOrganizationTokenClaims(organizationId, scopes),
+    (
+      organizationId: string,
+      scopes?: string[],
+      options?: LogtoTokenExchangeOptions,
+    ) => engine.getOrganizationTokenClaims(organizationId, scopes, options),
     [engine],
   );
   const getAccessTokenClaims = useCallback(
-    (resource: string, scopes?: string[]) =>
-      engine.getAccessTokenClaims(resource, scopes),
+    (
+      resource: string,
+      scopes?: string[],
+      options?: LogtoTokenExchangeOptions,
+    ) => engine.getAccessTokenClaims(resource, scopes, options),
     [engine],
   );
   const getOrganizationToken = useCallback(
-    (organizationId: string, scopes?: string[]) =>
-      engine.getOrganizationToken(organizationId, scopes),
+    (
+      organizationId: string,
+      scopes?: string[],
+      options?: LogtoTokenExchangeOptions,
+    ) => engine.getOrganizationToken(organizationId, scopes, options),
     [engine],
   );
   const getAccessToken = useCallback(
-    (resource: string, scopes?: string[]) =>
-      engine.getAccessToken(resource, scopes),
+    (
+      resource: string,
+      scopes?: string[],
+      options?: LogtoTokenExchangeOptions,
+    ) => engine.getAccessToken(resource, scopes, options),
     [engine],
   );
-  const fetchUserInfo = useCallback(() => engine.fetchUserInfo(), [engine]);
+  const fetchUserInfo = useCallback(
+    (options?: LogtoTokenExchangeOptions) => engine.fetchUserInfo(options),
+    [engine],
+  );
   return useMemo(
     () => ({
       isAuthenticated,
@@ -489,5 +514,8 @@ export type {
   LogtoSessionClientDescriptor,
   LogtoSessionSummary,
 } from "./session";
-export type { SessionSignOutServerStatus } from "./session-client";
+export type {
+  LogtoTokenExchangeOptions,
+  SessionSignOutServerStatus,
+} from "./session-client";
 export { SessionSignOutError } from "./session-client";

--- a/packages/convex-logto/src/react-session.tsx
+++ b/packages/convex-logto/src/react-session.tsx
@@ -22,6 +22,7 @@ import {
 import {
   SessionAuthEngine,
   SessionStorageArea,
+  type LogtoTokenExchangeOptions,
   type TokenStorageKind,
 } from "./session-client";
 import { defaultSessionTransport } from "./session-transport";
@@ -497,6 +498,7 @@ export type LogtoSessionAuth = {
   getOrganizationTokenClaims: (
     organizationId: string,
     scopes?: string[],
+    options?: LogtoTokenExchangeOptions,
   ) => Promise<LogtoResourceTokenClaims>;
   /**
    * What a Resource token authorizes. The resource must be listed in
@@ -506,6 +508,7 @@ export type LogtoSessionAuth = {
   getAccessTokenClaims: (
     resource: string,
     scopes?: string[],
+    options?: LogtoTokenExchangeOptions,
   ) => Promise<LogtoResourceTokenClaims>;
   /**
    * The Organization token *string*, for a caller that must reach a non-Convex
@@ -515,14 +518,19 @@ export type LogtoSessionAuth = {
   getOrganizationToken: (
     organizationId: string,
     scopes?: string[],
+    options?: LogtoTokenExchangeOptions,
   ) => Promise<string>;
   /** The Resource token *string*, under the same `exposeAccessTokens` gate. */
-  getAccessToken: (resource: string, scopes?: string[]) => Promise<string>;
+  getAccessToken: (
+    resource: string,
+    scopes?: string[],
+    options?: LogtoTokenExchangeOptions,
+  ) => Promise<string>;
   /**
    * Logto's live profile (`/oidc/me`), fetched by the component. A round trip,
    * unlike `user`, which is the copy the last ID token froze.
    */
-  fetchUserInfo: () => Promise<unknown>;
+  fetchUserInfo: (options?: LogtoTokenExchangeOptions) => Promise<unknown>;
 };
 
 /**
@@ -567,26 +575,41 @@ export function useLogtoAuth(): LogtoSessionAuth {
   );
   const getIdToken = useCallback(() => engine.getIdToken(), [engine]);
   const getOrganizationTokenClaims = useCallback(
-    (organizationId: string, scopes?: string[]) =>
-      engine.getOrganizationTokenClaims(organizationId, scopes),
+    (
+      organizationId: string,
+      scopes?: string[],
+      options?: LogtoTokenExchangeOptions,
+    ) => engine.getOrganizationTokenClaims(organizationId, scopes, options),
     [engine],
   );
   const getAccessTokenClaims = useCallback(
-    (resource: string, scopes?: string[]) =>
-      engine.getAccessTokenClaims(resource, scopes),
+    (
+      resource: string,
+      scopes?: string[],
+      options?: LogtoTokenExchangeOptions,
+    ) => engine.getAccessTokenClaims(resource, scopes, options),
     [engine],
   );
   const getOrganizationToken = useCallback(
-    (organizationId: string, scopes?: string[]) =>
-      engine.getOrganizationToken(organizationId, scopes),
+    (
+      organizationId: string,
+      scopes?: string[],
+      options?: LogtoTokenExchangeOptions,
+    ) => engine.getOrganizationToken(organizationId, scopes, options),
     [engine],
   );
   const getAccessToken = useCallback(
-    (resource: string, scopes?: string[]) =>
-      engine.getAccessToken(resource, scopes),
+    (
+      resource: string,
+      scopes?: string[],
+      options?: LogtoTokenExchangeOptions,
+    ) => engine.getAccessToken(resource, scopes, options),
     [engine],
   );
-  const fetchUserInfo = useCallback(() => engine.fetchUserInfo(), [engine]);
+  const fetchUserInfo = useCallback(
+    (options?: LogtoTokenExchangeOptions) => engine.fetchUserInfo(options),
+    [engine],
+  );
   return useMemo(
     () => ({
       isAuthenticated,
@@ -637,5 +660,8 @@ export type {
   LogtoSessionClientDescriptor,
   LogtoSessionSummary,
 } from "./session";
-export type { TokenStorageKind } from "./session-client";
+export type {
+  LogtoTokenExchangeOptions,
+  TokenStorageKind,
+} from "./session-client";
 export type { LogtoSessionCookieTransportOptions } from "./session-cookie";

--- a/packages/convex-logto/src/session-client.test.ts
+++ b/packages/convex-logto/src/session-client.test.ts
@@ -2451,6 +2451,62 @@ describe("token exchange", () => {
     });
   });
 
+  it("forwards forceRefresh, and omits it entirely when unasked", async () => {
+    // Omitted rather than sent as `false`: the arg is optional on the action,
+    // and a client that always sent it would make every existing call look
+    // like a deliberate cache decision in the deployment's logs.
+    const harness = makeHarness({
+      storedSession: { token: "session-token", sessionId: "session-1" },
+      storedIdToken: freshToken(),
+    });
+    harness.engine.start();
+    await settled(harness.engine);
+    harness.handlers.exchangeToken.mockResolvedValue({
+      claims: {
+        audience: "organization:org-1",
+        scopes: [],
+        expiresAt: 5_000_000,
+      },
+      minted: true,
+    });
+
+    await harness.engine.getOrganizationTokenClaims("org-1");
+    expect(harness.handlers.exchangeToken).toHaveBeenLastCalledWith({
+      sessionToken: "session-token",
+      organizationId: "org-1",
+    });
+
+    await harness.engine.getOrganizationTokenClaims("org-1", undefined, {
+      forceRefresh: true,
+    });
+    expect(harness.handlers.exchangeToken).toHaveBeenLastCalledWith({
+      sessionToken: "session-token",
+      organizationId: "org-1",
+      forceRefresh: true,
+    });
+  });
+
+  it("forwards forceRefresh on a profile fetch too", async () => {
+    const harness = makeHarness({
+      storedSession: { token: "session-token", sessionId: "session-1" },
+      storedIdToken: freshToken(),
+    });
+    harness.engine.start();
+    await settled(harness.engine);
+    harness.handlers.fetchUserInfo.mockResolvedValue({ sub: "user-1" });
+
+    await harness.engine.fetchUserInfo();
+    expect(harness.handlers.fetchUserInfo).toHaveBeenLastCalledWith({
+      sessionToken: "session-token",
+    });
+
+    await harness.engine.fetchUserInfo({ forceRefresh: true });
+    expect(harness.handlers.fetchUserInfo).toHaveBeenLastCalledWith({
+      sessionToken: "session-token",
+      forceRefresh: true,
+    });
+  });
+
   it("asks for a resource by indicator, never as an organization", async () => {
     const harness = makeHarness({
       storedSession: { token: "session-token", sessionId: "session-1" },

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -243,6 +243,17 @@ function sessionErrorCode(error: unknown): string | null {
 
 // --- storage -----------------------------------------------------------------
 
+/**
+ * Options every token-exchange method takes.
+ *
+ * `forceRefresh` is the escape hatch for a token the *resource server* has
+ * stopped accepting. The component caches a minted token until it expires, so
+ * without this a rejected one keeps being served for the rest of its lifetime
+ * and the caller has no way to say "not that one". It costs a Logto grant:
+ * reach for it on the failure path, not on every call.
+ */
+export type LogtoTokenExchangeOptions = { forceRefresh?: boolean };
+
 export type StoredSession = { token: string; sessionId: string };
 type StoredTransaction = { state: string };
 type StorageKind = "local" | "session" | "memory";
@@ -1406,8 +1417,15 @@ export class SessionAuthEngine {
   async getOrganizationTokenClaims(
     organizationId: string,
     scopes?: string[],
+    options?: LogtoTokenExchangeOptions,
   ): Promise<LogtoResourceTokenClaims> {
-    return (await this.exchange({ organizationId, scopes })).claims;
+    return (
+      await this.exchange({
+        organizationId,
+        scopes,
+        forceRefresh: options?.forceRefresh,
+      })
+    ).claims;
   }
 
   /**
@@ -1419,8 +1437,15 @@ export class SessionAuthEngine {
   async getAccessTokenClaims(
     resource: string,
     scopes?: string[],
+    options?: LogtoTokenExchangeOptions,
   ): Promise<LogtoResourceTokenClaims> {
-    return (await this.exchange({ resource, scopes })).claims;
+    return (
+      await this.exchange({
+        resource,
+        scopes,
+        forceRefresh: options?.forceRefresh,
+      })
+    ).claims;
   }
 
   /**
@@ -1436,16 +1461,31 @@ export class SessionAuthEngine {
   async getOrganizationToken(
     organizationId: string,
     scopes?: string[],
+    options?: LogtoTokenExchangeOptions,
   ): Promise<string> {
     return this.requireToken(
-      await this.exchange({ organizationId, scopes, includeToken: true }),
+      await this.exchange({
+        organizationId,
+        scopes,
+        includeToken: true,
+        forceRefresh: options?.forceRefresh,
+      }),
     );
   }
 
   /** The Resource token *string*, under the same `exposeAccessTokens` gate. */
-  async getAccessToken(resource: string, scopes?: string[]): Promise<string> {
+  async getAccessToken(
+    resource: string,
+    scopes?: string[],
+    options?: LogtoTokenExchangeOptions,
+  ): Promise<string> {
     return this.requireToken(
-      await this.exchange({ resource, scopes, includeToken: true }),
+      await this.exchange({
+        resource,
+        scopes,
+        includeToken: true,
+        forceRefresh: options?.forceRefresh,
+      }),
     );
   }
 
@@ -1455,7 +1495,7 @@ export class SessionAuthEngine {
    * A round trip, unlike `user`: this is the live profile from Logto rather
    * than the copy the last ID token froze. Use it after a profile edit.
    */
-  async fetchUserInfo(): Promise<unknown> {
+  async fetchUserInfo(options?: LogtoTokenExchangeOptions): Promise<unknown> {
     const action = this.options.api.fetchUserInfo;
     if (action === undefined) throw sessionApiUpgradeError("fetchUserInfo");
     const credential = await this.sessionCallCredential("fetchUserInfo");
@@ -1464,7 +1504,12 @@ export class SessionAuthEngine {
     return await this.withLock(() =>
       this.retrying(() =>
         this.callSessionAction("fetchUserInfo", () =>
-          this.options.transport.action(action, credential),
+          this.options.transport.action(action, {
+            ...credential,
+            ...(options?.forceRefresh === undefined
+              ? {}
+              : { forceRefresh: options.forceRefresh }),
+          }),
         ),
       ),
     );
@@ -1475,6 +1520,7 @@ export class SessionAuthEngine {
     resource?: string;
     scopes?: string[];
     includeToken?: boolean;
+    forceRefresh?: boolean;
   }): Promise<{
     claims: LogtoResourceTokenClaims;
     accessToken?: string;
@@ -1505,6 +1551,7 @@ export class SessionAuthEngine {
       resource?: string;
       scopes?: string[];
       includeToken?: boolean;
+      forceRefresh?: boolean;
     },
   ): Promise<{
     claims: LogtoResourceTokenClaims;
@@ -1522,6 +1569,9 @@ export class SessionAuthEngine {
         ...(args.includeToken === undefined
           ? {}
           : { includeToken: args.includeToken }),
+        ...(args.forceRefresh === undefined
+          ? {}
+          : { forceRefresh: args.forceRefresh }),
       }),
     );
   }

--- a/packages/convex-logto/src/session-cookie.test.ts
+++ b/packages/convex-logto/src/session-cookie.test.ts
@@ -1582,6 +1582,36 @@ describe("tokens route", () => {
     });
   });
 
+  it("forwards forceRefresh on both ops", async () => {
+    // The cookie transport is the one path where the browser cannot pass an
+    // argument straight through: every field has to be named on both sides. A
+    // dropped `forceRefresh` would silently serve the cached token the caller
+    // just told the library not to trust.
+    const { handler, handlers } = makeHarness();
+    await handler(
+      request("tokens", {
+        cookie: cookie("session-token-1"),
+        body: { op: "exchange", organizationId: "org-1", forceRefresh: true },
+      }),
+    );
+    expect(handlers.exchangeToken).toHaveBeenCalledWith({
+      sessionToken: "session-token-1",
+      organizationId: "org-1",
+      forceRefresh: true,
+    });
+
+    await handler(
+      request("tokens", {
+        cookie: cookie("session-token-1"),
+        body: { op: "userinfo", forceRefresh: true },
+      }),
+    );
+    expect(handlers.fetchUserInfo).toHaveBeenCalledWith({
+      sessionToken: "session-token-1",
+      forceRefresh: true,
+    });
+  });
+
   it("refuses without the session cookie", async () => {
     const { handler, handlers } = makeHarness();
     const response = await handler(
@@ -1673,5 +1703,41 @@ describe("browser transport token exchange", () => {
     await expect(
       transport.action(api.fetchUserInfo!, { sessionToken: "ignored" }),
     ).resolves.toEqual({ sub: "user-1", name: "Ada" });
+  });
+
+  it("carries forceRefresh across the transport, for both calls", async () => {
+    // End to end through the real route: the browser half has to *name* the
+    // field to send it, and the server half has to name it again to forward
+    // it. Two places to drop it, so this asserts what the app action received.
+    const { handler, handlers } = makeHarness();
+    const transport = createLogtoSessionCookieTransport(api, {
+      endpoint: `${APP_ORIGIN}${BASE_PATH}`,
+      fetch: (input, init) => {
+        const forwarded = new Request(input as string, init);
+        forwarded.headers.set("Origin", APP_ORIGIN);
+        forwarded.headers.set("Cookie", cookie("session-token-1"));
+        return handler(forwarded);
+      },
+    });
+
+    await transport.action(api.exchangeToken!, {
+      sessionToken: "ignored",
+      organizationId: "org-1",
+      forceRefresh: true,
+    });
+    expect(handlers.exchangeToken).toHaveBeenLastCalledWith({
+      sessionToken: "session-token-1",
+      organizationId: "org-1",
+      forceRefresh: true,
+    });
+
+    await transport.action(api.fetchUserInfo!, {
+      sessionToken: "ignored",
+      forceRefresh: true,
+    });
+    expect(handlers.fetchUserInfo).toHaveBeenLastCalledWith({
+      sessionToken: "session-token-1",
+      forceRefresh: true,
+    });
   });
 });

--- a/packages/convex-logto/src/session-cookie.ts
+++ b/packages/convex-logto/src/session-cookie.ts
@@ -860,12 +860,14 @@ export function createLogtoSessionCookieHandler(
             const resource = optionalDisplayString(body, "resource");
             const scopes = optionalStringArray(body, "scopes");
             const includeToken = optionalBoolean(body, "includeToken");
+            const forceRefresh = optionalBoolean(body, "forceRefresh");
             return jsonResponse(
               await options.action(exchangeToken, {
                 sessionToken,
                 ...(organizationId === undefined ? {} : { organizationId }),
                 ...(resource === undefined ? {} : { resource }),
                 ...(scopes === undefined ? {} : { scopes }),
+                ...(forceRefresh === undefined ? {} : { forceRefresh }),
                 // Forwarded as asked. Whether it is *allowed* is the app
                 // action's decision (`exposeAccessTokens` on
                 // `logtoSessionApi`), and duplicating that gate here would
@@ -881,8 +883,12 @@ export function createLogtoSessionCookieHandler(
             if (fetchUserInfo === undefined) {
               return sessionManagementUnavailable("fetchUserInfo", origin);
             }
+            const forceRefresh = optionalBoolean(body, "forceRefresh");
             return jsonResponse(
-              await options.action(fetchUserInfo, { sessionToken }),
+              await options.action(fetchUserInfo, {
+                sessionToken,
+                ...(forceRefresh === undefined ? {} : { forceRefresh }),
+              }),
               {},
               origin,
             );
@@ -1264,11 +1270,13 @@ function readExchangeArgs(args: Record<string, unknown>): {
   resource?: string;
   scopes?: string[];
   includeToken?: boolean;
+  forceRefresh?: boolean;
 } {
   const organizationId = args["organizationId"];
   const resource = args["resource"];
   const scopes = args["scopes"];
   const includeToken = args["includeToken"];
+  const forceRefresh = args["forceRefresh"];
   return {
     ...(typeof organizationId === "string" ? { organizationId } : {}),
     ...(typeof resource === "string" ? { resource } : {}),
@@ -1277,6 +1285,7 @@ function readExchangeArgs(args: Record<string, unknown>): {
       ? { scopes }
       : {}),
     ...(typeof includeToken === "boolean" ? { includeToken } : {}),
+    ...(typeof forceRefresh === "boolean" ? { forceRefresh } : {}),
   };
 }
 
@@ -1558,7 +1567,11 @@ export function createLogtoSessionCookieTransport(
         actionNames.fetchUserInfo !== undefined &&
         actionName === actionNames.fetchUserInfo
       ) {
-        return await post("tokens", { op: "userinfo" });
+        const forceRefresh = args["forceRefresh"];
+        return await post("tokens", {
+          op: "userinfo",
+          ...(typeof forceRefresh === "boolean" ? { forceRefresh } : {}),
+        });
       }
       throw new Error(
         "convex-logto: the cookie transport received an unknown session action.",

--- a/packages/convex-logto/src/session.test.ts
+++ b/packages/convex-logto/src/session.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { ORGANIZATIONS_SCOPE } from "./claims";
 import {
   assertSubjectHasActiveSession,
   assertUserHasActiveSession,
@@ -202,11 +203,18 @@ describe("logtoSessionApi exchangeToken", () => {
     minted: boolean;
   }>;
 
+  /**
+   * `scopes` carries the organization scope by default because an organization
+   * exchange is refused without it — Logto answers `403 insufficient_scope`,
+   * and no retry can fix a grant that is already signed. Tests about *that*
+   * rule pass their own `scopes`.
+   */
   function handlerFor(options: Record<string, unknown> = {}) {
     const api = logtoSessionApi(component, {
       endpoint: "https://auth.example.com",
       appId: "app-1",
       clientSecret: "secret",
+      scopes: [ORGANIZATIONS_SCOPE],
       ...options,
     });
     return (api.exchangeToken as unknown as Record<string, Handler>)[
@@ -246,6 +254,41 @@ describe("logtoSessionApi exchangeToken", () => {
       includeToken: undefined,
       reuseWindowMs: 321,
     });
+  });
+
+  it("refuses an organization token the grant can never satisfy", async () => {
+    // Measured against a real Logto: without `urn:logto:scope:organizations`
+    // the token endpoint answers `403 insufficient_scope`. Scopes are fixed at
+    // authorization time, so no retry and no `forceRefresh` can rescue an
+    // existing session — and letting it through spends a refresh claim on a
+    // request that cannot work.
+    const runAction = vi.fn();
+    await expect(
+      handlerFor({ scopes: [] })(
+        { runAction },
+        { sessionToken: "session-token", organizationId: "org-1" },
+      ),
+    ).rejects.toMatchObject({
+      data: { kind: "terminal", code: "organizations_scope_missing" },
+    });
+    expect(runAction).not.toHaveBeenCalled();
+  });
+
+  it("does not require that scope for a resource token", async () => {
+    // Resources are named by `resources`, not by the organization scope.
+    const runAction = vi.fn().mockResolvedValue({
+      claims: {
+        audience: "resource:https://api.example.com",
+        scopes: [],
+        expiresAt: 5_000_000,
+      },
+      minted: true,
+    });
+    await handlerFor({ scopes: [] })(
+      { runAction },
+      { sessionToken: "session-token", resource: "https://api.example.com" },
+    );
+    expect(runAction).toHaveBeenCalled();
   });
 
   it("refuses to hand back a token string unless the deployment opted in", async () => {

--- a/packages/convex-logto/src/session.ts
+++ b/packages/convex-logto/src/session.ts
@@ -126,6 +126,7 @@ export type LogtoSessionComponent = {
         resource?: string;
         scopes?: string[];
         includeToken?: boolean;
+        forceRefresh?: boolean;
         reuseWindowMs?: number;
       },
       {
@@ -143,6 +144,7 @@ export type LogtoSessionComponent = {
         clientSecret: string;
         sessionToken: string;
         deviceProof?: string;
+        forceRefresh?: boolean;
         reuseWindowMs?: number;
       },
       unknown
@@ -396,6 +398,7 @@ export type LogtoSessionApi = {
       resource?: string;
       scopes?: string[];
       includeToken?: boolean;
+      forceRefresh?: boolean;
     },
     {
       claims: LogtoResourceTokenClaims;
@@ -406,7 +409,7 @@ export type LogtoSessionApi = {
   fetchUserInfo?: FunctionReference<
     "action",
     "public",
-    { sessionToken: string; deviceProof?: string },
+    { sessionToken: string; deviceProof?: string; forceRefresh?: boolean },
     unknown
   >;
   sessionValid: FunctionReference<
@@ -770,6 +773,7 @@ export function logtoSessionApi(
         resource: v.optional(v.string()),
         scopes: v.optional(v.array(v.string())),
         includeToken: v.optional(v.boolean()),
+        forceRefresh: v.optional(v.boolean()),
       },
       returns: v.object({
         claims: v.object({
@@ -816,6 +820,7 @@ export function logtoSessionApi(
           resource: args.resource,
           scopes: args.scopes,
           includeToken: args.includeToken,
+          forceRefresh: args.forceRefresh,
           reuseWindowMs: options.reuseWindowMs,
         });
       },
@@ -824,6 +829,7 @@ export function logtoSessionApi(
       args: {
         sessionToken: v.string(),
         deviceProof: v.optional(v.string()),
+        forceRefresh: v.optional(v.boolean()),
       },
       returns: v.any(),
       handler: async (ctx, args) => {
@@ -831,6 +837,7 @@ export function logtoSessionApi(
           ...readSessionConfig(options),
           sessionToken: args.sessionToken,
           deviceProof: args.deviceProof,
+          forceRefresh: args.forceRefresh,
           reuseWindowMs: options.reuseWindowMs,
         });
       },

--- a/packages/convex-logto/src/session.ts
+++ b/packages/convex-logto/src/session.ts
@@ -13,6 +13,7 @@ import {
   sessionReuseDetectedError,
 } from "./component/core.js";
 import type { LogtoEndpointPolicy } from "./component/endpoint.js";
+import { ORGANIZATIONS_SCOPE } from "./claims";
 import { readEndpointAndAppId } from "./config";
 
 const sessionSummaryValidator = v.object({
@@ -796,6 +797,26 @@ export function logtoSessionApi(
             code: "missing_token_target",
             message:
               "convex-logto: pass an organizationId or a resource to exchangeToken.",
+          });
+        }
+        if (
+          args.organizationId !== undefined &&
+          !(options.scopes ?? []).includes(ORGANIZATIONS_SCOPE)
+        ) {
+          // Logto answers `403 insufficient_scope` for this, and scopes are
+          // fixed at authorization time — so no retry, no `forceRefresh` and no
+          // amount of waiting can make it succeed for a session that already
+          // exists. Refusing here costs the caller nothing; letting it through
+          // spends a refresh claim on a request that cannot work.
+          throw new ConvexError({
+            kind: "terminal" as const,
+            code: "organizations_scope_missing",
+            message:
+              "convex-logto: an organization token needs the " +
+              `${ORGANIZATIONS_SCOPE} scope in the grant. Add it to ` +
+              "`logtoSessionApi({ scopes })` and sign in again — a grant " +
+              "cannot be widened in place. Membership and roles need no token " +
+              "at all; they are already in the ID token.",
           });
         }
         if (args.includeToken && !options.exposeAccessTokens) {


### PR DESCRIPTION
Two rounds of work on the token exchange, both found by asking a **live** Logto what it actually does — the second through the component rather than raw OIDC (`e2e/probe-exchange.mjs`, new here).

## 1. A 403 deleted sessions

Ask Logto for an Organization token on a grant that never requested `urn:logto:scope:organizations`:

```
403 {"error":"insufficient_scope",
     "error_description":"refresh token missing required scope",
     "scope":"urn:logto:scope:organizations"}
```

`classifyTokenEndpointFailure` treated only `400` and `401` as answers Logto had actually decided, so this fell through to **outcome unknown** — which keeps the refresh claim on purpose, because an unknown outcome may have rotated the token.

Measured consequence: every later refresh on that session answered `refresh_in_flight`, and when the claim aged out the session was **deleted**. One missing scope in a deployment's config, every user signed out. That is precisely the failure the *"a deployment misconfiguration must be transient"* invariant exists to prevent.

- `403` joins `400`/`401` as a decision.
- `insufficient_scope` joins the configuration faults — transient, sessions kept, message naming the scope and where to add it.
- `logtoSessionApi` refuses an organization exchange it can already see cannot work, before it spends a claim.

Verified live: the call now fails immediately with an actionable message, and `fetchUserInfo` — which goes through the same claim — succeeds straight afterwards. Before, it did not.

`invalid_scope` shared the generic configuration-fault message, which sent readers to check `LOGTO_APP_ID` / `LOGTO_CLIENT_SECRET` / `LOGTO_ENDPOINT` — the wrong three things for a scope. It now names the scope and the subset rule.

## 2. An organization token's `scopes` is always empty

The api-reference's headline example was:

```ts
const { scopes } = await getOrganizationTokenClaims("org-id");
if (scopes.includes("invoice:delete")) { /* ... */ }
```

That check **denies everyone**. Logto issues `availableScopes ∩ requestedScopes`, where the requested set defaults to the grant's own scopes — and organization permissions are not OIDC scopes at all (absent from `scopes_supported`, so the authorize request drops them and they can never be in a grant). Asking for one explicitly is refused by the subset check above it.

Measured three ways, and Logto's own source says the same:

```js
const scope = params.scope ? requestParamScopes : refreshToken.scopes;
const issuedScopes = availableScopes.filter((name) => scope.has(name)).join(" ");
```

The docs now show a **Resource** token, whose scopes do work, and warn about the organization case; ADR 0003 records the measurement. Authorization on organizations belongs on `organization_roles` from the ID token — free, already there, and what `assertOrganizationRole` reads.

## 3. `forceRefresh` (the original scope of this PR)

The component caches a minted token until it expires, which left no way out of the case the cache exists to make cheap: **a token the resource server has stopped accepting.** Every token method now takes a final `{ forceRefresh: true }`, threaded through the app action, the component action, the browser engine and the cookie route.

`fetchUserInfo` does the retry itself — it is the one caller inside the library that consumes a minted token. `401`/`403` on a **cached** token → mint once, retry. The same answer on a token it **just minted** → no retry (deployment fault). A `5xx` → no retry (says nothing about the token).

## Verification

- Every new guard checked by disabling it and watching a specific test go red.
- `683` tests pass (up from 667 at the start of the day); `lint`, `format:check`, `check-types`, `build`, `lint:package`, `audit:dependencies` green.
- `src/component/_generated/component.ts` regenerated with `convex codegen`.
- All seven live `session-flow.mjs` steps still pass against a real Logto.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to force-refresh cached tokens during token exchange and user information requests.
  * Added automatic retry with a newly minted token after cached-token 401 or 403 responses.
  * Extended refresh controls across native, React, browser, and server session APIs.

* **Bug Fixes**
  * Improved handling of malformed user-information responses and token endpoint errors.
  * Added clearer handling for unsupported organization-token requests.

* **Documentation**
  * Clarified organization-token authorization guidance, refresh options, and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->