### PR TITLE
docs(examples): two comments in the Next.js session example promised more than the code does

### DIFF
--- a/examples/nextjs-session/app/page.tsx
+++ b/examples/nextjs-session/app/page.tsx
@@ -16,9 +16,9 @@ import { Dashboard } from "./dashboard";
  * and this browser's next `/token` call, this render can still paint the
  * signed-in shell. `me` returns identity the token already carries, so that
  * costs nothing beyond a shell the client corrects on hydration. A query that
- * returns *data* must not rely on the token alone: enforce revocation inside the
- * function, the way `convex/me.ts`'s `sensitive` does with
- * `assertSubjectHasActiveSession`.
+ * returns anything the bearer does not already hold must not rely on the token
+ * alone: enforce revocation inside the function, the way `convex/me.ts`'s
+ * `sensitive` does with `assertSubjectHasActiveSession`.
  */
 export default async function Home() {
   const token = readLogtoIdTokenCookie(await cookies());

--- a/examples/nextjs-session/app/page.tsx
+++ b/examples/nextjs-session/app/page.tsx
@@ -9,9 +9,16 @@ import { Dashboard } from "./dashboard";
  *
  * The token here is a bearer Convex validates — it proves nothing on its own,
  * and `null` just means "render the signed-out view and let the client take
- * over". Revocation is enforced where it always is: inside the function being
- * called. A cookie whose token expired is gone with it, so the worst case is an
- * unauthenticated first paint, not a stale authenticated one.
+ * over".
+ *
+ * What it is *not* is proof the session is still alive. An ID token stays
+ * cryptographically valid until it expires, so between a revocation elsewhere
+ * and this browser's next `/token` call, this render can still paint the
+ * signed-in shell. `me` returns identity the token already carries, so that
+ * costs nothing beyond a shell the client corrects on hydration. A query that
+ * returns *data* must not rely on the token alone: enforce revocation inside the
+ * function, the way `convex/me.ts`'s `sensitive` does with
+ * `assertSubjectHasActiveSession`.
  */
 export default async function Home() {
   const token = readLogtoIdTokenCookie(await cookies());

--- a/examples/nextjs-session/proxy.ts
+++ b/examples/nextjs-session/proxy.ts
@@ -13,10 +13,11 @@ import { logtoCookieHandler } from "@/server/logto-cookie";
  *
  * Two things this gets right that a naive matcher does not:
  *
- * - **One rotation per document request.** Every call here is a real Logto
- *   token-endpoint round trip that rotates the session token, and the library
- *   says so: "call at most once per incoming document request". A matcher that
- *   also caught `/favicon.ico`, images and RSC prefetches would fire several
+ * - **One rotation per document request.** Every call here rotates the session
+ *   token — always locally, and additionally through Logto's token endpoint once
+ *   the cached ID token has aged out — and the library says so: "call at most
+ *   once per incoming document request". A matcher that also caught
+ *   `/favicon.ico`, images and RSC prefetches would fire several
  *   rotations for one page view, and whichever `Set-Cookie` the browser happened
  *   to keep last could be an older generation than the server's — which the
  *   next client refresh presents outside its reuse window, and the component


### PR DESCRIPTION
Comment-only. Both are in `examples/nextjs-session`, which is the wiring people
copy, so an overstatement there propagates.

## `app/page.tsx`

> Revocation is enforced where it always is: inside the function being called. A
> cookie whose token expired is gone with it, so the worst case is an
> unauthenticated first paint, not a stale authenticated one.

Neither half holds for the page it sits on:

- the function being preloaded is `api.me.me`, which does **not** call
  `assertSubjectHasActiveSession` — `convex/me.ts`'s `sensitive` is the one that
  does;
- expiry is not the only way a session ends. An ID token stays cryptographically
  valid until `exp`, so between a revocation elsewhere and this browser's next
  `/token` call the worst case is exactly the stale authenticated paint the
  comment rules out.

Rewritten to say what is true and why it is acceptable *here*: `me` returns
identity the token already carries, so a stale shell costs nothing beyond one
paint the client corrects on hydration — and a query that returns data must
enforce revocation inside the function.

Related: #213 shortened this window by expiring the ID token cookie on a terminal
`/token` refresh. It did not remove it, and nothing can: the browser only learns
of a remote revocation over its own subscription.

## `proxy.ts`

> Every call here is a real Logto token-endpoint round trip that rotates the
> session token

It is always a session-token rotation, and reaches Logto only once the cached ID
token has aged out — `beginRefresh` returns `cached` and rotates locally
otherwise. The conclusion the paragraph draws (at most once per document request)
is unchanged and was always about the rotation, not the round trip.

No changeset: nothing in the published package changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified server-rendering guidance to require revocation checks for data not included in bearer tokens.
  * Updated session rotation guidance to explain local rotation and when the token endpoint is contacted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->