### PR TITLE
chore(deps): resolve under the same three-day release-age gate Dependabot uses

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3921,8 +3921,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.420:
-    resolution: {integrity: sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==}
+  electron-to-chromium@1.5.416:
+    resolution: {integrity: sha512-K6bvB2BjnNrugtIih6ewlbBI9DXa976jIdiIlRLHhBoEI9a4JaQjjHyF+A1IQI543aQYR4LnmOrT/K5fZj0aPA==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -9792,7 +9792,7 @@ snapshots:
     dependencies:
       baseline-browser-mapping: 2.11.20
       caniuse-lite: 1.0.30001810
-      electron-to-chromium: 1.5.420
+      electron-to-chromium: 1.5.416
       node-releases: 2.0.54
       update-browserslist-db: 1.3.2(browserslist@4.28.8)
 
@@ -10085,7 +10085,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.420: {}
+  electron-to-chromium@1.5.416: {}
 
   emoji-regex@8.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,11 @@ packages:
   - packages/*
   - docs
   - examples/*
+
+# Resolve only versions published at least three days ago (minutes). This is
+# the gate Dependabot applies when it regenerates the lockfile, so a local
+# `pnpm update` that pulled a fresher version would leave every open
+# Dependabot PR unable to rebase until that version aged past it. It also
+# keeps a package published minutes ago, the shape of a hijacked release, out
+# of the lockfile. `pnpm install --frozen-lockfile` is unaffected.
+minimumReleaseAge: 4320


### PR DESCRIPTION
Dependabot regenerates this lockfile with pnpm's `minimumReleaseAge` set to 4320 minutes (three days). #236's browserslist bump resolved locally without that gate and pulled in `electron-to-chromium@1.5.420`, published five hours earlier. Since then every Dependabot rebase fails with `ERR_PNPM_NO_MATURE_MATCHING_VERSION` (see the update runs at 02:42 UTC), so none of the open dependency PRs can update.

## What

- `pnpm-workspace.yaml` sets `minimumReleaseAge: 4320`, so a local `pnpm update` resolves under the same gate Dependabot applies. `pnpm install --frozen-lockfile` is unaffected. The setting also keeps a version published minutes ago, the shape of a hijacked release, out of the lockfile.
- `electron-to-chromium` re-resolved under the gate: 1.5.420 → 1.5.416.

## Verified

- All 1202 packages in the lockfile checked against the registry's publish times: none is younger than three days.
- `pnpm install --frozen-lockfile` and `pnpm audit:dependencies` pass.

https://claude.ai/code/session_01MWGGBr7qcGZep4gYy9YZcC
