### PR TITLE
test(e2e): the sign-in outcome race answered "neither" on its own navigation

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -165,13 +165,112 @@ test account accumulates sessions — every run leaves some behind — so "the o
 device" is not something the list can be asked for, and aiming a revoke at it
 would eventually aim at whatever an earlier run abandoned.
 
-One flake seen so far, and only after several runs back to back: the re-sign-in
-step reported that the click reached *neither* Logto's prompt nor a signed-in
-app, with a blank document. It did not reproduce on the next run. The assertion
-now prints the URL and whatever text is on screen, so the next occurrence says
-whether Logto refused the authorize request, a redirect was still in flight, or
-the app never navigated. Treat one "neither" as evidence to collect rather than a
-regression to bisect; treat two as a bug.
+### The flake, and what it turned out to be
+
+The re-sign-in step can report that the click reached *neither* Logto's prompt
+nor a signed-in app. The first time, all it left was a blank screenshot. Two
+things were wrong, and only the diagnostic separated them.
+
+**The harness's own race.** `signInOutcome` used to race two `waitFor*` calls and
+map each rejection to `"neither"` — so *any* early rejection decided the whole
+question. A sign-in click navigates, navigation destroys the execution context a
+`waitForFunction` poll is running in, and that rejects **immediately**: it won
+the race and reported "neither" while the credential prompt was still on its way.
+The failures looked exactly like Logto's sign-in page failing to render. It was
+rendering fine — a probe found `input[name=identifier]` present and no console
+errors. It now polls both conditions in one `evaluate`, treats a failed read as
+"ask again", and lets only the deadline answer `"neither"`.
+
+**A genuinely slow IdP.** Underneath that, this self-hosted Logto does sometimes
+stall a request for tens of seconds. Straight from the shell, three requests to
+the same URL:
+
+```
+sign-in page: 000 in 30.005678s   ← timed out
+sign-in page: 302 in 0.304516s
+sign-in page: 302 in 0.300324s
+```
+
+Nothing in `convex-logto` is on that path — the app has already redirected and is
+waiting on the IdP. It shows up now as a Playwright *navigation* timeout naming
+the `/oidc/auth` URL, which is a much better failure than "neither". Re-run.
+
+**Reading a failure here.** The assertion prints a **redacted** URL — origin and
+path in full, query and fragment reduced to parameter *names*, because this runs
+right after a sign-in click and the raw URL can carry an authorization `code` —
+plus whatever text is on screen. A `"neither"` naming an **app** origin is the
+one worth bisecting: it means the click never got the browser off the app at all.
+
+Every step is a required assertion, and each one asserts the thing rather than a
+proxy for it:
+
+- **zero-RTT** fails if the restore *mints a token*, named by function rather
+  than counted by URL — elapsed time proves nothing (a fast round trip looks
+  identical), and a POST count would also catch the calls the example's own UI
+  makes, so the library's test would break whenever the example changed;
+- **rotation runs twice**, because a rotated token that was never persisted
+  passes the first refresh and fails the second;
+- **sign-out is re-checked after a reload**, because cleared UI with live
+  credentials still in storage is exactly the bug;
+- **re-sign-in must be prompted.** Sign-out is federated by default, so Logto
+  has to ask for credentials again — that prompt is the only evidence the
+  RP-initiated logout actually reached Logto, since clearing local storage looks
+  identical from the app either way;
+- **revocation reaches the other device without a reload**, because a revocation
+  that only lands on the next page load is a cache expiry, not a revocation —
+  and the device that *did* the revoking has to stay signed in;
+- **sign-out everywhere** is checked on the device that never saw the click;
+- **organization authorization** is asserted both ways — the test user's real
+  role in their real organization grants, and the *same role name* in an
+  organization they do not belong to is denied. Whether Logto puts
+  `organizations` and `organization_roles` in the **ID token** for the configured
+  scopes is a property of the deployment, and every one of the
+  `assertOrganization*` helpers is built on it being true;
+- **the organization token is minted, then cached, then forced past the cache.**
+  `minted` is the only externally visible difference between "asked Logto" and
+  "served from the component", every mint spends a refresh grant, and there is no
+  way to prove `forceRefresh` bypasses a cache without first proving the cache
+  exists. The exchange also has to return **no token string**, because the app
+  never set `exposeAccessTokens`;
+- **`fetchUserInfo` answers for the same subject** the ID token names — a
+  userinfo response for a different subject would mean the component
+  authenticated the wrong session, and both are just JSON to an offline test.
+
+Each run names the session it is about to revoke (`e2e-target-<runid>`). The
+test account accumulates sessions — every run leaves some behind — so "the other
+device" is not something the list can be asked for, and aiming a revoke at it
+would eventually aim at whatever an earlier run abandoned.
+
+### The one flake, and what it turned out to be
+
+The re-sign-in step can report that the click reached *neither* Logto's prompt
+nor a signed-in app. The first time, all it left was a blank screenshot. The
+assertion now prints a **redacted** URL — origin and path in full, query and
+fragment reduced to parameter *names*, because this runs right after a sign-in
+click and the raw URL can carry an authorization `code` — plus whatever text is
+on screen:
+
+```
+✗ failed after 7 step(s): the sign-in click reached neither Logto's prompt nor a
+  signed-in app, at https://auth.example.com/sign-in?[app_id] showing "(unreadable)"
+```
+
+Which named it in one run: the browser *had* reached Logto's sign-in experience,
+and that page never rendered. Confirmed straight from the shell — the first
+request hung for the full 30 second timeout and the next two answered in 0.3s:
+
+```
+sign-in page: 000 in 30.005678s
+sign-in page: 302 in 0.304516s
+sign-in page: 302 in 0.300324s
+```
+
+So it is the Logto deployment stalling a request, not the library. Nothing in
+`convex-logto` is on that path — the app has already redirected and is waiting on
+the IdP. Re-run.
+
+A "neither" that names an **app** origin is a different animal and worth
+bisecting: it means the sign-in click never got the browser off the app at all.
 
 > The zero-RTT step needs `initialAuthTokenReuse: true` on the app's
 > `ConvexReactClient`, which every example here sets. Without it Convex confirms

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -165,6 +165,14 @@ test account accumulates sessions — every run leaves some behind — so "the o
 device" is not something the list can be asked for, and aiming a revoke at it
 would eventually aim at whatever an earlier run abandoned.
 
