### PR TITLE
fix(session): a sign-in started during a sign-out waits for it

### DIFF
--- a/.changeset/quiet-doors-wait.md
+++ b/.changeset/quiet-doors-wait.md
@@ -1,0 +1,9 @@
+---
+"convex-logto": patch
+---
+
+Session mode: a `signIn()` started while a `signOut()` is in flight now waits for it, and starts nothing once the page is on its way to Logto's end-session endpoint.
+
+Sign-out clears local state, then awaits the server revoke, then navigates to end the SSO session. An app that sends every unauthenticated render to its sign-in route (protected route → `/login` → `signIn()` on mount) called `signIn()` inside that await. Its authorize navigation cancelled the end-session one, Logto's SSO cookie answered it without a prompt, and the user who had just clicked "Sign out" was signed straight back in. Reproduced live against a self-hosted Logto; bridge mode never showed it because `@logto/react` navigates in the same tick it clears state.
+
+A sign-out that stays on the page (`federated: false`, native, or a failed navigation) releases the wait, so the sign-in that follows it is an ordinary one.

--- a/docs/content/docs/session-mode.mdx
+++ b/docs/content/docs/session-mode.mdx
@@ -644,7 +644,11 @@ signed-out until the user reloaded.
    invalidating a still-live sibling that shares Logto grant state.
 5. **Sign-out.** Clears local state first (other tabs sharing localStorage
    follow via the `storage` event), removes the component Session, then ends the
-   current browser's SSO session unless you disable federated sign-out.
+   current browser's SSO session unless you disable federated sign-out. An app
+   whose sign-in route calls `signIn()` on mount reaches it in that window, so
+   `signIn()` waits for the sign-out and starts nothing once the page is
+   leaving for Logto. Otherwise the authorize navigation would cancel the
+   end-session one and Logto's SSO cookie would sign the user straight back in.
 
 The client single-flights concurrent refreshes at three layers: per tab
 (in-flight merge), per browser (Web Locks), per session (a server-side claim). A

