### PR TITLE
fix(session): the SSR ID token cookie outlived the session it belonged to

### DIFF
--- a/.changeset/id-token-cookie-clearing.md
+++ b/.changeset/id-token-cookie-clearing.md
@@ -1,0 +1,21 @@
+---
+"convex-logto": patch
+---
+
+Expire the SSR ID token cookie on every exit that expires the session cookie.
+
+`idTokenCookie: true` writes the ID token to `__Host-convex-logto-id-token`, and
+sign-out cleared it — but only on the success path. Three exits cleared the
+session cookie and left the ID token behind: a sign-out the deployment could not
+complete, a sign-out whose body never parsed, and a terminal `/token` refresh,
+which is what a revoked, reused or deleted session looks like.
+
+Neither cookie is reachable from JavaScript, so nothing on the client could
+finish the job. The browser went on handing a signed-in identity to every server
+render until the token's own `Max-Age` ran out — up to its full lifetime, and on
+a shared computer that is the previous user's identity rendered into the next
+visitor's HTML. Both cookies are now expired together, whatever the exit.
+
+`readLogtoIdTokenCookie` also checks `exp` itself now. The cookie's `Max-Age`
+already comes from the token's `exp`, but that is the browser's guarantee, and a
+`Cookie` header replayed from a cache or a proxy does not arrive behind one.

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -244,10 +244,12 @@ const token = readLogtoIdTokenCookie(await cookies());
 const preloaded = await preloadQuery(api.me.me, {}, token ? { token } : {});
 ```
 
-Returns `null` when the cookie is absent — including once the token has expired,
-because the cookie's `Max-Age` comes from the token's own `exp`. A cookie that
-outlived its token would server-render a page as signed in for a bearer Convex
-refuses.
+Returns `null` when the cookie is absent, and when the token has expired. The
+cookie's `Max-Age` comes from the token's own `exp`, so a browser stops sending
+an expired one on its own; the read checks `exp` as well, because a `Cookie`
+header replayed from a cache or a proxy is not behind that guarantee. A token
+that outlived its cookie would server-render a page as signed in for a bearer
+Convex refuses.
 
 This mints nothing and rotates nothing, so it costs the session token's
 rotation-based theft detection nothing. What it does cost is custody: a cookie
@@ -259,9 +261,11 @@ everywhere else.
 
 An ID token that is already expired, is not a JWT, or is too large for a cookie
 (over 3 KiB encoded) is **skipped rather than cleared** — the previous cookie
-expires on its own instead of a size problem becoming a sign-out. Sign-out clears
-it unconditionally, even when the option is off, so turning it off never strands
-a live token.
+expires on its own instead of a size problem becoming a sign-out. Every exit that
+expires the session cookie expires this one with it: sign-out on success *and* on
+failure, and a terminal `/token` refresh. That holds even when `idTokenCookie` is
+off, so turning it off never strands a live token. Neither cookie is reachable
+from JavaScript, so a half-cleared pair is one nothing on the client can finish.
 
 Cookie transport and device binding cannot be combined: HttpOnly makes the
 session token unavailable to the JavaScript-held signing key, and cookie

--- a/packages/convex-logto/src/session-cookie.test.ts
+++ b/packages/convex-logto/src/session-cookie.test.ts
@@ -1528,6 +1528,18 @@ describe("SSR ID token cookie", () => {
     ).toBe(idToken);
   });
 
+  it("reads null for a token that outlived its cookie", () => {
+    // The cookie's own Max-Age normally handles this, but that is the browser's
+    // guarantee and this read is not always behind one — a replayed or cached
+    // Cookie header would otherwise render the page signed in for a bearer
+    // Convex refuses.
+    for (const value of [tokenExpiringIn(-1), tokenExpiringIn(-3600), "nope"]) {
+      const header = `${LOGTO_ID_TOKEN_COOKIE_NAME}=${encodeURIComponent(value)}`;
+      expect(readLogtoIdTokenCookie(header)).toBeNull();
+      expect(readLogtoIdTokenCookie({ get: () => ({ value }) })).toBeNull();
+    }
+  });
+
   it("reads null when the cookie is absent or empty", () => {
     expect(readLogtoIdTokenCookie("")).toBeNull();
     expect(
@@ -1535,6 +1547,69 @@ describe("SSR ID token cookie", () => {
     ).toBeNull();
     expect(readLogtoIdTokenCookie({ get: () => undefined })).toBeNull();
     expect(readLogtoIdTokenCookie({ get: () => ({ value: "" }) })).toBeNull();
+  });
+
+  // Every exit that expires the session cookie has to expire this one with it.
+  // Neither is reachable from JavaScript, so a half-cleared pair cannot be
+  // finished by anything on the client: the browser keeps handing a signed-in
+  // identity to every server render until the token's own `Max-Age` runs out —
+  // on a shared computer, into the next visitor's HTML.
+  it("is expired by every exit that expires the session cookie", async () => {
+    const idToken = tokenExpiringIn(3600);
+    const expired = [
+      `${LOGTO_SESSION_COOKIE_NAME}=; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0`,
+      `${LOGTO_ID_TOKEN_COOKIE_NAME}=; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=0`,
+    ];
+
+    // 1. A terminal refresh. The session is gone for good, which is exactly when
+    //    a surviving ID token has the longest run — up to its full lifetime.
+    const terminal = makeHarness({ idTokenCookie: true, idToken });
+    terminal.handlers.refresh.mockRejectedValueOnce(
+      new ConvexError({
+        kind: "terminal",
+        code: "session_not_found",
+        message: "gone",
+      }),
+    );
+    const afterTerminal = await terminal.handler(
+      request("token", { cookie: cookie("spent") }),
+    );
+    expect(afterTerminal.status).toBe(401);
+    expect(afterTerminal.headers.getSetCookie()).toEqual(expired);
+
+    // 2. A sign-out the deployment could not complete. The route clears on every
+    //    exit precisely because rejecting the request is not a reason to keep the
+    //    session alive — and the ID token is part of that session.
+    const failing = makeHarness({ idTokenCookie: true, idToken });
+    failing.handlers.signOut.mockRejectedValueOnce(
+      new ConvexError({
+        kind: "transient",
+        code: "logto_unreachable",
+        message: "down",
+      }),
+    );
+    const afterFailedSignOut = await failing.handler(
+      request("sign-out", { cookie: cookie("session-token-2") }),
+    );
+    expect(afterFailedSignOut.status).toBe(503);
+    expect(afterFailedSignOut.headers.getSetCookie()).toEqual(expired);
+
+    // 3. A sign-out whose body never parsed. Same rule, earlier exit.
+    const malformed = makeHarness({ idTokenCookie: true, idToken });
+    const afterMalformed = await malformed.handler(
+      new Request(`${APP_ORIGIN}${BASE_PATH}/sign-out`, {
+        method: "POST",
+        headers: {
+          Origin: APP_ORIGIN,
+          "Content-Type": "application/json",
+          Cookie: cookie("session-token-2"),
+          [LOGTO_SESSION_CSRF_HEADER]: LOGTO_SESSION_CSRF_VALUE,
+        },
+        body: "{not json",
+      }),
+    );
+    expect(afterMalformed.status).toBe(400);
+    expect(afterMalformed.headers.getSetCookie()).toEqual(expired);
   });
 });
 

--- a/packages/convex-logto/src/session-cookie.ts
+++ b/packages/convex-logto/src/session-cookie.ts
@@ -295,6 +295,28 @@ function clearCookieHeader(): string {
   );
 }
 
+/**
+ * Expire *both* cookies — the only correct way to end a session over this
+ * transport.
+ *
+ * Clearing the session cookie alone leaves the ID token behind, and neither
+ * cookie can be reached from JavaScript, so nothing on the client can finish the
+ * job: the browser goes on presenting a signed-in identity to every server
+ * render until the token's own `Max-Age` runs out, which is up to its full
+ * lifetime. On a shared computer that is the *previous* user's identity, served
+ * into the next visitor's HTML.
+ *
+ * Both are cleared even when `idTokenCookie` was never enabled: expiring a
+ * cookie that does not exist is inert, and turning the option off must not
+ * strand a live token written while it was on.
+ */
+function clearCookieHeaders(): Headers {
+  const headers = new Headers();
+  headers.append("Set-Cookie", clearCookieHeader());
+  headers.append("Set-Cookie", clearIdTokenCookieHeader());
+  return headers;
+}
+
 function readCookieHeader(header: string | null, name: string): string | null {
   if (!header) return null;
   for (const part of header.split(";")) {
@@ -334,8 +356,8 @@ export type LogtoCookieSource =
  * Read the ID token a route handler stored for server-side rendering.
  *
  * Requires `idTokenCookie: true` on {@link createLogtoSessionCookieHandler};
- * returns `null` otherwise, and whenever the token has expired out of its own
- * cookie. Pair it with Convex's `preloadQuery` / `fetchQuery`:
+ * returns `null` otherwise, and whenever the token has expired. Pair it with
+ * Convex's `preloadQuery` / `fetchQuery`:
  *
  * @example
  * // app/page.tsx — a Server Component, which cannot set cookies
@@ -351,6 +373,10 @@ export type LogtoCookieSource =
 export function readLogtoIdTokenCookie(
   source: LogtoCookieSource,
 ): string | null {
+  return unexpired(rawIdTokenCookie(source));
+}
+
+function rawIdTokenCookie(source: LogtoCookieSource): string | null {
   if (typeof source === "string") {
     return readCookieHeader(source, LOGTO_ID_TOKEN_COOKIE_NAME);
   }
@@ -362,6 +388,20 @@ export function readLogtoIdTokenCookie(
   }
   const entry = source.get(LOGTO_ID_TOKEN_COOKIE_NAME);
   return entry === undefined || entry.value === "" ? null : entry.value;
+}
+
+/**
+ * The cookie's `Max-Age` already comes from the token's own `exp`, so a browser
+ * stops sending an expired one on its own — but that is the *browser's*
+ * guarantee, and this read does not always sit behind one. A `Cookie` header
+ * replayed from a cache, a proxy, or a fixture arrives with whatever lifetime it
+ * was captured with, and an expired token server-renders the page as signed in
+ * for a bearer Convex will refuse. Checking here makes the promise this function
+ * documents its own, instead of one it delegates.
+ */
+function unexpired(idToken: string | null): string | null {
+  if (idToken === null) return null;
+  return idTokenMaxAge(idToken) > 0 ? idToken : null;
 }
 
 function routeFor(request: Request, basePath: string): CookieRoute | null {
@@ -691,12 +731,12 @@ export function createLogtoSessionCookieHandler(
     request: Request,
     origin: string,
   ): Promise<Response> => {
-    // Sign-out must expire the cookie on *every* exit. It is the only credential
-    // in this mode and JavaScript cannot delete it, so a response without this
-    // header leaves the caller signed in while reporting a failure it cannot act
-    // on. Rejecting the request is not a reason to keep the session alive.
-    const clearing =
-      route === "sign-out" ? { "Set-Cookie": clearCookieHeader() } : undefined;
+    // Sign-out must expire the cookies on *every* exit. They are the only
+    // credentials in this mode and JavaScript cannot delete either, so a
+    // response without these headers leaves the caller signed in while reporting
+    // a failure it cannot act on. Rejecting the request is not a reason to keep
+    // the session alive.
+    const clearing = route === "sign-out" ? clearCookieHeaders() : undefined;
 
     const bodyResult = await readJsonObject(request);
     if (!bodyResult.ok) {
@@ -766,12 +806,7 @@ export function createLogtoSessionCookieHandler(
           );
         }
         case "sign-out": {
-          const headers = new Headers();
-          headers.append("Set-Cookie", clearCookieHeader());
-          // Always cleared, even when the companion cookie was never enabled:
-          // turning the option off must not leave a live ID token behind, and a
-          // clear for a cookie that does not exist is inert.
-          headers.append("Set-Cookie", clearIdTokenCookieHeader());
+          const headers = clearCookieHeaders();
           const postLogoutRedirectUri = optionalString(
             body,
             "postLogoutRedirectUri",
@@ -982,7 +1017,7 @@ export function createLogtoSessionCookieHandler(
       const headers =
         clearing ??
         (route === "token" && data?.kind === "terminal"
-          ? { "Set-Cookie": clearCookieHeader() }
+          ? clearCookieHeaders()
           : undefined);
       return actionErrorResponse(error, origin, headers);
     }


### PR DESCRIPTION
## What

`idTokenCookie: true` (shipped in #204) writes the ID token to a second
`HttpOnly` cookie so a Server Component that cannot rotate the session cookie can
still read an identity. Sign-out clears it — but only on the success path.

Three exits cleared `__Host-convex-logto-session` and left
`__Host-convex-logto-id-token` alive:

| exit | before | after |
|---|---|---|
| `sign-out` succeeded | both cleared | both cleared |
| `sign-out` action threw (503) | session only | both |
| `sign-out` body unparseable (400/413) | session only | both |
| terminal `/token` refresh (401) | session only | both |

The sign-out route already clears on *every* exit, deliberately — "rejecting the
request is not a reason to keep the session alive". The ID token is part of that
session; it was just not part of that rule.

## Why it matters

Neither cookie is reachable from JavaScript, so a half-cleared pair is one
nothing on the client can finish. The terminal-`/token` row is the common one: it
is what a revoked, reused, or deleted session looks like. The browser then goes
on handing a signed-in identity to every server render until the token's own
`Max-Age` runs out — up to its full lifetime.

Concretely, with the wiring `docs/nextjs.mdx` recommends:

1. App sets `idTokenCookie: true`; the root layout calls
   `readLogtoIdTokenCookie(await cookies())` and server-renders the signed-in
   shell.
2. User A signs in on a shared computer. `Max-Age` is A's ID token lifetime,
   typically an hour.
3. A's session dies — A revokes it from another device, the account is deleted
   through the webhook, or reuse detection kills the grant.
4. The next `/token` refresh returns terminal. The session cookie is expired; the
   ID token cookie is not.
5. Every server render for the rest of that hour still emits A's identity, into
   whoever is sitting there next.

An app that follows the documented guidance and calls
`assertSubjectHasActiveSession` inside its queries leaks no *data* — but the
rendered shell is still A's, and the cookie is still a live bearer.

## Also

`readLogtoIdTokenCookie` checks `exp` itself now. Its doc comment already
promised `null` for an expired token; that promise was delegated to the browser's
`Max-Age`, and a `Cookie` header replayed from a cache, a proxy, or a fixture
does not arrive behind that guarantee.

## Deliberately unchanged

- The `sessions` route still never clears. Its terminal errors are about the
  *target* session id, so clearing there would sign out the device doing the
  revoking — the bug the existing comment guards against.
- The `tokens` route still never clears. Its terminal errors include
  `organizations_scope_missing`, a deployment configuration gap; clearing there
  would sign every user out over one missing scope.
- An oversized, expired, or non-JWT ID token is still skipped rather than
  cleared, so a size problem does not become a sign-out.

## Tests

One new case per exit (`session-cookie.test.ts`), plus the `exp` read. Both fail
on `main`:

```
- "__Host-convex-logto-session=; …; Max-Age=0",
-   "__Host-convex-logto-id-token=; …; Max-Age=0",   ← missing
```

Full workspace `lint` / `format:check` / `check-types` / `test` (685) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expired or malformed ID-token cookies are now ignored.
  * ID-token cookies are cleared whenever session cookies expire, including failed sign-outs and terminal token refresh errors.
  * Cookie expiration is enforced even when browser `Max-Age` handling is bypassed.

* **Documentation**
  * Updated API documentation to describe ID-token validation and cleanup behavior.

* **Tests**
  * Added coverage for expired, malformed, and failure-related cookie scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->