### PR TITLE
feat(session): export SessionSignOutError from the web entry too

### DIFF
--- a/.changeset/export-session-signout-error.md
+++ b/.changeset/export-session-signout-error.md
@@ -1,0 +1,18 @@
+---
+"convex-logto": minor
+---
+
+Export `SessionSignOutError` from `convex-logto/react-session`.
+
+`signOut()` rejects with it when local credential cleanup fails twice, and
+`convex-logto/native-session` has always exported the class — the web entry never
+did, so the same failure was `instanceof`-checkable in one mode and reachable
+only through `error.name` in the other. `SessionSignOutServerStatus` comes with
+it, and the web `signOut`'s type now documents the rejection the way native's
+already did.
+
+The build verifier gained a check for exactly this: a short list of names both
+session entries must export, asserted against the emitted declaration files.
+They are separate tsup entries with separate export lists, so one can lose a name
+the other keeps and nothing else notices — each entry still typechecks and builds
+on its own.

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -30,6 +30,7 @@ description: Every export from convex-logto and its web, native, and session-mod
 | default | `convex-logto/convex.config` | The session component, for `app.use(logto)` in `convex/convex.config.ts`. |
 | `ConvexLogtoSessionProvider` | `convex-logto/react-session` | Session mode's provider — no Logto SDK; talks to your `logtoSessionApi` functions. |
 | `useLogtoAuth()` | `convex-logto/react-session` | Session auth plus `signOutEverywhere({ postLogoutRedirectUri? })`, `listSessions()` / `renameSession()` / `revokeSession()`, and `getIdToken()` / `getOrganizationTokenClaims()` / `getAccessTokenClaims()` / `fetchUserInfo()`. |
+| `SessionSignOutError` | `convex-logto/react-session`, `convex-logto/native-session` | The error `signOut()` rejects with when local credential cleanup fails twice; `serverSessionStatus` says whether the server session survived. |
 | `ConvexLogtoProvider` | `convex-logto/native` | React Native / Expo provider (on `@logto/rn`). Same `config` / `configQuery` model; no callback route. |
 | `useLogtoAuth()` | `convex-logto/native` | Native `{ isAuthenticated, isLoading, user, signIn, signOut }`; `signIn({ redirectUri? })` / `signOut({ postLogoutRedirectUri? })`. |
 | `ConvexLogtoSessionProvider` | `convex-logto/native-session` | React Native / Expo session provider using SecureStore + the system browser. |
@@ -582,6 +583,32 @@ A router `push`/`replace` is a soft, same-document navigation and is safe. If
 you need a hard one, pass the destination as `postLogoutRedirectUri` and let the
 sign-out land there itself.
 </Callout>
+
+`signOut()` rejects with **`SessionSignOutError`** when local credential cleanup
+fails twice — exported from `convex-logto/react-session` and
+`convex-logto/native-session`, so it is `instanceof`-checkable rather than
+matched on a message. Two fields say what state the user is actually in:
+
+```ts
+import { SessionSignOutError } from "convex-logto/react-session";
+
+try {
+  await signOut();
+} catch (error) {
+  if (error instanceof SessionSignOutError) {
+    // "revoked": the server session is gone; only this browser's copy lingers.
+    // "revocation_failed": the server session is still live. This one matters.
+    // "not_present": there was nothing to revoke.
+    reportToUser(error.serverSessionStatus);
+  }
+}
+```
+
+`code` collapses the same thing to two values: `local_cleanup_failed`, or
+`local_cleanup_and_server_revocation_failed`. Credentials are cleared *before*
+the network call, so a rejection never means "still signed in" — it means the
+wipe could not be made durable, which is worth telling the user on a shared
+device.
 - `listSessions()` — a snapshot (not a subscription: the credential it
   authenticates with rotates) of the caller's own sessions, `{ sessions,
   truncated }`, newest first. Call it again after a rename or revoke.

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -31,6 +31,7 @@ description: Every export from convex-logto and its web, native, and session-mod
 | `ConvexLogtoSessionProvider` | `convex-logto/react-session` | Session mode's provider — no Logto SDK; talks to your `logtoSessionApi` functions. |
 | `useLogtoAuth()` | `convex-logto/react-session` | Session auth plus `signOutEverywhere({ postLogoutRedirectUri? })`, `listSessions()` / `renameSession()` / `revokeSession()`, and `getIdToken()` / `getOrganizationTokenClaims()` / `getAccessTokenClaims()` / `fetchUserInfo()`. |
 | `SessionSignOutError` | `convex-logto/react-session`, `convex-logto/native-session` | The error `signOut()` rejects with when local credential cleanup fails twice; `serverSessionStatus` says whether the server session survived. |
+| `LogtoUserClaims` | `convex-logto` | The type of `user` in all four entries — standard claims named, everything else through an index signature. Import it to type a helper that takes one. |
 | `ConvexLogtoProvider` | `convex-logto/native` | React Native / Expo provider (on `@logto/rn`). Same `config` / `configQuery` model; no callback route. |
 | `useLogtoAuth()` | `convex-logto/native` | Native `{ isAuthenticated, isLoading, user, signIn, signOut }`; `signIn({ redirectUri? })` / `signOut({ postLogoutRedirectUri? })`. |
 | `ConvexLogtoSessionProvider` | `convex-logto/native-session` | React Native / Expo session provider using SecureStore + the system browser. |

--- a/docs/content/docs/api-reference.mdx
+++ b/docs/content/docs/api-reference.mdx
@@ -606,10 +606,14 @@ try {
 ```
 
 `code` collapses the same thing to two values: `local_cleanup_failed`, or
