### PR TITLE
ci: check that every documented import names a real export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,8 @@ jobs:
 
       - name: Validate published package (publint + are-the-types-wrong)
         run: pnpm lint:package
+
+      # After the build, because it reads the emitted declarations rather than
+      # the source — it sees the surface a reader's `npm i` would.
+      - name: Check documented imports against the built exports
+        run: pnpm check:docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,10 @@ jobs:
 
       - run: pnpm lint:package
 
+      # After the build, because it reads the emitted declarations rather than
+      # the source — it sees the surface a reader's `npm i` would.
+      - run: pnpm check:docs
+
   release:
     needs: verify
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ library and will miss a broken example or docs build.
 | Test | `pnpm test` (vitest) |
 | Build | `NEXT_PUBLIC_CONVEX_URL=… pnpm build` |
 | Validate package | `pnpm lint:package` (publint + are-the-types-wrong) |
+| Check documented imports | `pnpm check:docs` (every `import … from "convex-logto…"` in `docs/` names a real export; reads `dist/`, so it runs after the build) |
 
 Not part of that sequence — `format` rewrites files and `dev` never exits:
 
@@ -69,7 +70,8 @@ clean clone (`git clone --no-hardlinks . /tmp/x && cd /tmp/x && pnpm install
 - **Lint/format:** OXC — `oxlint` + `oxfmt`. Run `format` before committing; CI enforces `lint` + `format:check`. oxfmt is scoped to `src/` (never reformats `package.json` / `CHANGELOG.md` / lockfiles).
 - **Runtime:** the library must run in Convex's **V8 runtime** — use Web APIs (e.g. `crypto.subtle`), not Node-only APIs.
 - **TypeScript:** strict, `verbatimModuleSyntax`. `check-types` runs **two** projects: `tsconfig.json` (the library, `types: []` — no ambient Node globals, because it runs in Convex's V8 runtime) and `tsconfig.test.json` (the same options plus `@types/node` and ES2023, over the test files the base config excludes so tsup and the component build never emit them). A new test file is covered automatically; a test that needs a Node API belongs in the second project only.
-- **Build verification:** `packages/convex-logto/scripts/verify-build-artifacts.mjs` runs at the end of every build. It asserts every path in `package.json#exports` exists, and — since nothing else ever loads them — that every relative specifier under `dist/component/` resolves and `dist/component/convex.config.js` imports. Without it a broken component emit surfaces on a *user's* next `convex dev` push.
+- **Build verification:** `packages/convex-logto/scripts/verify-build-artifacts.mjs` runs at the end of every build. It asserts every path in `package.json#exports` exists, that every relative specifier under `dist/component/` resolves and `dist/component/convex.config.js` imports (nothing else ever loads them), and that the two session entries still export the small set of names they share. Without it a broken component emit surfaces on a *user's* next `convex dev` push, and an export lost from one entry surfaces as a failure handleable in one mode and not the other.
+- **Docs verification:** `scripts/check-docs-imports.mjs` (`pnpm check:docs`, after the build) checks every `import { … } from "convex-logto…"` in `docs/content/docs/` against the **emitted** declaration files. Nothing compiles an `.mdx` code fence, so a renamed export otherwise reaches readers as a build error in *their* project. Import lines only, on purpose: making every snippet typecheck would mean giving each one a preamble it does not need to be read.
 - **`convex-logto/react` is ESM-only** because it depends on `@logto/react@4` (ESM-only). The root `convex-logto` entry is dual ESM+CJS.
 - **Auth model:** validate Logto's **ID token** over OIDC (Convex rejects `at+jwt` access tokens). No manual JWT config — the signing algorithm and JWKS are auto-discovered.
 - **Component schema evolution:** new fields on existing component tables must be `v.optional(...)`. There is no migration mechanism — the schema ships inside the npm package and is validated against existing rows on the app's next push. A brand-new table may have required fields.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "format:check": "turbo run format:check",
     "lint:package": "turbo run lint:package",
     "audit:dependencies": "node ./scripts/audit-dependencies.mjs",
+    "check:docs": "node ./scripts/check-docs-imports.mjs",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "changeset publish"

--- a/scripts/check-docs-imports.mjs
+++ b/scripts/check-docs-imports.mjs
@@ -1,0 +1,103 @@
+// Every name the docs import from `convex-logto` has to exist.
+//
+// This is the drift that keeps happening, and it is silent in both directions:
+// nothing compiles an `.mdx` code fence, and the exports map has no idea the
+// docs exist. A renamed export leaves the docs telling readers to import
+// something that is gone — which they discover as a build error in *their*
+// project, on the version they just installed.
+//
+// Deliberately only the import lines. Making every fenced snippet typecheck
+// would mean giving each one a preamble it does not need to be read, and the
+// churn would make the docs worse to serve a gate. An import line is the part a
+// reader copies verbatim and the part a rename actually breaks.
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const docsDir = resolve(repoRoot, "docs/content/docs");
+const distDir = resolve(repoRoot, "packages/convex-logto/dist");
+
+/** Entry subpath -> the declaration file that states its public surface. */
+const ENTRIES = {
+  "convex-logto": "index.d.ts",
+  "convex-logto/react": "react.d.ts",
+  "convex-logto/react-session": "react-session.d.ts",
+  "convex-logto/native": "native.d.ts",
+  "convex-logto/native-session": "native-session.d.ts",
+};
+
+/**
+ * The emitted `export { ... }` list, not every declaration in the file.
+ *
+ * tsup emits a `declare class` for anything an exported type mentions, so
+ * scanning declarations would accept names no consumer can import — passing on
+ * exactly the drift this exists to catch.
+ */
+function exportedNames(declarationFile) {
+  const source = readFileSync(declarationFile, "utf8");
+  const names = new Set();
+  for (const [, list] of source.matchAll(/^export \{([^}]*)\};?$/gm)) {
+    for (const part of list.split(",")) {
+      const name = part.trim().replace(/^type\s+/, "").split(/\s+as\s+/).pop();
+      if (name) names.add(name);
+    }
+  }
+  return names;
+}
+
+const surface = new Map();
+for (const [specifier, file] of Object.entries(ENTRIES)) {
+  const path = join(distDir, file);
+  let names;
+  try {
+    names = exportedNames(path);
+  } catch {
+    console.error(
+      `check-docs-imports: ${file} is missing. Build the package first ` +
+        "(`pnpm --filter convex-logto build`); this check reads the emitted " +
+        "declarations, not the source, so it sees what a consumer would.",
+    );
+    process.exit(1);
+  }
+  if (names.size === 0) {
+    console.error(`check-docs-imports: ${file} declares no exports.`);
+    process.exit(1);
+  }
+  surface.set(specifier, names);
+}
+
+/** `import ... from "convex-logto..."`, named bindings only. */
+const IMPORT = /import\s+(type\s+)?\{([^}]*)\}\s*from\s*["'](convex-logto[^"']*)["']/g;
+
+const problems = [];
+for (const file of readdirSync(docsDir).filter((n) => n.endsWith(".mdx"))) {
+  const text = readFileSync(join(docsDir, file), "utf8");
+  for (const [, , bindings, specifier] of text.matchAll(IMPORT)) {
+    // Subpaths with no importable surface of their own — `convex.config` is a
+    // default export the Convex CLI consumes, never a named import.
+    if (!surface.has(specifier)) {
+      problems.push(`${file}: imports from unknown entry "${specifier}"`);
+      continue;
+    }
+    const names = surface.get(specifier);
+    for (const part of bindings.split(",")) {
+      const name = part.trim().replace(/^type\s+/, "").split(/\s+as\s+/)[0];
+      if (name && !names.has(name)) {
+        problems.push(`${file}: "${specifier}" does not export ${name}`);
+      }
+    }
+  }
+}
+
+if (problems.length > 0) {
+  console.error(
+    `check-docs-imports: ${problems.length} import(s) in the docs name ` +
+      `something the package does not export:\n  ${problems.join("\n  ")}`,
+  );
+  process.exit(1);
+}
+
+console.error(
+  `check-docs-imports: every documented import resolves (${surface.size} entries).`,
+);