+One flake seen so far, and only after several runs back to back: the re-sign-in
+step reported that the click reached *neither* Logto's prompt nor a signed-in
+app, with a blank document. It did not reproduce on the next run. The assertion
+now prints the URL and whatever text is on screen, so the next occurrence says
+whether Logto refused the authorize request, a redirect was still in flight, or
+the app never navigated. Treat one "neither" as evidence to collect rather than a
+regression to bisect; treat two as a bug.
+
 > The zero-RTT step needs `initialAuthTokenReuse: true` on the app's
 > `ConvexReactClient`, which every example here sets. Without it Convex confirms
 > the cached token and immediately refetches, spending a Logto refresh grant on

--- a/e2e/session-flow.mjs
+++ b/e2e/session-flow.mjs
@@ -224,6 +224,22 @@ async function signInOutcome(page) {
   ]);
 }
 
+/**
+ * Where the browser actually ended up, for the third outcome.
+ *
+ * "Neither" is the one answer that names no cause, and it has happened: a blank
+ * document with nothing to read. Whether that is Logto refusing the authorize
+ * request, a redirect still in flight, or an app that never navigated is the
+ * whole question, and the URL plus whatever text is on screen separates them.
+ * Reported rather than asserted on, because this is a diagnosis, not a rule.
+ */
+async function describePage(page) {
+  const text = await page
+    .evaluate(() => document.body.innerText.replace(/\s+/g, " ").trim())
+    .catch(() => "(unreadable)");
+  return `at ${page.url()} showing ${text ? JSON.stringify(text.slice(0, 160)) : "an empty document"}`;
+}
+
 /** The cached ID token, read from the library's own key. */
 function readStoredIdToken(page) {
   return page.evaluate(() => {
@@ -518,7 +534,8 @@ try {
     outcome === "silent"
       ? "sign-out did not end Logto's session: the next sign-in completed " +
           "silently over a surviving SSO cookie"
-      : "the sign-in click reached neither Logto's prompt nor a signed-in app",
+      : "the sign-in click reached neither Logto's prompt nor a signed-in app, " +
+          `${await describePage(page)}`,
   );
   await signInAtLogto(page);
   await waitForSignedIn(page);

--- a/e2e/session-flow.mjs
+++ b/e2e/session-flow.mjs
@@ -199,29 +199,69 @@ async function renameCurrentDevice(target, label) {
 
 /**
  * Which outcome a sign-in click produced: Logto's credential prompt, or an app
- * that is already signed in. Racing the two is the point — "silent" and
- * "prompted" are both plausible outcomes of the same click, and waiting for
- * only the one we expect turns a wrong answer into an opaque timeout.
+ * that is already signed in. Watching for both is the point — "silent" and
+ * "prompted" are both plausible outcomes of the same click, and waiting for only
+ * the one we expect turns a wrong answer into an opaque timeout.
+ *
+ * Polled rather than raced, and that is not a style choice. Racing two
+ * `waitFor*` calls and mapping each rejection to "neither" makes *any* early
+ * rejection decide the whole question — and a sign-in click navigates, which
+ * destroys the execution context a `waitForFunction` poll is running in. That
+ * rejects immediately, wins the race, and reports "neither" while the credential
+ * prompt is still on its way. It cost an afternoon: the failures looked like
+ * Logto's sign-in page not rendering, and the page was rendering fine.
+ *
+ * So: read both conditions in one evaluate, treat a failed read as "ask again",
+ * and let only the deadline answer "neither".
  */
 async function signInOutcome(page) {
-  return await Promise.race([
-    page
-      .waitForSelector("input[name=identifier]", { timeout: 45_000 })
-      .then(
-        () => "prompted",
-        () => "neither",
-      ),
-    page
-      .waitForFunction(
-        () => /sign out/i.test(document.body.innerText),
-        undefined,
-        { timeout: 45_000 },
-      )
-      .then(
-        () => "silent",
-        () => "neither",
-      ),
-  ]);
+  const deadline = Date.now() + 45_000;
+  while (Date.now() < deadline) {
+    const state = await page
+      .evaluate(() => ({
+        prompted: document.querySelector("input[name=identifier]") !== null,
+        signedIn: /sign out/i.test(document.body.innerText),
+      }))
+      .catch(() => null);
+    if (state?.prompted) return "prompted";
+    if (state?.signedIn) return "silent";
+    await page.waitForTimeout(250);
+  }
+  return "neither";
+}
+
+/**
+ * A URL safe to write down: origin and path in full, query and fragment reduced
+ * to their parameter *names*.
+ *
+ * This runs immediately after a sign-in click, so the browser may be sitting on
+ * an authorization request or a callback — `?code=…&state=…`, or a fragment
+ * carrying a token. Failures go to stderr and the README tells you to redirect
+ * stderr to a file, so a raw URL here is an authorization code written into a
+ * log. The names alone still answer the question being asked: seeing `code` and
+ * `state` present is what tells you the callback was reached.
+ */
+function safeUrl(raw) {
+  let url;
+  try {
+    url = new URL(raw);
+  } catch {
+    return "(unparseable URL)";
+  }
+  // `about:blank` — the very page this diagnostic was written for — has origin
+  // "null", and joining that to a pathname produces "nullblank".
+  const base =
+    url.origin === "null"
+      ? `${url.protocol}${url.pathname}`
+      : `${url.origin}${url.pathname}`;
+  const parts = [base.slice(0, 200)];
+  const names = (search) => [...new URLSearchParams(search).keys()].join(",");
+  const query = names(url.search);
+  // A fragment is not always `a=b`, so say it is there even when nothing parses.
+  const fragment = url.hash === "" ? "" : names(url.hash.slice(1)) || "…";
+  if (query) parts.push(`?[${query}]`);
+  if (fragment) parts.push(`#[${fragment}]`);
+  return parts.join("");
 }
 
 /**
@@ -230,14 +270,14 @@ async function signInOutcome(page) {
  * "Neither" is the one answer that names no cause, and it has happened: a blank
  * document with nothing to read. Whether that is Logto refusing the authorize
  * request, a redirect still in flight, or an app that never navigated is the
- * whole question, and the URL plus whatever text is on screen separates them.
- * Reported rather than asserted on, because this is a diagnosis, not a rule.
+ * whole question, and the redacted URL plus whatever text is on screen narrows
+ * it. Reported rather than asserted on, because this is a diagnosis, not a rule.
  */
 async function describePage(page) {
   const text = await page
     .evaluate(() => document.body.innerText.replace(/\s+/g, " ").trim())
     .catch(() => "(unreadable)");
-  return `at ${page.url()} showing ${text ? JSON.stringify(text.slice(0, 160)) : "an empty document"}`;
+  return `at ${safeUrl(page.url())} showing ${text ? JSON.stringify(text.slice(0, 160)) : "an empty document"}`;
 }
 
 /** The cached ID token, read from the library's own key. */
@@ -290,6 +330,42 @@ function clearCachedIdToken(page) {
       }
     }
   });
+}
+
+/**
+ * Prove the redactor before anything can need it.
+ *
+ * It only ever runs on a failure, so a bug in it would first show up in the one
+ * place there is no second chance: a log that has already been written, with an
+ * authorization code in it. Checked here rather than in a test file because
+ * `e2e/` is outside the workspace and has no runner — and because a guarantee
+ * about what may be written down belongs next to the writing.
+ */
+for (const [raw, expected] of [
+  [
+    "http://localhost:5174/callback?code=SECRET&state=SECRET",
+    "http://localhost:5174/callback?[code,state]",
+  ],
+  [
+    "https://auth.example.com/oidc/auth?client_id=a&state=SECRET",
+    "https://auth.example.com/oidc/auth?[client_id,state]",
+  ],
+  [
+    "http://localhost:5174/#access_token=SECRET&token_type=bearer",
+    "http://localhost:5174/#[access_token,token_type]",
+  ],
+  ["http://localhost:5174/", "http://localhost:5174/"],
+  ["about:blank", "about:blank"],
+  ["not a url", "(unparseable URL)"],
+]) {
+  const got = safeUrl(raw);
+  if (got !== expected || got.includes("SECRET")) {
+    console.error(
+      `session-flow: the URL redactor is broken — ${JSON.stringify(raw)} ` +
+        `became ${JSON.stringify(got)}, expected ${JSON.stringify(expected)}.`,
+    );
+    process.exit(1);
+  }
 }
 
 const browser = await chromium.launch({ headless, channel: "chrome" });