-`local_cleanup_and_server_revocation_failed`. Credentials are cleared *before*
-the network call, so a rejection never means "still signed in" — it means the
-wipe could not be made durable, which is worth telling the user on a shared
-device.
+`local_cleanup_and_server_revocation_failed`.
+
+**Take the rejection seriously.** The engine clears its in-memory auth state
+first, so the tab reads "signed out" either way — but this error is thrown
+precisely because the *durable* wipe failed twice, so credentials may still be in
+browser storage. With `revocation_failed` the server session is live as well, and
+a reload can sign the user straight back in. On a shared device that is worth
+saying out loud rather than swallowing.
 - `listSessions()` — a snapshot (not a subscription: the credential it
   authenticates with rotates) of the caller's own sessions, `{ sessions,
   truncated }`, newest first. Call it again after a rename or revoke.

--- a/packages/convex-logto/scripts/verify-build-artifacts.mjs
+++ b/packages/convex-logto/scripts/verify-build-artifacts.mjs
@@ -143,6 +143,68 @@ if (unresolved.length > 0) {
   process.exit(1);
 }
 
+/**
+ * The two session entries have to agree on the surface they share.
+ *
+ * They are separate tsup entries with separate export lists, so one can quietly
+ * lose a name the other keeps — and nothing else notices, because each entry
+ * typechecks and builds on its own. That has already happened once:
+ * `SessionSignOutError` shipped from `native-session` and not from
+ * `react-session`, leaving a web app matching on `error.name` for a failure a
+ * native app could `instanceof`.
+ *
+ * Deliberately a small explicit list rather than a diff with an exception list:
+ * the entries *should* differ (cookies and `TokenStorageKind` are web-only,
+ * `completeSignIn` is native-only), so a full diff would need an allowlist,
+ * and an allowlist is the thing that rots. These are the names that must be in
+ * both because both engines produce them.
+ */
+const SHARED_SESSION_EXPORTS = [
+  "ConvexLogtoSessionProvider",
+  "useLogtoAuth",
+  "LogtoSessionApi",
+  "LogtoSessionAuth",
+  "LogtoSessionSummary",
+  "LogtoResourceTokenClaims",
+  "LogtoTokenExchangeOptions",
+  "LogtoAuthEvent",
+  "LogtoAuthPhase",
+  "SessionSignOutError",
+  "SessionSignOutServerStatus",
+];
+
+const asymmetric = [];
+for (const entry of ["react-session", "native-session"]) {
+  const declaration = resolve(packageDir, `dist/${entry}.d.ts`);
+  if (!isFile(declaration)) {
+    console.error(`convex-logto: dist/${entry}.d.ts is missing.`);
+    process.exit(1);
+  }
+  const source = readFileSync(declaration, "utf8");
+  // The emitted export list, not the whole file: a `declare class` that no
+  // export names is not part of the public surface, and matching on it would
+  // make this check pass on exactly the drift it exists to catch.
+  const exported = new Set(
+    [...source.matchAll(/^export \{([^}]*)\};?$/gm)]
+      .flatMap(([, names]) => names.split(","))
+      .map((name) => name.trim().replace(/^type\s+/, "").split(/\s+as\s+/).pop())
+      .filter(Boolean),
+  );
+  for (const name of SHARED_SESSION_EXPORTS) {
+    if (!exported.has(name)) asymmetric.push(`${entry} is missing ${name}`);
+  }
+}
+
+if (asymmetric.length > 0) {
+  console.error(
+    `convex-logto: the session entries disagree about their own API:\n  ` +
+      `${asymmetric.join("\n  ")}\n` +
+      "Both engines produce these; exporting one from only one entry makes the " +
+      "same failure handleable in one mode and not the other.",
+  );
+  process.exit(1);
+}
+
 // The component's entry point must also actually load.
 await import(pathToFileURL(resolve(componentDir, "convex.config.js")).href).catch(
   (error) => {

--- a/packages/convex-logto/src/react-session.tsx
+++ b/packages/convex-logto/src/react-session.tsx
@@ -439,6 +439,10 @@ export type LogtoSessionAuth = {
    * unless `federated: false` — ends Logto's SSO session and returns to
    * `postLogoutRedirectUri` (default `window.location.origin`, which you must
    * register as a **Post sign-out redirect URI**).
+   *
+   * Rejects with {@link SessionSignOutError} when durable cleanup fails twice;
+   * its `serverSessionStatus` distinguishes a successful revocation from a dual
+   * failure.
    */
   signOut: (options?: {
     postLogoutRedirectUri?: string;
@@ -662,6 +666,14 @@ export type {
 } from "./session";
 export type {
   LogtoTokenExchangeOptions,
+  SessionSignOutServerStatus,
   TokenStorageKind,
 } from "./session-client";
+// A value, not a type: `instanceof` is how an app tells a sign-out that could
+// not durably wipe its credentials apart from one that simply failed. The
+// browser engine throws the same class the native one does, and
+// `convex-logto/native-session` has always exported it — a web app reduced to
+// matching on `error.name` for the identical failure is exactly the entry-point
+// drift this package keeps having to undo.
+export { SessionSignOutError } from "./session-client";
 export type { LogtoSessionCookieTransportOptions } from "./session-cookie";


### PR DESCRIPTION
## The asymmetry

`SessionAuthEngine.signOut()` rejects with `SessionSignOutError` when durable
local cleanup fails twice. Both engines throw it — it lives in
`session-client.ts`, which both entries build on.

Only one entry exported it:

```
convex-logto/native-session → …, SessionSignOutError, type SessionSignOutServerStatus, …
convex-logto/react-session  → …no mention at all…
```

So a native app writes `error instanceof SessionSignOutError`, and a web app
hitting the identical failure is reduced to `error.name === "SessionSignOutError"`
— against a class it cannot import, whose `name` is not part of any documented
contract. That is the entry-point drift #201 existed to undo: "the four entries
disagreed about their own API."

`SessionSignOutServerStatus` comes with it, and the web `signOut`'s type now
documents the rejection the way native's already did.

## Why the error is worth catching

Credentials are cleared *before* the network call, so a rejection never means
"still signed in". It means the wipe could not be made durable — and
`serverSessionStatus` says which of three states the user is in:

| value | what actually happened |
|---|---|
| `revoked` | server session gone; only this browser's copy lingers |
| `revocation_failed` | **the server session is still live** |
| `not_present` | nothing to revoke |

On a shared device those are not the same message. Documented in the API
reference with a worked `try`/`catch`.

## The gate

`scripts/verify-build-artifacts.mjs` gained a short list of names both session
entries must export, asserted against the **emitted export lists** in
`dist/*.d.ts` — not the whole file, because a `declare class` no export names is
not public surface, and matching on it would make the check pass on the exact
drift it exists to catch.

Deliberately an explicit list rather than a diff-with-exceptions: the entries
*should* differ (cookies and `TokenStorageKind` are web-only, `completeSignIn` is
native-only), so a diff would need an allowlist, and the allowlist is the part
that rots.

Proved it discriminates by deleting `SessionSignOutError` from a built
declaration:

```
convex-logto: the session entries disagree about their own API:
  react-session is missing SessionSignOutError
```

## Checks

Full workspace `lint` / `format:check` / `check-types` / `test` / `build` /
`lint:package` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exported `SessionSignOutError` and `SessionSignOutServerStatus` from the web session API.
  * Documented sign-out errors, server session statuses, and consolidated error codes.
  * Documented the exported `LogtoUserClaims` type.

* **Documentation**
  * Expanded API reference guidance for session sign-out behavior and error handling.

* **Tests**
  * Added build validation to verify required session API exports are available consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->