### PR TITLE
docs(organizations): claims are a snapshot, and the two scopes are independent

### DIFF
--- a/.changeset/organization-claim-snapshot.md
+++ b/.changeset/organization-claim-snapshot.md
@@ -19,5 +19,7 @@ immediately, check your own table instead.
 does not: Logto advertises the two separately in `scopes_supported`, maps each to
 its own claim, and a grant carries exactly what was requested. A deployment that
 followed that advice and requested only the roles scope has no `organizations`
-claim, so every `assertOrganizationMember` call denies — silently, because a
-missing claim is indistinguishable from a user who belongs to nothing.
+claim, so every `assertOrganizationMember` call denies — for everyone, because a
+missing claim is deliberately indistinguishable from a user who belongs to
+nothing. The failure names the missing scope, which is the only thing separating
+this from an unexplained outage.

--- a/.changeset/organization-claim-snapshot.md
+++ b/.changeset/organization-claim-snapshot.md
@@ -1,0 +1,23 @@
+---
+"convex-logto": patch
+---
+
+Say what organization claims actually are, and stop claiming one scope implies
+the other.
+
+`assertOrganizationMember` / `assertOrganizationRole` read the ID token Convex
+already validated, which is what makes them free — and also means they read a
+**snapshot**. The claims were true when the token was issued and stay frozen
+until the next one is, at most the token's own lifetime (Logto's default is an
+hour), so removing someone from an organization or taking a role away does not
+take effect at once. Deleting or suspending the *user* is different: the webhook
+revokes their sessions immediately. Documented on the helpers and in the API
+reference, with the mitigation — when a membership change has to bite
+immediately, check your own table instead.
+
+`ORGANIZATION_ROLES_SCOPE`'s doc claimed it implies `ORGANIZATIONS_SCOPE`. It
+does not: Logto advertises the two separately in `scopes_supported`, maps each to
+its own claim, and a grant carries exactly what was requested. A deployment that
+followed that advice and requested only the roles scope has no `organizations`
+claim, so every `assertOrganizationMember` call denies — silently, because a
+missing claim is indistinguishable from a user who belongs to nothing.

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -310,7 +310,26 @@ A **missing scope authorizes nothing**, not everything: absent and empty are the
 same answer, because a deployment that never requested the scope is
 indistinguishable from a user who belongs to nothing, and only one reading is
 safe. The failure names the scope so a configuration gap does not read as a
-denial.
+denial. The two scopes are independent — Logto advertises them separately and a
+grant carries exactly what was requested — so request **both** if you read both
+claims. A deployment that requests only `urn:logto:scope:organization_roles` has
+no `organizations` claim, and every `assertOrganizationMember` call then denies.
+
+<Callout type="warn">
+**These claims are a snapshot, not a lookup.** They were true when the ID token
+was issued and stay frozen until the next one is — at most the token's own
+lifetime, which Logto defaults to an hour. Removing someone from an organization,
+or taking a role away, does not take effect at once. Nothing re-reads Logto here,
+by design: not re-reading it is what makes the check free.
+
+Deleting or suspending the *user* is different — the
+[webhook](/docs/webhook-sync) revokes their sessions, and that is immediate.
+
+When a membership change has to bite immediately, do not use these helpers for
+it: keep membership in your own table and check that, so the authorization reads
+current state rather than past state. Shortening the ID token's lifetime in Logto
+narrows the window; it never closes it.
+</Callout>
 
 Organization **permissions** are the one part Logto puts nowhere but an
 organization token, audienced `urn:logto:organization:{id}` and typed `at+jwt`,