--- a/packages/convex-logto/src/react-session.tsx
+++ b/packages/convex-logto/src/react-session.tsx
@@ -431,7 +431,9 @@ export type LogtoSessionAuth = {
    * redirect to Logto and back to the provider's `callbackPath`. `returnTo`
    * (a same-origin path starting with `/`) is where the user lands after
    * sign-in completes; it overrides the provider's `afterSignIn`. Initiation
-   * failures reach `onAuthError` before this promise rejects.
+   * failures reach `onAuthError` before this promise rejects. Called while a
+   * `signOut` is in flight, it waits for that sign-out and resolves without
+   * starting anything once the page is leaving for Logto.
    */
   signIn: (options?: { returnTo?: string }) => Promise<void>;
   /**

--- a/packages/convex-logto/src/session-client.test.ts
+++ b/packages/convex-logto/src/session-client.test.ts
@@ -1426,6 +1426,39 @@ describe("signOut", () => {
     expect(handlers.signIn).not.toHaveBeenCalled();
   });
 
+  it("a second sign-out during the first keeps the gate until the first has navigated", async () => {
+    // A double-click. The second sign-out finds no local session, skips the
+    // revoke and never navigates. It must not release the gate the first one
+    // still owns.
+    const { engine, storage, handlers } = makeHarness();
+    storage.writeSession({ token: "t1", sessionId: "s1" });
+    const revoke = deferred<{ endSessionUrl: string }>();
+    handlers.signOut.mockReturnValue(revoke.promise);
+    handlers.signIn.mockResolvedValue({
+      url: "https://auth.example.com/oidc/auth?state=st-1",
+    });
+
+    const first = engine.signOut();
+    await vi.waitFor(() => expect(handlers.signOut).toHaveBeenCalledTimes(1));
+    await engine.signOut();
+    expect(handlers.signOut).toHaveBeenCalledTimes(1);
+    const signingIn = engine.signIn();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(handlers.signIn).not.toHaveBeenCalled();
+
+    revoke.resolve({
+      endSessionUrl: "https://auth.example.com/oidc/session/end?x",
+    });
+    await first;
+    await signingIn;
+
+    expect(handlers.signIn).not.toHaveBeenCalled();
+    expect(window.location.assign).toHaveBeenCalledTimes(1);
+    expect(window.location.assign).toHaveBeenCalledWith(
+      "https://auth.example.com/oidc/session/end?x",
+    );
+  });
+
   it("a sign-in waits for a sign-out that stays on the page, then proceeds", async () => {
     const { engine, storage, handlers } = makeHarness();
     storage.writeSession({ token: "t1", sessionId: "s1" });

--- a/packages/convex-logto/src/session-client.test.ts
+++ b/packages/convex-logto/src/session-client.test.ts
@@ -1388,6 +1388,69 @@ describe("signOut", () => {
     );
   });
 
+  it("a sign-in started while a federated sign-out is in flight starts nothing", async () => {
+    // The shape of every "protected route → /login → auto signIn()" app: the
+    // moment local state clears, the route tree bounces to sign-in and calls
+    // signIn() while the sign-out is still awaiting the server revoke. Its
+    // authorize navigation would cancel the end-session one, and Logto's SSO
+    // cookie would answer it without a prompt.
+    const { engine, storage, handlers } = makeHarness();
+    storage.writeSession({ token: "t1", sessionId: "s1" });
+    storage.writeIdToken(freshToken());
+    const revoke = deferred<{ endSessionUrl: string }>();
+    handlers.signOut.mockReturnValue(revoke.promise);
+    handlers.signIn.mockResolvedValue({
+      url: "https://auth.example.com/oidc/auth?state=st-1",
+    });
+
+    const signingOut = engine.signOut();
+    await vi.waitFor(() => expect(handlers.signOut).toHaveBeenCalled());
+    expect(engine.getSnapshot().status).toBe("unauthenticated");
+    const signingIn = engine.signIn();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(handlers.signIn).not.toHaveBeenCalled();
+
+    revoke.resolve({
+      endSessionUrl: "https://auth.example.com/oidc/session/end?x",
+    });
+    await signingOut;
+    await signingIn;
+
+    expect(handlers.signIn).not.toHaveBeenCalled();
+    expect(window.location.assign).toHaveBeenCalledTimes(1);
+    expect(window.location.assign).toHaveBeenCalledWith(
+      "https://auth.example.com/oidc/session/end?x",
+    );
+    // The page is leaving. A later sign-in stays put too.
+    await engine.signIn();
+    expect(handlers.signIn).not.toHaveBeenCalled();
+  });
+
+  it("a sign-in waits for a sign-out that stays on the page, then proceeds", async () => {
+    const { engine, storage, handlers } = makeHarness();
+    storage.writeSession({ token: "t1", sessionId: "s1" });
+    const revoke = deferred<Record<string, never>>();
+    handlers.signOut.mockReturnValue(revoke.promise);
+    handlers.signIn.mockResolvedValue({
+      url: "https://auth.example.com/oidc/auth?state=st-1",
+    });
+
+    const signingOut = engine.signOut({ federated: false });
+    await vi.waitFor(() => expect(handlers.signOut).toHaveBeenCalled());
+    const signingIn = engine.signIn();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(handlers.signIn).not.toHaveBeenCalled();
+
+    revoke.resolve({});
+    await signingOut;
+    await signingIn;
+
+    expect(handlers.signIn).toHaveBeenCalledTimes(1);
+    expect(window.location.assign).toHaveBeenCalledWith(
+      "https://auth.example.com/oidc/auth?state=st-1",
+    );
+  });
+
   it("local sign-out survives a dead server, and skips the SSO redirect", async () => {
     const { engine, storage, handlers } = makeHarness();
     storage.writeSession({ token: "t1", sessionId: "s1" });

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -1724,10 +1724,30 @@ export class SessionAuthEngine {
     // page is on its way to Logto; a sign-out that stays on the page (native,
     // `federated: false`, a failed navigation) releases the gate again, so
     // the next sign-in is an ordinary one.
+    //
+    // Chained onto any sign-out already in flight. A second click finds no
+    // local session, skips the revoke and never navigates; on its own it would
+    // settle false and release the gate while the first sign-out was still
+    // awaiting the server, reopening the window this exists to close. So the
+    // gate settles once every in-flight sign-out has, true if any navigated,
+    // and only the current gate may release the field.
     let navigated = false;
     let settle!: (navigated: boolean) => void;
-    this.inflightSignOut = new Promise<boolean>((resolve) => {
+    const own = new Promise<boolean>((resolve) => {
       settle = resolve;
+    });
+    const previous = this.inflightSignOut;
+    const gate =
+      previous === null
+        ? own
+        : Promise.all([previous, own]).then(
+            ([earlier, mine]) => earlier || mine,
+          );
+    this.inflightSignOut = gate;
+    void gate.then((anyNavigated) => {
+      if (!anyNavigated && this.inflightSignOut === gate) {
+        this.inflightSignOut = null;
+      }
     });
     try {
       await this.performSignOutInner(options, () => {
@@ -1735,7 +1755,6 @@ export class SessionAuthEngine {
       });
     } finally {
       settle(navigated);
-      if (!navigated) this.inflightSignOut = null;
     }
   }
 

--- a/packages/convex-logto/src/session-client.ts
+++ b/packages/convex-logto/src/session-client.ts
@@ -622,6 +622,14 @@ export class SessionAuthEngine {
   private inflightSignIn: Promise<void> | null = null;
   private inflightCompletion: Promise<void> | null = null;
   private inflightRefresh: Promise<string | null> | null = null;
+  /**
+   * The sign-out in progress, resolving to whether it handed the page to
+   * Logto's end-session endpoint. A sign-out clears local state before it
+   * makes that navigation, and `signIn` must not start in between; see
+   * `signInInner`. Stays set once the page is leaving, so nothing starts a
+   * sign-in during the unload either.
+   */
+  private inflightSignOut: Promise<boolean> | null = null;
   private recoveringFor: number | null = null;
   private storagePreparation: Promise<void> | null = null;
   /** Invalidates async credential work that started before a local sign-out. */
@@ -1172,6 +1180,15 @@ export class SessionAuthEngine {
           `paths to prevent open redirects.`,
       );
     }
