### PR TITLE
test(e2e): cover organization authorization and the token exchange live

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,4 @@ dist
 e2e/failure.png
 e2e/.env.e2e
 e2e/package-lock.json
-e2e/.probe-*.json
-e2e/.probe-*.log
+e2e/.probe-*

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -44,6 +44,18 @@ Find-or-create, and it *repairs* — an app that exists but has lost a redirect 
 is the failure that actually happens (a port changes, someone edits the console),
 and it presents as an opaque HTTP 400 from `/oidc/auth`. Running it twice is safe.
 
+It also creates the **organization** the authorization steps need
+(`convex-logto-e2e-org`), an organization role named `admin` — the name
+`examples/vite-react-session/convex/organizations.ts` requires — and puts the
+test user in the first holding the second. Membership and the role assignment are
+repaired on every run, because a user quietly dropped from an organization
+presents as an authorization denial with nothing to point at.
+
+The Management API credentials are written back into the file, so `.env.e2e`
+alone is enough to rerun this script. Dropping them is how the setup evaporates:
+the next run reads the file, finds none, and the only other copy was in someone's
+shell history.
+
 Secrets are written to **`e2e/.env.e2e`** with mode `0600` (gitignored), never to
 stdout — a terminal is a scrollback buffer, and in CI it is a log. Only the
 non-secret values are printed. `--out <path>` moves the file.
@@ -94,7 +106,8 @@ node session-flow.mjs
 ```
 
 Drives the real browser through cold sign-in → zero-RTT restore → two rounds of
-rotation → sign-out → re-sign-in → revoking a second device → sign-out
+rotation → organization authorization → the organization token exchange and its
+cache → userinfo → sign-out → re-sign-in → revoking a second device → sign-out
 everywhere. `E2E_HEADED=1` to watch it. A failure writes `failure.png` next to
 the script and exits non-zero.
 
@@ -122,7 +135,22 @@ proxy for it:
 - **revocation reaches the other device without a reload**, because a revocation
   that only lands on the next page load is a cache expiry, not a revocation —
   and the device that *did* the revoking has to stay signed in;
-- **sign-out everywhere** is checked on the device that never saw the click.
+- **sign-out everywhere** is checked on the device that never saw the click;
+- **organization authorization** is asserted both ways — the test user's real
+  role in their real organization grants, and the *same role name* in an
+  organization they do not belong to is denied. Whether Logto puts
+  `organizations` and `organization_roles` in the **ID token** for the configured
+  scopes is a property of the deployment, and every one of the
+  `assertOrganization*` helpers is built on it being true;
+- **the organization token is minted, then cached, then forced past the cache.**
+  `minted` is the only externally visible difference between "asked Logto" and
+  "served from the component", every mint spends a refresh grant, and there is no
+  way to prove `forceRefresh` bypasses a cache without first proving the cache
+  exists. The exchange also has to return **no token string**, because the app
+  never set `exposeAccessTokens`;
+- **`fetchUserInfo` answers for the same subject** the ID token names — a
+  userinfo response for a different subject would mean the component
+  authenticated the wrong session, and both are just JSON to an offline test.
 
 Each run names the session it is about to revoke (`e2e-target-<runid>`). The
 test account accumulates sessions — every run leaves some behind — so "the other
@@ -149,8 +177,7 @@ is the opposite — it asks the deployment a question whose answer is not known
 yet, and its output is a finding, not a pass or a fail.
 
 ```bash
-set -a; . ./.env.e2e; set +a
-export LOGTO_M2M_APP_ID=... LOGTO_M2M_APP_SECRET=...   # same as provisioning
+set -a; . ./.env.e2e; set +a      # the M2M credentials it needs are in there
 node probe-org-tokens.mjs
 ```
 
@@ -168,11 +195,10 @@ gitignored), rewritten after every finding so a late failure does not discard
 evidence that cost real authorization grants.
 
 `probe-exchange.mjs` asks the same kind of question one layer up — through the
-*component*, not raw OIDC. It needs an app already running (see step 2) and an
-organization the test user belongs to:
+*component*, not raw OIDC. It needs an app already running (see step 2), and
+`E2E_ORG_ID` from `.env.e2e`:
 
 ```bash
