### PR TITLE
fix(react): keep the React Compiler rules on, and fix what they found

### DIFF
--- a/packages/convex-logto/.oxlintrc.json
+++ b/packages/convex-logto/.oxlintrc.json
@@ -24,27 +24,10 @@
       }
     ],
     "react/react-in-jsx-scope": "off",
-    // oxlint 1.79 folded the React Compiler rules into the react plugin's
-    // correctness and suspicious categories. This library is not compiled by
-    // the React Compiler, and the five below flag patterns this code uses on
-    // purpose; the comment beside each site says why. The rest of that set
-    // (set-state-in-render, purity, immutability, ...) stays on: it passes,
-    // and it catches real mistakes.
-    // The "latest handler" refs are assigned during render because child
-    // effects run before the parent's; an effect would hand the watcher the
-    // previous render's handler.
-    "react/refs": "off",
-    // `ConvexProviderWithAuth` takes the auth hook as a prop. That is Convex's
-    // API, not a hook used as a value.
-    "react/hooks": "off",
-    // The engine memo reads seed values (`seedRef.current`) that must stay out
-    // of its dependency list: a re-issued SSR token would otherwise rebuild
-    // the engine and abandon an in-flight callback exchange.
-    "react/memo-dependencies": "off",
-    "react/preserve-manual-memoization": "off",
-    // The one-frame settle effects write state from an effect so the settled
-    // frame is its own commit; each converges in one extra render.
-    "react/set-state-in-effect": "off",
+    // The React Compiler rules (react/refs, react/set-state-in-effect, ...)
+    // stay on even though nothing here is compiled by the React Compiler: they
+    // catch real mistakes. The few sites that break one on purpose carry a
+    // disable directive with the reason.
     "typescript/consistent-type-assertions": [
       "error",
       {

--- a/packages/convex-logto/src/auth-loading.ts
+++ b/packages/convex-logto/src/auth-loading.ts
@@ -68,8 +68,13 @@ export function useNativeAuthState(
 ): { isLoading: boolean; isAuthenticated: boolean } {
   const [seenAuthenticated, setSeenAuthenticated] = useState(false);
   useEffect(() => {
-    if (seenAuthenticated !== isAuthenticated)
+    // From an effect, not during render: the loading pulse has to be a
+    // committed frame Convex can see, and a render-time update would fold it
+    // into the settled frame.
+    if (seenAuthenticated !== isAuthenticated) {
+      // oxlint-disable-next-line react/set-state-in-effect -- see above
       setSeenAuthenticated(isAuthenticated);
+    }
   }, [isAuthenticated, seenAuthenticated]);
   return nativeAuthState(isInitialized, isAuthenticated, seenAuthenticated);
 }

--- a/packages/convex-logto/src/native-session.tsx
+++ b/packages/convex-logto/src/native-session.tsx
@@ -17,6 +17,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useInsertionEffect,
   useMemo,
   useRef,
   useSyncExternalStore,
@@ -106,14 +107,15 @@ export function ConvexLogtoSessionProvider({
   const onAuthErrorRef = useRef(onAuthError);
   const clientDescriptorRef = useRef(clientDescriptor);
   const onAuthEventRef = useRef(onAuthEvent);
-  useEffect(() => {
+  // An insertion effect, because React runs every insertion effect of a
+  // commit before any passive effect. The `convex_authenticated` watcher below
+  // is a child, and a child's passive effect runs before this component's, so
+  // a passive effect here would hand it the previous render's handler.
+  useInsertionEffect(() => {
     onAuthErrorRef.current = onAuthError;
     clientDescriptorRef.current = clientDescriptor;
+    onAuthEventRef.current = onAuthEvent;
   });
-  // Assigned during render, not in an effect: child effects run before the
-  // parent's, so the `convex_authenticated` watcher below would emit into a
-  // ref that still held the previous render's handler.
-  onAuthEventRef.current = onAuthEvent;
 
   const engine = useMemo(() => {
     const storage = new NativeSessionStorageArea(
@@ -151,6 +153,7 @@ export function ConvexLogtoSessionProvider({
 
   return (
     <SessionContext.Provider value={contextValue}>
+      {/* oxlint-disable-next-line react/hooks -- `useAuth` is a prop that takes a hook; that is Convex's API. */}
       <ConvexProviderWithAuth client={client} useAuth={useAuthFromSession}>
         {reactiveRevocation ? <RevocationWatcher /> : null}
         <ConvexAuthPhaseWatcher engine={engine} />

--- a/packages/convex-logto/src/native.bridge.test.tsx
+++ b/packages/convex-logto/src/native.bridge.test.tsx
@@ -9,6 +9,7 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { ConvexLogtoProvider, useLogtoAuth } from "./native";
+import type { LogtoAuthEvent } from "./auth-events";
 
 (
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -41,6 +42,7 @@ type ReportedAuth = {
 };
 let reportedAuth: ReportedAuth | null = null;
 
+let convexAuthenticated = false;
 vi.mock("convex/react", () => ({
   // The real provider calls `useAuth` and stops asking for a token after one
   // `null`. Calling it here is what makes the bridge's own contract observable.
@@ -54,7 +56,10 @@ vi.mock("convex/react", () => ({
     reportedAuth = useAuth();
     return children;
   },
-  useConvexAuth: () => ({ isLoading: false, isAuthenticated: false }),
+  useConvexAuth: () => ({
+    isLoading: false,
+    isAuthenticated: convexAuthenticated,
+  }),
 }));
 
 type AuthApi = ReturnType<typeof useLogtoAuth>;
@@ -65,23 +70,31 @@ function ApiProbe() {
 }
 
 let root: Root | null = null;
+function providerTree(
+  onAuthError?: (error: Error) => void,
+  onAuthEvent?: (event: LogtoAuthEvent) => void,
+) {
+  return (
+    <ConvexLogtoProvider
+      client={{} as never}
+      config={{ endpoint: "https://example.logto.app", appId: "app123" }}
+      redirectUri="io.logto://callback"
+      {...(onAuthError ? { onAuthError } : {})}
+      {...(onAuthEvent ? { onAuthEvent } : {})}
+    >
+      <ApiProbe />
+    </ConvexLogtoProvider>
+  );
+}
 async function renderProvider(onAuthError?: (error: Error) => void) {
   root = createRoot(document.createElement("div"));
   await act(async () => {
-    root!.render(
-      <ConvexLogtoProvider
-        client={{} as never}
-        config={{ endpoint: "https://example.logto.app", appId: "app123" }}
-        redirectUri="io.logto://callback"
-        {...(onAuthError ? { onAuthError } : {})}
-      >
-        <ApiProbe />
-      </ConvexLogtoProvider>,
-    );
+    root!.render(providerTree(onAuthError));
   });
 }
 
 beforeEach(() => {
+  convexAuthenticated = false;
   mockLogto.signIn.mockReset().mockResolvedValue(undefined);
   mockLogto.signOut.mockReset().mockResolvedValue(undefined);
   mockLogto.getIdToken.mockReset().mockResolvedValue(undefined);
@@ -192,4 +205,19 @@ it("a sign-in that fails leaves Convex disarmed", async () => {
     await capturedApi!.signIn().catch(() => {});
   });
   expect(reportedAuth?.isAuthenticated).toBe(false);
+});
+
+it("a handler passed on the render that authenticates sees convex_authenticated", async () => {
+  // Same commit-order contract as the web bridge: the child watcher's passive
+  // effect runs before the provider's, so the provider publishes the handler
+  // from an insertion effect.
+  const events: LogtoAuthEvent[] = [];
+  await renderProvider();
+
+  convexAuthenticated = true;
+  await act(async () => {
+    root!.render(providerTree(undefined, (event) => events.push(event)));
+  });
+
+  expect(events.map((event) => event.phase)).toEqual(["convex_authenticated"]);
 });

--- a/packages/convex-logto/src/native.tsx
+++ b/packages/convex-logto/src/native.tsx
@@ -15,6 +15,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useInsertionEffect,
   useMemo,
   useRef,
   useState,
@@ -268,13 +269,17 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
   }
 
   // Opt-in phase timings. The emitter is built once per mount and reads the
-  // handler through a ref, so an inline arrow never rebuilds anything — and
+  // handler through a ref, so an inline arrow never rebuilds anything, and
   // while the ref is empty (no `onAuthEvent`) an emit costs nothing.
   const onAuthEventRef = useRef(onAuthEvent);
-  // Assigned during render, not in an effect: child effects run before the
-  // parent's, so the `convex_authenticated` watcher below would emit into a
-  // ref that still held the previous render's handler.
-  onAuthEventRef.current = onAuthEvent;
+  // An insertion effect, because React runs every insertion effect of a
+  // commit before any passive effect. The `convex_authenticated` watcher below
+  // is a child, and a child's passive effect runs before this component's, so
+  // a passive effect here would hand it the previous render's handler.
+  useInsertionEffect(() => {
+    onAuthEventRef.current = onAuthEvent;
+  });
+  // oxlint-disable-next-line react/refs -- the emitter reads the ref at emit time, from effects and handlers, never during render
   const events = useMemo(() => createAuthEventEmitter(onAuthEventRef), []);
   useEffect(() => {
     events("bootstrap_start");
@@ -346,6 +351,7 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
       <AuthErrorContext.Provider value={onAuthError}>
         <TokenFailureContext.Provider value={tokenFailure}>
           <LogtoProvider config={logtoConfig}>
+            {/* oxlint-disable-next-line react/hooks -- `useAuth` is a prop that takes a hook; that is Convex's API. */}
             <ConvexProviderWithAuth client={client} useAuth={useAuthFromLogto}>
               <ConvexAuthPhaseWatcher events={events} />
               {children}
@@ -430,6 +436,10 @@ export function useLogtoAuth(): LogtoAuth {
           if (active) setUser(undefined);
         });
     } else {
+      // Deriving `user` from `isAuthenticated` instead would show the previous
+      // user's claims for a frame on the next sign-in, until the fetch above
+      // replaces them. Clearing them costs one render, at sign-out.
+      // oxlint-disable-next-line react/set-state-in-effect -- see above
       setUser(undefined);
     }
     return () => {

--- a/packages/convex-logto/src/react-session.tsx
+++ b/packages/convex-logto/src/react-session.tsx
@@ -15,6 +15,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useInsertionEffect,
   useMemo,
   useRef,
   useSyncExternalStore,
@@ -187,39 +188,31 @@ export function ConvexLogtoSessionProvider({
   const cookieDeviceBinding = cookieTransport?.deviceBinding;
 
   // The engine must survive re-renders, but `navigate`/`onAuthError` are often
-  // inline arrows with a fresh identity each render — route them through refs
-  // so the engine stays stable and still always calls the latest one. The
-  // client descriptor rides along for a stronger reason: apps usually learn it
+  // inline arrows with a fresh identity each render. They go through refs so
+  // the engine stays stable and still calls the latest one. The client
+  // descriptor rides along for a stronger reason: apps usually learn it
   // asynchronously, and rebuilding the engine to deliver it would restart the
-  // mount state machine — abandoning an in-flight callback exchange and leaving
+  // mount state machine, abandoning an in-flight callback exchange and leaving
   // the tree signed out with a live session on the server.
+  // Same reason for `cookieTransport={{ fetch: (u, i) => fetch(u, i) }}`: a
+  // documented option, and an inline arrow changes identity on every render.
   const navigateRef = useRef(navigate);
   const onAuthErrorRef = useRef(onAuthError);
   const clientDescriptorRef = useRef(clientDescriptor);
   const onAuthEventRef = useRef(onAuthEvent);
-  useEffect(() => {
+  const cookieFetchRef = useRef(cookieFetch);
+  // An insertion effect, because React runs every insertion effect of a
+  // commit before any passive effect. The `convex_authenticated` watcher below
+  // is a child, and a child's passive effect runs before this component's, so
+  // a passive effect here would hand it the previous render's handler.
+  useInsertionEffect(() => {
     navigateRef.current = navigate;
     onAuthErrorRef.current = onAuthError;
     clientDescriptorRef.current = clientDescriptor;
+    onAuthEventRef.current = onAuthEvent;
+    cookieFetchRef.current = cookieFetch;
   });
-  // Assigned during render, not in an effect: child effects run before the
-  // parent's, so the `convex_authenticated` watcher below would emit into a
-  // ref that still held the previous render's handler.
-  onAuthEventRef.current = onAuthEvent;
 
-  // Seed values, not dependencies. `handler.getInitialToken()` rotates the
-  // cookie and mints a fresh ID token on every call, so re-running the SSR
-  // loader — `router.invalidate()`, a reload — hands back a different string
-  // every time. Rebuilding the engine for that abandons an in-flight exchange,
-  // spends the callback's single-use transaction under its replacement, and
-  // renders `isAuthenticated: false` with `isLoading: false` for a full
-  // re-auth round trip: a real signed-out flash.
-  const seedRef = useRef({ initialToken, initialSessionId });
-  seedRef.current = { initialToken, initialSessionId };
-  // Same reason: `cookieTransport={{ fetch: (u, i) => fetch(u, i) }}` is a
-  // documented option, and an inline arrow changes identity on every render.
-  const cookieFetchRef = useRef(cookieFetch);
-  cookieFetchRef.current = cookieFetch;
   const cookieFetchProxy = useCallback<typeof fetch>(
     (input, init) =>
       cookieFetchRef.current
@@ -228,6 +221,16 @@ export function ConvexLogtoSessionProvider({
     [],
   );
 
+  // `initialToken` and `initialSessionId` are seed values, not dependencies.
+  // `handler.getInitialToken()` rotates the cookie and mints a fresh ID token
+  // on every call, so re-running the SSR loader (`router.invalidate()`, a
+  // reload) hands back a different string every time. Rebuilding the engine
+  // for that abandons an in-flight exchange, spends the callback's single-use
+  // transaction under its replacement, and renders `isAuthenticated: false`
+  // with `isLoading: false` for a full re-auth round trip: a real signed-out
+  // flash. The engine reads them in its constructor, during this render,
+  // because its first snapshot has to match what the server rendered.
+  /* oxlint-disable react-hooks/exhaustive-deps -- see above */
   const engine = useMemo(() => {
     // Namespace storage by deployment so two dev apps on the same origin
     // (localhost) don't cross-read each other's sessions.
@@ -246,15 +249,12 @@ export function ConvexLogtoSessionProvider({
       storage,
       callbackPath,
       afterSignIn,
-      initialToken: seedRef.current.initialToken ?? undefined,
+      initialToken: initialToken ?? undefined,
       // Cookie mode always writes a non-secret marker. That both overwrites a
       // legacy localStorage credential and makes reload attempt the /token
       // route even though JavaScript cannot inspect the HttpOnly cookie.
       initialSession: usesCookieTransport
-        ? createCookieSessionMarker(
-            storage.readSession(),
-            seedRef.current.initialSessionId,
-          )
+        ? createCookieSessionMarker(storage.readSession(), initialSessionId)
         : undefined,
       // The credential is an HttpOnly cookie only the server can expire, so a
       // failed revoke is a failed sign-out — not something to swallow.
@@ -287,6 +287,7 @@ export function ConvexLogtoSessionProvider({
     cookieDeviceBinding,
     deviceBinding,
   ]);
+  /* oxlint-enable react-hooks/exhaustive-deps */
 
   useEffect(() => {
     engine.start();

--- a/packages/convex-logto/src/react.bridge.test.tsx
+++ b/packages/convex-logto/src/react.bridge.test.tsx
@@ -10,6 +10,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import type { ConvexLogtoProviderProps } from "./react";
 import { ConvexLogtoProvider, useLogtoAuth } from "./react";
+import type { LogtoAuthEvent } from "./auth-events";
 
 (
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -51,6 +52,7 @@ type CapturedAuth = {
 };
 let capturedAuth: CapturedAuth | null = null;
 
+let convexAuthenticated = false;
 vi.mock("convex/react", () => ({
   ConvexProviderWithAuth: ({
     useAuth,
@@ -62,7 +64,10 @@ vi.mock("convex/react", () => ({
     capturedAuth = useAuth();
     return children;
   },
-  useConvexAuth: () => ({ isLoading: false, isAuthenticated: false }),
+  useConvexAuth: () => ({
+    isLoading: false,
+    isAuthenticated: convexAuthenticated,
+  }),
 }));
 
 // --- harness ----------------------------------------------------------------
@@ -121,6 +126,7 @@ function setUrl(url: string) {
 }
 
 beforeEach(() => {
+  convexAuthenticated = false;
   setUrl("http://localhost:3000/");
   mockLogto.isAuthenticated = false;
   mockLogto.isLoading = false;
@@ -557,4 +563,34 @@ it("a forced fetch is never satisfied by a plain in-flight fetch", async () => {
   await expect(plain).resolves.toBe("plain-token");
   await expect(forced).resolves.toBe("forced-token");
   expect(mockLogto.clearAccessToken).toHaveBeenCalledTimes(1);
+});
+
+it("a handler passed on the render that authenticates sees convex_authenticated", async () => {
+  // The watcher that reports the phase is a child, and a child's passive
+  // effect runs before the provider's. The provider has to publish the new
+  // handler before any passive effect of that commit, or the phase an app
+  // measures against is lost to the previous render's empty slot.
+  const events: LogtoAuthEvent[] = [];
+  await renderProvider();
+
+  convexAuthenticated = true;
+  await rerenderProvider({ onAuthEvent: (event) => events.push(event) });
+
+  expect(events.map((event) => event.phase)).toEqual(["convex_authenticated"]);
+});
+
+it("latches on the first settle and ignores the SDK's later isLoading churn", async () => {
+  // `@logto/react` toggles `isLoading` around every SDK call. Forwarding that
+  // to Convex after the first settle would flicker the identity on each one.
+  mockLogto.isLoading = true;
+  await renderProvider();
+  expect(capturedAuth?.isLoading).toBe(true);
+
+  mockLogto.isLoading = false;
+  await rerenderProvider();
+  expect(capturedAuth?.isLoading).toBe(false);
+
+  mockLogto.isLoading = true;
+  await rerenderProvider();
+  expect(capturedAuth?.isLoading).toBe(false);
 });

--- a/packages/convex-logto/src/react.tsx
+++ b/packages/convex-logto/src/react.tsx
@@ -16,6 +16,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useInsertionEffect,
   useMemo,
   useRef,
   useState,
@@ -153,9 +154,10 @@ function useAuthFromLogto() {
     isLoading,
     authFlowPending,
   );
-  useEffect(() => {
-    if (shouldSettle) setSettled(true);
-  }, [shouldSettle]);
+  // Latched during render, the way React documents for remembering a fact
+  // from an earlier render: it re-runs this component before committing, so
+  // the settled frame commits once instead of once plus an effect re-render.
+  if (shouldSettle && !settled) setSettled(true);
 
   // Merge concurrent fetches of the same kind into one in-flight promise, so
   // StrictMode double-invokes and overlapping WS auth attempts can't stack
@@ -296,20 +298,20 @@ function LogtoCallback({
       onResolved();
       return;
     }
-    // The user cancelled / there was no session — just return to the app.
+    // The user cancelled / there was no session: just return to the app.
+    // `done` is not set here; it only gates <CodeExchange>, which a benign or
+    // error outcome never mounts.
     if (outcome.kind === "benign") {
       resolved.current = true;
-      setDone(true);
       onResolved();
       goAfterSignIn();
       return;
     }
     // A setup error (e.g. invalid_scope): recoverable, not fatal. Report and
-    // return to the app logged out, instead of throwing during render — a throw
+    // return to the app logged out, instead of throwing during render. A throw
     // would blank any tree without an error boundary above the provider.
     if (outcome.kind === "error") {
       resolved.current = true;
-      setDone(true);
       reportAuthError(onAuthError, new Error(outcome.message));
       onResolved();
       goAfterSignIn();
@@ -527,13 +529,17 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
   }
 
   // Opt-in phase timings. The emitter is built once per mount and reads the
-  // handler through a ref, so an inline arrow never rebuilds anything — and
+  // handler through a ref, so an inline arrow never rebuilds anything, and
   // while the ref is empty (no `onAuthEvent`) an emit costs nothing.
   const onAuthEventRef = useRef(onAuthEvent);
-  // Assigned during render, not in an effect: child effects run before the
-  // parent's, so the `convex_authenticated` watcher below would emit into a
-  // ref that still held the previous render's handler.
-  onAuthEventRef.current = onAuthEvent;
+  // An insertion effect, because React runs every insertion effect of a
+  // commit before any passive effect. The `convex_authenticated` watcher below
+  // is a child, and a child's passive effect runs before this component's, so
+  // a passive effect here would hand it the previous render's handler.
+  useInsertionEffect(() => {
+    onAuthEventRef.current = onAuthEvent;
+  });
+  // oxlint-disable-next-line react/refs -- the emitter reads the ref at emit time, from effects and handlers, never during render
   const events = useMemo(() => createAuthEventEmitter(onAuthEventRef), []);
   useEffect(() => {
     events("bootstrap_start");
@@ -664,6 +670,7 @@ export function ConvexLogtoProvider(props: ConvexLogtoProviderProps) {
             onResolved={endCallbackFlow}
           />
         ) : null}
+        {/* oxlint-disable-next-line react/hooks -- `useAuth` is a prop that takes a hook; that is Convex's API. */}
         <ConvexProviderWithAuth client={client} useAuth={useAuthFromLogto}>
           <ConvexAuthPhaseWatcher events={events} />
           {children}
@@ -728,6 +735,10 @@ export function useLogtoAuth(): LogtoAuth {
           if (active) setUser(undefined);
         });
     } else {
+      // Deriving `user` from `isAuthenticated` instead would show the previous
+      // user's claims for a frame on the next sign-in, until the fetch above
+      // replaces them. Clearing them costs one render, at sign-out.
+      // oxlint-disable-next-line react/set-state-in-effect -- see above
       setUser(undefined);
     }
     return () => {


### PR DESCRIPTION
#236 turned off the six React Compiler rules that oxlint 1.79 folded into the categories this repo sets to error. Every finding was a pattern the code used on purpose, but "off" also stops the rules from catching the next real mistake. This turns them back on and answers each finding at its site.

## Fixed

- **The "latest handler" refs were written during render** so a child's passive effect (the `convex_authenticated` watcher) would see the handler from the same commit. An insertion effect gives the same guarantee, since React runs every insertion effect of a commit before any passive effect, without storing a value from a render that may never commit. Both bridge suites now have a test for that ordering, and each fails against a passive effect (the session suite already had one).
- **The bridge's settle latch** moved from an effect to a guarded render-time update, the pattern React documents for remembering a fact from an earlier render. The settled frame now commits once instead of once plus an effect re-render. The latch itself had no test; it does now, and it fails when the latch is removed.
- **`LogtoCallback` set `done` on the benign and error paths**, where nothing reads it. `done` only gates `<CodeExchange>`, which those outcomes never mount.
- **The session provider read its SSR seed through a ref written during render.** It now reads the props directly inside the engine memo, with the `exhaustive-deps` directive that says why they are not dependencies (the engine reads them in its constructor, during that render, because its first snapshot has to match what the server rendered).

## Kept, with a directive and the reason at the site

- `useAuth={...}` on `ConvexProviderWithAuth`: Convex's API takes the hook as a prop.
- Passing the handler ref to `createAuthEventEmitter`: the emitter reads it at emit time, never during render.
- `useNativeAuthState` writes state from an effect because the loading pulse has to be a committed frame Convex can see.
- Clearing `user` from the claims effect on sign-out: deriving it from `isAuthenticated` would show the previous user's claims for a frame on the next sign-in.
- `react/globals` stays off for test files, where doubles reassign module-level `let`s from inside a fake provider.

One thing to know: a disable directive for a `react-hooks` rule inside a component makes the React Compiler analysis skip that whole component, so the session providers' other compiler rules are quiet by construction. That is how the compiler treats suppressions; the directives are narrow and each says why.

## Verified

Full CI sequence locally: lint (0 findings with the rules on), format:check, check-types, test (688 library + 10 example). Three mutants run: passive effect instead of insertion effect in `react.tsx` and `native.tsx`, and the latch removed. Each fails exactly the new test.

https://claude.ai/code/session_01MWGGBr7qcGZep4gYy9YZcC