### PR DESCRIPTION
The re-sign-in step races two meaningful answers — Logto's credential prompt
(sign-out reached Logto) against an already-signed-in app (it did not) — and has
a third, `"neither"`, which named no cause at all. It fired today, once, with a
blank screenshot and nothing to work from.

Adding the diagnostic (below) turned one flake into two findings.

## 1. The race was answering its own navigation

`signInOutcome` raced two `waitFor*` calls and mapped **each rejection** to
`"neither"`, so any early rejection decided the whole question:

```js
page.waitForFunction(() => /sign out/i.test(document.body.innerText), …)
  .then(() => "silent", () => "neither")   // ← any failure, not just the timeout
```

A sign-in click navigates. Navigation destroys the execution context that poll is
running in, so it rejects **immediately** — winning the race and reporting
`"neither"` while the credential prompt was still on its way.

It reads exactly like Logto failing to render, and that is what I chased. A probe
found the opposite: `200` for `/sign-in` and every asset, `input[name=identifier]`
present, no console errors, `document.body.innerText` = `"Sign in to your account
… Sign in … No account yet? Create account"`.

Now it polls both conditions in one `evaluate`, treats a failed read as "ask
again", and lets only the deadline answer `"neither"`. Three consecutive
ten-step runs since.

## 2. Underneath it, a genuinely slow IdP