-export E2E_ORG_ID=...          # from `GET /api/organizations`
 node probe-exchange.mjs                       # findings on stderr, like the rest
 node probe-exchange.mjs 2> .probe-exchange.log # …redirect to keep them
 ```

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -111,6 +111,14 @@ cache → userinfo → sign-out → re-sign-in → revoking a second device → 
 everywhere. `E2E_HEADED=1` to watch it. A failure writes `failure.png` next to
 the script and exits non-zero.
 
+Progress and failures go to **stderr**, like everything else here — the exit code
+is the machine-readable result, so stdout stays free for a caller to redirect
+without swallowing the log. Keep a run with `2>`:
+
+```bash
+node session-flow.mjs 2> .probe-session-flow.log   # gitignored
+```
+
 The last two steps open **separate browser contexts**, which is what makes them
 worth running: a second context is a second cookie jar and a second storage
 origin, so it is a second *device* to both Logto and the component — and

--- a/e2e/provision.mjs
+++ b/e2e/provision.mjs
@@ -249,10 +249,15 @@ async function ensureOrganization(call, userId) {
       }),
     }));
 
-  const members = await call(
-    `/organizations/${org.id}/users?page=1&page_size=100`,
+  // Paged, for the reason `findPaged`'s own comment gives: a single page of 100
+  // silently misses a member in a larger organization, and "not a member" here
+  // means a POST that adds someone who is already there.
+  const member = await findPaged(
+    call,
+    `/organizations/${org.id}/users`,
+    (candidate) => candidate.id === userId,
   );
-  if (!members.some((member) => member.id === userId)) {
+  if (member === undefined) {
     await call(`/organizations/${org.id}/users`, {
       method: "POST",
       body: JSON.stringify({ userIds: [userId] }),

--- a/e2e/provision.mjs
+++ b/e2e/provision.mjs
@@ -40,6 +40,11 @@ const webOrigin = process.env.E2E_WEB_ORIGIN ?? "http://localhost:5174";
 
 const SPA_NAME = "convex-logto-e2e-spa";
 const WEB_NAME = "convex-logto-e2e-web";
+const ORG_NAME = "convex-logto-e2e-org";
+// The name `examples/vite-react-session/convex/organizations.ts` requires. The
+// reference app names the role; this provisions the role the reference app
+// names, not the other way round.
+const ORG_ROLE = "admin";
 const USER_EMAIL = "convex-logto-e2e@example.com";
 const USER_PASSWORD = required(
   "E2E_USER_PASSWORD",
@@ -213,6 +218,56 @@ async function ensureUser(call) {
 }
 
 /**
+ * An organization the test user belongs to, holding {@link ORG_ROLE}.
+ *
+ * Find-or-create *and* repair, for the same reason `ensureApplication` is: the
+ * failure that actually happens is an object that exists but has drifted — the
+ * user dropped from the organization, or holding no role in it — and every one
+ * of those presents as an authorization denial with nothing to point at.
+ *
+ * The role assignment is a PUT: it *is* the desired state, so re-running it is
+ * both the repair and the no-op.
+ */
+async function ensureOrganization(call, userId) {
+  const org =
+    (await findPaged(call, "/organizations", (o) => o.name === ORG_NAME)) ??
+    (await call("/organizations", {
+      method: "POST",
+      body: JSON.stringify({
+        name: ORG_NAME,
+        description: "convex-logto live end-to-end tests. Safe to delete.",
+      }),
+    }));
+
+  const role =
+    (await findPaged(call, "/organization-roles", (r) => r.name === ORG_ROLE)) ??
+    (await call("/organization-roles", {
+      method: "POST",
+      body: JSON.stringify({
+        name: ORG_ROLE,
+        description: "convex-logto live end-to-end tests. Safe to delete.",
+      }),
+    }));
+
+  const members = await call(
+    `/organizations/${org.id}/users?page=1&page_size=100`,
+  );
+  if (!members.some((member) => member.id === userId)) {
+    await call(`/organizations/${org.id}/users`, {
+      method: "POST",
+      body: JSON.stringify({ userIds: [userId] }),
+    });
+    console.error(`  added the test user to ${ORG_NAME}`);
+  }
+  await call(`/organizations/${org.id}/users/${userId}/roles`, {
+    method: "PUT",
+    body: JSON.stringify({ organizationRoleIds: [role.id] }),
+  });
+
+  return { org, role };
+}
+
+/**
  * The client secret lives only on the application detail response.
  *
  * Fails rather than returning null: session mode's code exchange cannot run
@@ -260,7 +315,8 @@ const web = await ensureApplication(call, {
   type: "Traditional",
   origin: webOrigin,
 });
-await ensureUser(call);
+const user = await ensureUser(call);
+const { org, role } = await ensureOrganization(call, user.id);
 const secret = await clientSecret(call, web.id, WEB_NAME);
 
 // Secrets go to a 0600 file, never to stdout: a terminal is a scrollback buffer,
@@ -282,6 +338,16 @@ E2E_USER_EMAIL=${USER_EMAIL}
 E2E_USER_PASSWORD=${USER_PASSWORD}
 E2E_SPA_ORIGIN=${spaOrigin}
 E2E_WEB_ORIGIN=${webOrigin}
+
+# Organization authorization and the organization token exchange. Not secrets.
+E2E_ORG_ID=${org.id}
+E2E_ORG_ROLE=${role.name}
+
+# Management API client, written back so this file alone can rerun this script.
+# Dropping them is how the setup evaporates: the next run reads the file, finds
+# no credentials, and the only copy was in someone's shell history.
+LOGTO_M2M_APP_ID=${m2mId}
+LOGTO_M2M_APP_SECRET=${m2mSecret}
 `;
 writeFileSync(outPath, env, { mode: 0o600 });
 