@@ -353,10 +372,11 @@ and asking for one explicitly is refused (`invalid_scope`, "a refresh grant can
 only request scopes it already holds").
 
 So do not authorize on `getOrganizationTokenClaims(...).scopes` — it would deny
-everyone. Use `organization_roles` from the ID token, which is free and
-authoritative: `assertOrganizationRole(ctx, orgId, ["admin"])` above. The
-organization token is still the right thing to *send* to a service that
-validates the `urn:logto:organization:<id>` audience itself.
+everyone. Use `organization_roles` from the ID token, which is free and actually
+populated: `assertOrganizationRole(ctx, orgId, ["admin"])` above — as of the
+token's issuance, per the note there. The organization token is still the right
+thing to *send* to a service that validates the `urn:logto:organization:<id>`
+audience itself.
 </Callout>
 
 The component mints the token from the Session's Logto refresh token and hands

--- a/docs/content/docs/session-mode.mdx
+++ b/docs/content/docs/session-mode.mdx
@@ -676,12 +676,15 @@ Logto requires *before* sign-in) and `exposeAccessTokens`.
 
 ## Organization and API-resource tokens
 
-Organization membership and roles need nothing here: Logto puts them in the ID
-token, so `user.organizations` and `user.organization_roles` are already in
-every authenticated request, and
+Organization membership and roles need no token here. Request
+`ORGANIZATIONS_SCOPE` and `ORGANIZATION_ROLES_SCOPE` in `logtoSessionApi({
+scopes })` — two independent scopes, so ask for both — and Logto puts the
+matching claims in the ID token. `user.organizations` and
+`user.organization_roles` are then in every authenticated request, and
 [`assertOrganizationRole`](/docs/api-reference#organization-authorization)
 reads them server-side for free — as a snapshot taken when the token was issued,
-which is the one thing to know before authorizing on them.
+which is the one thing to know before authorizing on them. Without the scopes the
+claims are absent, and absent authorizes nothing.
 
 What does need a token is a fine-grained organization **permission**, or a
 non-Convex API you registered with Logto. The component mints those from the

--- a/docs/content/docs/session-mode.mdx
+++ b/docs/content/docs/session-mode.mdx
@@ -680,7 +680,8 @@ Organization membership and roles need nothing here: Logto puts them in the ID
 token, so `user.organizations` and `user.organization_roles` are already in
 every authenticated request, and
 [`assertOrganizationRole`](/docs/api-reference#organization-authorization)
-reads them server-side for free.
+reads them server-side for free — as a snapshot taken when the token was issued,
+which is the one thing to know before authorizing on them.
 
 What does need a token is a fine-grained organization **permission**, or a
 non-Convex API you registered with Logto. The component mints those from the

--- a/packages/convex-logto/src/claims.ts
+++ b/packages/convex-logto/src/claims.ts
@@ -56,7 +56,7 @@ export type LogtoUserClaims = {
 /**
  * Request the `organizations` claim in the ID token.
  *
- * Also what enables the organization *token* grant, so
+ * It also enables the organization *token* grant, so
  * `getOrganizationTokenClaims` needs this scope specifically.
  */
 export const ORGANIZATIONS_SCOPE = "urn:logto:scope:organizations";

--- a/packages/convex-logto/src/claims.ts
+++ b/packages/convex-logto/src/claims.ts
@@ -53,10 +53,24 @@ export type LogtoUserClaims = {
   organization_roles?: string[];
 } & Record<string, unknown>;
 
-/** Request organization membership in the ID token. */
+/**
+ * Request the `organizations` claim in the ID token.
+ *
+ * Also what enables the organization *token* grant, so
+ * `getOrganizationTokenClaims` needs this scope specifically.
+ */
 export const ORGANIZATIONS_SCOPE = "urn:logto:scope:organizations";
 
-/** Request organization roles in the ID token. Implies {@link ORGANIZATIONS_SCOPE}. */
+/**
+ * Request the `organization_roles` claim in the ID token.
+ *
+ * Independent of {@link ORGANIZATIONS_SCOPE}, not implied by it and not implying
+ * it: Logto advertises the two separately in `scopes_supported` and maps each to
+ * its own claim, and a grant carries exactly the scopes that were requested. Ask
+ * for both if you read both claims — a deployment that requests only this one
+ * has no `organizations` claim, and every `assertOrganizationMember` check then
+ * denies.
+ */
 export const ORGANIZATION_ROLES_SCOPE = "urn:logto:scope:organization_roles";
 
 /**

--- a/packages/convex-logto/src/organizations.ts
+++ b/packages/convex-logto/src/organizations.ts
@@ -17,6 +17,19 @@ import {
  * Organization *permissions* are the exception. Logto issues those only in an
  * organization token, audienced `urn:logto:organization:{id}` and typed
  * `at+jwt`, which Convex rejects — see `docs/adr/0002-token-custody.md`.
+ *
+ * **These claims are a snapshot, not a lookup.** They were true when the ID
+ * token was issued and stay frozen until the next one is, which is at most the
+ * token's own lifetime (Logto's default is an hour). Removing a user from an
+ * organization, or taking away a role, therefore does not take effect at once —
+ * nothing here re-reads Logto, by design, because that is what makes the check
+ * free. Deleting or suspending the *user* is different: the webhook in
+ * `convex-logto/webhooks` revokes their sessions, which is immediate.
+ *
+ * When a membership change has to bite immediately, do not reach for these
+ * helpers: keep the membership in your own table and check that, so the
+ * authorization is a read of current state rather than of a past one. Shortening
+ * the ID token's lifetime in Logto narrows the window but never closes it.
  */
 
 /** The slice of a Convex ctx these helpers need. Works in queries, mutations and actions. */


### PR DESCRIPTION
Two corrections to the organization authorization surface shipped in #201/#209.
No behavior change; both are things a reader would otherwise get wrong.

## 1. The claims are a snapshot, and nothing said so

`assertOrganizationMember` / `assertOrganizationRole` read the ID token Convex
already validated. That is exactly what makes them free — and it also means they
read state as of *issuance*. The claims stay frozen until the next token is
issued, at most the token's own lifetime, which Logto defaults to an hour.

So removing someone from an organization, or taking a role away, does not take
effect at once. Nothing in the package re-reads Logto, by design. The docs
described the helpers as "free and authoritative" and never named the cost.

Deleting or suspending the *user* is different — `logtoSync`'s webhook revokes
their sessions and that is immediate — which makes the gap easy to miss: account
removal bites straight away, membership removal does not.

Documented on the module, in the API reference (a `warn` callout), and in
session-mode's pointer to it, together with the mitigation: when a membership
change has to bite immediately, keep membership in your own table and check that,
so the authorization reads current state. Shortening the ID token TTL narrows the
window; it never closes it.

"free and authoritative" → "free and actually populated", which is the property
that paragraph was really contrasting against an organization token's empty
`scopes`.

## 2. `ORGANIZATION_ROLES_SCOPE` does not imply `ORGANIZATIONS_SCOPE`

Its doc comment said it did. Checked three ways and it does not:

- the live deployment's `scopes_supported` lists
  `urn:logto:scope:organizations` and `urn:logto:scope:organization_roles` as two
  independent entries, and a grant carries the requested ∩ supported set;
- `@logto/js`'s `idTokenClaims` maps each scope to its own claim, with no
  overlap — `Organizations → ['organizations']`,
  `OrganizationRoles → ['organization_roles']`;
- `@logto/js` documents `UserScope.Organizations` as the one that also enables
  the organization token grant, which is what `logtoSessionApi`'s
  `organizations_scope_missing` preflight (#212) already requires.

A deployment that trusted the implication and requested only the roles scope has
no `organizations` claim — so every `assertOrganizationMember` call denies, and
denies *silently*, because a missing claim is deliberately indistinguishable from
a user who belongs to nothing. The corrected comment says to request both if you
read both, and says why.

## Checks

Full workspace `lint` / `format:check` / `check-types` / `test` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that organization membership and role claims reflect the state at token issuance and may remain unchanged until token refresh or expiry.
  * Documented that user deletion or suspension revokes sessions immediately.
  * Recommended application-managed membership checks when immediate authorization updates are required.
  * Clarified that organization and role scopes must be requested independently when both claims are needed.
  * Noted that missing organization claims deny authorization and identify the missing scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->