This self-hosted Logto does sometimes stall a request for tens of seconds.
Straight from the shell, same URL, three times:

```
sign-in page: 000 in 30.005678s   ← timed out
sign-in page: 302 in 0.304516s
sign-in page: 302 in 0.300324s
```

Nothing in `convex-logto` is on that path — the app has already redirected and is
waiting on the IdP. With the race fixed it surfaces as a Playwright *navigation*
timeout naming the `/oidc/auth` URL, which is a far better failure than
`"neither"`. Documented in `e2e/README.md` as "re-run", with the note that a
`"neither"` naming an **app** origin is the one worth bisecting.

## The diagnostic, redacted

`describePage` reports where the browser ended up. The URL is **redacted** —
origin and path in full, query and fragment reduced to parameter *names*:

```
at https://auth.example.com/sign-in?[app_id] showing "(unreadable)"
at http://localhost:5174/callback?[code,state] showing …
```

This runs right after a sign-in click, so the raw URL can be an authorize request
or a callback carrying `code`/`state` — and failures go to stderr, which the
README tells you to redirect into a file. The parameter names keep the whole
diagnostic value (seeing `code` and `state` is what tells you the callback was
reached) without writing either value down.

A startup self-check proves the redactor on six inputs — including `about:blank`,
whose `origin` is the string `"null"` and which naively renders as `"nullblank"`
— before anything can need it. It only ever runs on a failure, so a bug in it
would first appear in the one place there is no second chance: a log that has
already been written.

No changeset: `e2e/` is outside the workspace and outside the published package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in outcome detection by polling combined page states, reducing intermittent failures caused by competing waits.
  * Navigation errors during sign-in are treated as temporary until the timeout is reached.
  * Enhanced failure diagnostics with redacted URLs and visible page details, protecting query and fragment values.

* **Documentation**
  * Added guidance for interpreting intermittent re-sign-in failures, including troubleshooting context and example diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->