@@ -291,6 +357,7 @@ console.error(`done.
   SPA app          ${spa.id}
   web app          ${web.id}
   test user        ${USER_EMAIL}
+  organization     ${org.id} (${ORG_NAME}), test user holds "${role.name}"
   client secret    written to the file below
 
   ${outPath}   (mode 0600, gitignored)

--- a/e2e/session-flow.mjs
+++ b/e2e/session-flow.mjs
@@ -26,6 +26,11 @@ const appOrigin = new URL(appUrl).origin;
 const convexUrl = trimSlash(need("E2E_CONVEX_URL"));
 const email = need("E2E_USER_EMAIL");
 const password = need("E2E_USER_PASSWORD");
+// The organization `provision.mjs` puts the test user in, and the role it gives
+// them there — which is the role `examples/vite-react-session`'s `adminOnly`
+// query requires.
+const organizationId = need("E2E_ORG_ID");
+const organizationRole = need("E2E_ORG_ROLE");
 const headless = process.env.E2E_HEADED !== "1";
 const screenshotPath = fileURLToPath(new URL("./failure.png", import.meta.url));
 // Labels outlive a run: a revoke aimed at "the other device" would eventually
@@ -219,6 +224,47 @@ async function signInOutcome(page) {
   ]);
 }
 
+/** The cached ID token, read from the library's own key. */
+function readStoredIdToken(page) {
+  return page.evaluate(() => {
+    for (const store of [sessionStorage, localStorage]) {
+      const key = Object.keys(store).find((candidate) =>
+        candidate.endsWith(":idToken"),
+      );
+      if (key === undefined) continue;
+      const stored = JSON.parse(store.getItem(key) ?? "null");
+      const raw = typeof stored === "string" ? stored : stored?.token;
+      if (typeof raw === "string") return raw;
+    }
+    return null;
+  });
+}
+
+/**
+ * Call a Convex function through the page, so the request carries the app's own
+ * origin — the deployment's CORS policy is part of what is under test.
+ *
+ * Returns Convex's envelope untouched (`{status, value}` or
+ * `{status, errorData}`): a helper that threw on `status: "error"` would make
+ * the denial assertions below unable to see the denial they are asserting.
+ */
+async function callConvex(page, kind, path, args, bearer) {
+  return await page.evaluate(
+    async ([url, route, name, payload, token]) => {
+      const response = await fetch(`${url}/api/${route}`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ path: name, args: payload, format: "json" }),
+      });
+      return await response.json();
+    },
+    [convexUrl, kind, path, args, bearer ?? null],
+  );
+}
+
 /** Drop the cached ID token so the next restore must go to the deployment. */
 function clearCachedIdToken(page) {
   return page.evaluate(() => {
@@ -328,7 +374,123 @@ try {
   }
   step("rotation persisted across two refreshes");
 
-  // 4. Sign-out has to survive a reload. A cleared UI with live credentials
+  // 4. Organization authorization, straight out of the ID token. Nothing here
+  //    is checkable offline: whether Logto actually puts `organizations` and
+  //    `organization_roles` in the *ID* token for the configured scopes is a
+  //    property of the deployment, and the whole helper family is built on it
+  //    being true. The denial half matters as much as the grant: a check that
+  //    matched on the role alone would authorize one organization's `admin`
+  //    inside another's.
+  const idToken = await readStoredIdToken(page);
+  assert(idToken !== null, "no ID token was cached after sign-in");
+  const granted = await callConvex(
+    page,
+    "query",
+    "organizations:adminOnly",
+    { organizationId },
+    idToken,
+  );
+  assert(
+    granted.status === "success",
+    `adminOnly denied a real ${organizationRole} of ${organizationId}: ` +
+      JSON.stringify(granted),
+  );
+  const foreign = await callConvex(
+    page,
+    "query",
+    "organizations:adminOnly",
+    { organizationId: `${organizationId}-not-mine` },
+    idToken,
+  );
+  assert(
+    foreign.status === "error" &&
+      JSON.stringify(foreign).includes("organization_forbidden"),
+    "adminOnly authorized an organization the user does not belong to: " +
+      JSON.stringify(foreign),
+  );
+  step(
+    "organization authorization",
+    `"${organizationRole}" in ${organizationId}, and nowhere else`,
+  );
+
+  // 5. The organization token exchange, and its cache. `minted` is the only
+  //    externally visible difference between "asked Logto" and "served from the
+  //    component", and it is the thing worth asserting: every mint spends a
+  //    refresh grant, so a cache that silently never hits would multiply this
+  //    deployment's traffic to Logto by however often the app asks. `forceRefresh`
+  //    is the deliberate way past it, and there is no way to prove it bypasses a
+  //    cache without first proving the cache exists.
+  const sessionToken = await readStoredSessionToken(page);
+  assert(sessionToken !== null, "no session token to exchange with");
+  const exchange = async (extra) =>
+    await callConvex(page, "action", "auth:exchangeToken", {
+      sessionToken,
+      organizationId,
+      ...extra,
+    });
+
+  const first = await exchange({});
+  assert(
+    first.status === "success",
+    `the organization token exchange failed: ${JSON.stringify(first)}`,
+  );
+  assert(
+    first.value.minted === true,
+    "the first exchange of this run was served from cache, so nothing proves " +
+      "a mint still works",
+  );
+  assert(
+    first.value.claims.audience === `organization:${organizationId}`,
+    `wrong audience: ${JSON.stringify(first.value.claims)}`,
+  );
+  assert(
+    first.value.claims.expiresAt > Date.now(),
+    `the minted token is already expired: ${JSON.stringify(first.value.claims)}`,
+  );
+  // Never requested, so it must never be returned. `exposeAccessTokens` is off
+  // in this app, and a token string leaking without it is the failure that
+  // would be silent everywhere else.
+  assert(
+    first.value.accessToken === undefined,
+    "the exchange returned a token string that was never asked for",
+  );
+
+  const cached = await exchange({});
+  assert(
+    cached.status === "success" && cached.value.minted === false,
+    "the second exchange minted again — the component's cache did not hit, " +
+      `and every call spends a Logto refresh grant: ${JSON.stringify(cached)}`,
+  );
+
+  const forced = await exchange({ forceRefresh: true });
+  assert(
+    forced.status === "success" && forced.value.minted === true,
+    `forceRefresh was served from cache: ${JSON.stringify(forced)}`,
+  );
+  step("organization token", "minted, cached, and forced past the cache");
+
+  // 6. `fetchUserInfo` goes to Logto's `/oidc/me` with an opaque token the
+  //    component mints for the purpose. Its subject has to be the same person
+  //    the ID token names — a userinfo response for a *different* subject would
+  //    mean the component authenticated the wrong session, and no offline test
+  //    can see the difference because both are just JSON.
+  const userinfo = await callConvex(page, "action", "auth:fetchUserInfo", {
+    sessionToken,
+  });
+  assert(
+    userinfo.status === "success",
+    `fetchUserInfo failed: ${JSON.stringify(userinfo)}`,
+  );
+  const subject = JSON.parse(
+    atob((idToken.split(".")[1] ?? "").replace(/-/g, "+").replace(/_/g, "/")),
+  ).sub;
+  assert(
+    userinfo.value.sub === subject,
+    `userinfo answered for ${userinfo.value.sub}, not ${subject}`,
+  );
+  step("userinfo", "same subject as the ID token");
+
+  // 7. Sign-out has to survive a reload. A cleared UI with live credentials
   //    still in storage would pass a text-only check and is exactly the bug.
   // Not `/^sign out/`: the app also offers "Sign out everywhere", and matching
   // both makes Playwright refuse rather than pick — which is the right call, and
@@ -343,7 +505,7 @@ try {
   );
   step("sign-out", "credentials gone, and still gone after a reload");
 
-  // 5. Sign in again. Sign-out is federated by default — it ends Logto's SSO
+  // 8. Sign in again. Sign-out is federated by default — it ends Logto's SSO
   //    session as well as the local one — so this must *not* be silent. The
   //    credential prompt is the only evidence that the RP-initiated logout
   //    actually reached Logto: clearing local storage looks identical from the
@@ -368,7 +530,7 @@ try {
   );
   step("re-sign-in", "prompted — the federated sign-out reached Logto");
 
-  // 6. Revoking another device has to reach it without a reload, and must not
+  // 9. Revoking another device has to reach it without a reload, and must not
   //    touch this one. This is the reactive `sessionValid` subscription plus
   //    the revocation watermark, and it is the part of the component with the
   //    most moving pieces: a marker commits before the rows are drained, and a
@@ -414,9 +576,9 @@ try {
     await second.context.close();
   }
 
-  // 7. Sign out everywhere. The one guarantee that cannot be checked from a
-  //    single browser: a *different* device, which never sees the click, has to
-  //    lose its session too — live, and without asking for it.
+  // 10. Sign out everywhere. The one guarantee that cannot be checked from a
+  //     single browser: a *different* device, which never sees the click, has
+  //     to lose its session too — live, and without asking for it.
   const third = await newDevice();
   try {
     await signInOnFreshDevice(third.page);

--- a/examples/vite-react-session/convex/_generated/api.d.ts
+++ b/examples/vite-react-session/convex/_generated/api.d.ts
@@ -12,6 +12,7 @@ import type * as auth from "../auth.js";
 import type * as http from "../http.js";
 import type * as logto from "../logto.js";
 import type * as me from "../me.js";
+import type * as organizations from "../organizations.js";
 
 import type {
   ApiFromModules,
@@ -24,6 +25,7 @@ declare const fullApi: ApiFromModules<{
   http: typeof http;
   logto: typeof logto;
   me: typeof me;
+  organizations: typeof organizations;
 }>;
 
 /**

--- a/examples/vite-react-session/convex/organizations.ts
+++ b/examples/vite-react-session/convex/organizations.ts
@@ -1,0 +1,47 @@
+// Organization authorization, read straight from the ID token Convex validated.
+//
+// Nothing here talks to Logto. `urn:logto:scope:organizations` and
+// `urn:logto:scope:organization_roles` (both requested in `auth.ts`) put an
+// `organizations` and an `organization_roles` claim in the ID token, and Convex
+// passes claims it does not recognise through to `getUserIdentity()` — so
+// membership and roles are already inside the request, for free.
+//
+// The cost of "free" is that they are a *snapshot*: true when the token was
+// issued and frozen until the next one is. A user removed from an organization
+// keeps these claims until then. When a membership change has to bite
+// immediately, keep membership in your own table and check that instead.
+import { v } from "convex/values";
+import {
+  assertOrganizationRole,
+  logtoOrganizationRoles,
+  logtoOrganizations,
+} from "convex-logto";
+import { query } from "./_generated/server";
+
+/** The role `adminOnly` requires. `e2e/provision.mjs` creates one with this name. */
+const ADMIN_ROLE = "admin";
+
+export const organizations = query({
+  handler: async (ctx) => await logtoOrganizations(ctx),
+});
+
+export const roles = query({
+  args: { organizationId: v.string() },
+  handler: async (ctx, { organizationId }) =>
+    await logtoOrganizationRoles(ctx, organizationId),
+});
+
+/**
+ * The shape a real authorization check takes: the *function* names the role it
+ * requires, and the caller only names the organization it is acting in.
+ *
+ * A role check matches on the organization **and** the role, so one
+ * organization's `admin` cannot authorize another's.
+ */
+export const adminOnly = query({
+  args: { organizationId: v.string() },
+  handler: async (ctx, { organizationId }) => {
+    await assertOrganizationRole(ctx, organizationId, ADMIN_ROLE);
+    return { secret: `only ${ADMIN_ROLE}s of ${organizationId} see this` };
+  },
+});


### PR DESCRIPTION
0.6.0 shipped `assertOrganization*`, the organization/resource token exchange and
`fetchUserInfo`. None of it had a live check, and every property those rest on is
a property of the *deployment*:

- whether Logto actually puts `organizations` / `organization_roles` in the **ID
  token** for the configured scopes — the whole `assertOrganization*` family is
  built on it;
- whether the component's token cache hits, when every miss spends a Logto
  refresh grant;
- whether `forceRefresh` gets past that cache.

An offline test sees none of those. This is the gap the ADR-0003 work opened and
left open.

## `session-flow.mjs` — 7 steps → 10

Inserted between rotation and sign-out, while the page is signed in (the exchange
does not rotate the session token, so the later `previous`-token assertions are
untouched):

**4. Organization authorization, both ways.** The test user's real role in their
real organization grants; the *same role name* in an organization they do not
belong to is denied with `organization_forbidden`. The denial half is the one
that matters — a check matching on the role alone would authorize one
organization's `admin` inside another's.

**5. The organization token: minted → cached → forced.** `minted` is the only
externally visible difference between "asked Logto" and "served from the
component". There is no way to prove `forceRefresh` bypasses a cache without
first proving the cache exists, hence all three in order. Also asserts the
audience, a future `expiresAt`, and that **no token string** comes back — the app
never set `exposeAccessTokens`, and a leak there would be silent everywhere else.

**6. `fetchUserInfo` answers for the same subject** the ID token names. A
userinfo response for a *different* subject would mean the component
authenticated the wrong session, and both are just JSON to an offline test.

### Both new assertions were checked against mutants

Not just "it passes":

```
# organizationId: `${organizationId}-not-mine`  →  { organizationId }
✗ failed after 3 step(s): adminOnly authorized an organization the user does not
  belong to: {"status":"success","value":{"secret":"only admins of ioza6… see this"}}

# exchange({})  →  exchange({ forceRefresh: true })
✗ failed after 4 step(s): the second exchange minted again — the component's
  cache did not hit, and every call spends a Logto refresh grant: {…"minted":true}
```

## `provision.mjs`

Creates `convex-logto-e2e-org` and an organization role named `admin` — the name
the reference app requires, so the provisioning follows the app rather than the
app following the provisioning — and puts the test user in the first holding the
second. Membership and the role assignment are **repaired** on every run, like
the redirect URIs already are: a user quietly dropped from an organization
presents as an authorization denial with nothing to point at.

Writes `E2E_ORG_ID` / `E2E_ORG_ROLE`, and writes the Management API credentials
back. That last one is a real gap: the script *requires* them and never persisted
them, so `.env.e2e` alone could not rerun the script that produced it — which is
exactly the evaporating setup this directory exists to stop. `probe-exchange.mjs`
stops asking for a hand-set `E2E_ORG_ID`.

## `examples/vite-react-session/convex/organizations.ts`

New. 0.6.0's headline feature had no worked example. It shows the shape a real
check takes — the **function** names the role it requires, the caller only names
the organization it is acting in — and states the cost of reading a claim: the
values are a snapshot taken at token issuance (see #214).

## Verification

10/10 steps against the live Logto and a real Convex deployment. Full workspace
`lint` / `format:check` / `check-types` / `test` / `build` pass.

No changeset: `e2e/` is outside the workspace, and the example is not published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added organization-aware authorization, membership and role validation, and admin-only access controls.
  * Added organization token exchange, caching, refresh, user information, and cross-device sign-out coverage.
* **Testing**
  * Expanded end-to-end checks and automated setup for organizations, roles, and memberships.
* **Documentation**
  * Updated organization configuration and persistent test credential instructions.
* **Chores**
  * Excluded probe artifacts from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->