### PR DESCRIPTION
## The gap

Nothing in this repo compiles an `.mdx` code fence, and the exports map has no
idea `docs/` exists. So a renamed or removed export leaves the documentation
telling readers to import something that is gone — and they find out as a build
error in *their* project, on the version they just installed.

It is not hypothetical drift. Each of the four audit waves has turned up
documentation that had come apart from the code; this PR is the slice of that a
machine can hold.

## What it does

`scripts/check-docs-imports.mjs` (`pnpm check:docs`) extracts every
`import { … } from "convex-logto…"` in `docs/content/docs/*.mdx` and checks each
name against the **emitted** `dist/*.d.ts` export list for that entry.

- **Emitted, not source.** tsup writes a `declare class` for anything an
  exported type mentions, so scanning declarations would accept names no
  consumer can import — passing on exactly the drift this exists to catch. It
  parses the `export { … }` list instead.
- **After the build**, for the same reason: it should see the surface an
  `npm i` produces. Added to `ci.yml` and `release.yml` right after
  `lint:package`, the other "verify the published artifact" step.
- **Import lines only, on purpose.** Making every fenced snippet typecheck would
  mean giving each one a preamble it does not need in order to be *read*, and
  that churn would make the docs worse to serve a gate. An import line is the
  part a reader copies verbatim and the part a rename actually breaks.
- An unknown entry subpath fails too, so `convex-logto/reeact-session` cannot
  slip through as "no exports to check".

## It discriminates

Renaming one documented import:

```
check-docs-imports: 1 import(s) in the docs name something the package does not export:
  api-reference.mdx: "convex-logto" does not export assertOrganizationRoleTypo
exit=1
```

Clean today across all five entries. `AGENTS.md` documents the command and the
reasoning next to the existing build-verification note — which also gained a
line for the session-entry parity check added in #218.

Full workspace `lint` / `format:check` / `check-types` / `test` / `build` /
`lint:package` / `check:docs` pass.