+    // A sign-out clears local state, then awaits the server revoke, then
+    // hands the page to Logto's end-session endpoint. An app that sends every
+    // unauthenticated render to its sign-in route starts a sign-in inside
+    // that await. Its authorize navigation would cancel the end-session one,
+    // Logto's SSO cookie would answer it without a prompt, and the user who
+    // just signed out would be signed straight back in. Wait for the
+    // sign-out instead; once it has left the page there is nothing to start.
+    const signOut = this.inflightSignOut;
+    if (signOut !== null && (await signOut)) return;
     await this.prepareStorage();
     await this.options.deviceBinding?.prepare();
     const redirectUri =
@@ -1703,6 +1720,38 @@ export class SessionAuthEngine {
       postLogoutRedirectUri: string,
     ) => Promise<{ endSessionUrl?: string }>;
   }): Promise<void> {
+    // Published for `signInInner`, which waits on it. Resolves to whether the
+    // page is on its way to Logto; a sign-out that stays on the page (native,
+    // `federated: false`, a failed navigation) releases the gate again, so
+    // the next sign-in is an ordinary one.
+    let navigated = false;
+    let settle!: (navigated: boolean) => void;
+    this.inflightSignOut = new Promise<boolean>((resolve) => {
+      settle = resolve;
+    });
+    try {
+      await this.performSignOutInner(options, () => {
+        navigated = true;
+      });
+    } finally {
+      settle(navigated);
+      if (!navigated) this.inflightSignOut = null;
+    }
+  }
+
+  private async performSignOutInner(
+    options: {
+      postLogoutRedirectUri?: string;
+      federated: boolean;
+      requireServerSuccess: boolean;
+      revoke: (
+        sessionToken: string,
+        deviceProof: string | undefined,
+        postLogoutRedirectUri: string,
+      ) => Promise<{ endSessionUrl?: string }>;
+    },
+    onNavigate: () => void,
+  ): Promise<void> {
     // Fence first, before any async storage preparation or network work. A
     // refresh that began in the previous generation must never resurrect it.
     this.authGeneration += 1;
@@ -1844,6 +1893,7 @@ export class SessionAuthEngine {
           this.reportError(this.asError(error));
         }
       } else if (navigationUrl !== undefined) {
+        onNavigate();
         window.location.assign(navigationUrl);
       }
     }


### PR DESCRIPTION
Found while running plany's session-mode branch against the real Logto.

## The race

Session mode's `signOut()` clears local state, awaits the server revoke, then navigates to Logto's end-session endpoint. plany's route tree sends every unauthenticated render of `/app` to `/login`, and `/login` calls `signIn()` on mount. That call landed inside the await:

```
10.6s  → logto:signOut
10.6s  → logto:signIn
10.6s  ⇒ GET https://auth.bielcrystal.app/oidc/session/end
10.7s  ← logto:signOut 200
10.7s  ← logto:signIn 200
11.5s  ⇒ GET http://localhost:5176/callback?code=…   (no prompt)
```

The authorize navigation cancelled the end-session one before Logto's auto-submitted confirm step, the SSO cookie answered the new authorize request silently, and the user who had just clicked "Sign out" was signed back in. Deterministic on unpatched 0.7.1. Bridge mode never showed it because `@logto/react` navigates in the same tick it clears state.

## The fix

`performSignOut` publishes the sign-out in flight as a promise that resolves to whether it handed the page to Logto. `signInInner` waits on it and returns once the page is leaving. A sign-out that stays on the page (`federated: false`, native, a failed navigation) releases the wait, so the sign-in that follows is an ordinary one.

## Verified

- Two engine tests, one per branch; both fail on `main`.
- Live, with the patched build wired into plany's worktree, 2/2 runs: sign-out reaches `POST /oidc/session/end/confirm`, the page returns to the app origin, and the next sign-in is the fresh page's and prompts for credentials. The same script fails on 0.7.1 as shown above.
- `pnpm lint`, `format:check`, `check-types`, `test` (692).

Docs: one paragraph in the session-mode token dance, and the `signIn` JSDoc.

https://claude.ai/code/session_01MWGGBr7qcGZep4gYy9YZcC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a race condition when signing in during an in-progress sign-out.
  - Federated sign-out now completes its redirect without being interrupted by a competing sign-in.
  - Prevented users from being immediately signed back in through the SSO session after signing out.
  - Non-federated sign-in continues normally once sign-out processing finishes.

- **Documentation**
  - Clarified sign-in and sign-out behavior, including recoverable authentication errors and navigation handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->